### PR TITLE
Secure user creation

### DIFF
--- a/server/controllers/userController.ts
+++ b/server/controllers/userController.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from 'express';
 import userRepository from '../repositories/userRepository';
-import { RequestUser, UserRoles } from '../models/UserApi';
+import { RequestUser, UserApi, UserRoles } from '../models/UserApi';
 import authTokenRepository from '../repositories/authTokenRepository';
 import mailService, { ActivationMail } from '../services/mailService';
 import { UserFiltersApi } from '../models/UserFiltersApi';
@@ -10,7 +10,19 @@ const createUser = async (request: Request, response: Response): Promise<Respons
 
     console.log('Create user')
 
-    const userApi = request.body.draftUser;
+    const draftUser = request.body.draftUser;
+
+    if (!draftUser || !draftUser.email || !draftUser.establishmentId) {
+        return response.sendStatus(400);
+    }
+
+    const userApi = <UserApi> {
+        email: draftUser.email,
+        firstName: draftUser.firstName,
+        lastName: draftUser.lastName,
+        role: UserRoles.Usual,
+        establishmentId: draftUser.establishmentId
+    };
 
     return userRepository.insert(userApi)
         .then(_ => response.status(200).json(_));


### PR DESCRIPTION
### Faille de sécurité : élévation de privilèges
L'API de création d'utilisateurs accepte actuellement tous les champs d'un utilisateur (`UserApi`), y compris le role. Cela permet de créer des utilisateurs avec un role Admin, avec un simple token JWT valide sans role Admin.

### Solution proposée
Je propose pour commencer de ne conserver que les champs auxquels l'API s'attend (email, firstName, lastName, establishmentId) et de mettre le role à `Usual` par défaut. J'ai regardé le code de `UserCreationModal` pour voir les champs qui sont envoyés.

Les champs pourraient également être "assainis" pour plus de sécurité.