### PR TITLE
Fix issues

### DIFF
--- a/database/seeds/test/005-housing.ts
+++ b/database/seeds/test/005-housing.ts
@@ -1,38 +1,55 @@
 import { Owner1 } from './004-owner';
 import { genHousingApi } from '../../../server/test/testFixtures';
-import housingRepository, { housingTable, ownersHousingTable } from '../../../server/repositories/housingRepository';
+import housingRepository, {
+  housingTable,
+  ownersHousingTable,
+  ReferenceDataYear,
+} from '../../../server/repositories/housingRepository';
 import { Locality1 } from './001-establishments';
 import { Knex } from 'knex';
 
 export const Housing0 = genHousingApi(Locality1.geoCode);
 export const Housing1 = genHousingApi(Locality1.geoCode);
 export const Housing2 = genHousingApi(Locality1.geoCode);
+export const HousingShortVacancy = {
+  ...genHousingApi(Locality1.geoCode),
+  vacancyStartYear: ReferenceDataYear - 1,
+};
 
 // @ts-ignore
-exports.seed = function(knex: Knex) {
-    return Promise.all([
-        knex.table(housingTable).insert([
-            housingRepository.formatHousingApi(Housing0),
-            housingRepository.formatHousingApi(Housing1),
-            housingRepository.formatHousingApi(Housing2),
-        ]).then(() =>
-            knex.table(ownersHousingTable).insert([
-                {
-                    owner_id: Owner1.id,
-                    housing_id: Housing0.id,
-                    rank: 1
-                },
-                {
-                    owner_id: Owner1.id,
-                    housing_id: Housing1.id,
-                    rank: 1
-                },
-                {
-                    owner_id: Owner1.id,
-                    housing_id: Housing2.id,
-                    rank: 1
-                }
-            ])
-        )
-    ])
+exports.seed = function (knex: Knex) {
+  return Promise.all([
+    knex
+      .table(housingTable)
+      .insert([
+        housingRepository.formatHousingApi(Housing0),
+        housingRepository.formatHousingApi(Housing1),
+        housingRepository.formatHousingApi(Housing2),
+        housingRepository.formatHousingApi(HousingShortVacancy),
+      ])
+      .then(() =>
+        knex.table(ownersHousingTable).insert([
+          {
+            owner_id: Owner1.id,
+            housing_id: Housing0.id,
+            rank: 1,
+          },
+          {
+            owner_id: Owner1.id,
+            housing_id: Housing1.id,
+            rank: 1,
+          },
+          {
+            owner_id: Owner1.id,
+            housing_id: Housing2.id,
+            rank: 1,
+          },
+          {
+            owner_id: Owner1.id,
+            housing_id: HousingShortVacancy.id,
+            rank: 1,
+          },
+        ])
+      ),
+  ]);
 };

--- a/frontend/src/utils/numberUtils.ts
+++ b/frontend/src/utils/numberUtils.ts
@@ -7,3 +7,6 @@ export const percent = (value?: number, total?: number) =>
 
 export const numberSort = (n1?: number, n2?: number) =>
   n1 ? (n2 ? n1 - n2 : 1) : n2 ? -1 : 0;
+
+export const numberOption = (value: string | undefined) =>
+  value ? Number(value) : undefined;

--- a/frontend/src/views/Campaign/CampaignView.tsx
+++ b/frontend/src/views/Campaign/CampaignView.tsx
@@ -25,6 +25,7 @@ import CampaignBundleTitle from '../../components/CampaignBundle/CampaignBundleT
 import { hasFilters } from '../../models/HousingFilters';
 import { useDocumentTitle } from '../../hooks/useDocumentTitle';
 import { useAppDispatch } from '../../hooks/useStore';
+import { numberOption } from '../../utils/numberUtils';
 
 const CampaignView = () => {
   useDocumentTitle('Campagne');
@@ -41,8 +42,8 @@ const CampaignView = () => {
   useEffect(() => {
     dispatch(
       getCampaignBundle({
-        campaignNumber: campaignNumber ? Number(campaignNumber) : undefined,
-        reminderNumber: reminderNumber ? Number(reminderNumber) : undefined,
+        campaignNumber: numberOption(campaignNumber),
+        reminderNumber: numberOption(reminderNumber),
       })
     );
   }, [dispatch, campaignNumber, reminderNumber]);
@@ -60,7 +61,9 @@ const CampaignView = () => {
     setCampaignRemovalModalOpen(false);
   }
 
-  return bundle ? (
+  return bundle &&
+    bundle.campaignNumber === numberOption(campaignNumber) &&
+    bundle.reminderNumber === numberOption(reminderNumber) ? (
     <>
       {campaignRemovalModalOpen && (
         <ConfirmationModal

--- a/server/controllers/ownerController.test.ts
+++ b/server/controllers/ownerController.test.ts
@@ -1,0 +1,41 @@
+import request from 'supertest';
+import { constants } from 'http2';
+import { createServer } from '../server';
+import fetchMock from 'jest-fetch-mock';
+import { withAccessToken } from '../test/testUtils';
+import { Housing1 } from '../../database/seeds/test/005-housing';
+
+const { app } = createServer();
+
+describe('Owner controller', () => {
+  beforeEach(() => {
+    fetchMock.resetMocks();
+  });
+
+  describe('listByHousing', () => {
+    const testRoute = (housingId: string) => `/api/owners/housing/${housingId}`;
+
+    it('should be forbidden for a not authenticated user', async () => {
+      await request(app)
+        .get(testRoute(Housing1.id))
+        .expect(constants.HTTP_STATUS_UNAUTHORIZED);
+    });
+
+    it('should return the owner list for a housing', async () => {
+      const res = await withAccessToken(
+        request(app).get(testRoute(Housing1.id))
+      ).expect(constants.HTTP_STATUS_OK);
+
+      expect(res.status).toBe(constants.HTTP_STATUS_OK);
+
+      expect(res.body).toMatchObject(
+        expect.arrayContaining([
+          expect.objectContaining({
+            housingId: Housing1.id,
+            housingCount: 3,
+          }),
+        ])
+      );
+    });
+  });
+});

--- a/server/models/UserApi.ts
+++ b/server/models/UserApi.ts
@@ -17,6 +17,7 @@ export function toUserDTO(user: UserApi): User {
     email: user.email,
     firstName: user.firstName,
     lastName: user.lastName,
+    role: user.role,
     activatedAt: user.activatedAt,
   };
 }

--- a/shared/models/User.ts
+++ b/shared/models/User.ts
@@ -3,5 +3,6 @@ export interface User {
   email: string;
   firstName: string;
   lastName: string;
+  role: number;
   activatedAt?: Date;
 }


### PR DESCRIPTION
Bugs corrigés : 
- page utilisateur pour les admins similaires à la page pour les collectivités (plus de boutons supprimer, ...)
- lorsqu'on accédait au détail d'une campagne en cours à partir de la liste des logements suivis, la récupération des logements se faisait à partir du campaign bundle dans le state qui n'était pas encore mis à jour avec celui pointé par l'URL. Au rafraichissement de la page le state étant préalablement vidé, il n'y avait plus de problème.
- le décompte du nombre de logements d'un propriétaire prenait en compte à tort les logements vacants de moins de deux ans