### PR TITLE
Quickwins

### DIFF
--- a/frontend/src/App.scss
+++ b/frontend/src/App.scss
@@ -431,6 +431,10 @@ a.fr-btn[target='_blank']:after {
   align-items: center
 }
 
+.flex-1 {
+  flex: 1;
+}
+
 .word-wrap {
   hyphens: auto;
   word-wrap: break-word;

--- a/frontend/src/components/AppHeader/AppHeader.tsx
+++ b/frontend/src/components/AppHeader/AppHeader.tsx
@@ -119,7 +119,11 @@ function AppHeader() {
 
   return (
     <>
-      <Header closeButtonLabel="Fermer" data-testid="header">
+      <Header
+        closeButtonLabel="Fermer"
+        data-testid="header"
+        className={styles.header}
+      >
         <HeaderBody>
           <Logo splitCharacter={10}>
             Ministère de la transition écologique et de la cohésion des

--- a/frontend/src/components/AppHeader/app-header.module.scss
+++ b/frontend/src/components/AppHeader/app-header.module.scss
@@ -18,12 +18,19 @@
   width: 1.5rem;
 }
 
-.brandService {
-  label {
-    display: none;
+.header {
+  a:before {
+    display: none !important;
   }
 
-  input {
-    width: 450px;
+  .brandService {
+    label {
+      display: none;
+    }
+
+    input {
+      width: 450px;
+    }
+
   }
 }

--- a/frontend/src/components/Inbox/InboxMessageList.tsx
+++ b/frontend/src/components/Inbox/InboxMessageList.tsx
@@ -139,7 +139,7 @@ function InboxMessageList(props: Props) {
           isSimple
           onClick={() => props.onDisplay?.({ ...owner, read: true })}
         >
-          Afficher la fiche contact
+          Afficher le message
         </ButtonLink>
       ),
     },

--- a/frontend/src/dsfr-fix.scss
+++ b/frontend/src/dsfr-fix.scss
@@ -47,7 +47,3 @@ span.ri-checkbox-circle-line.ds-fr-tag-icon {
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='24' height='24'%3E%3Cpath fill='none' d='M0 0h24v24H0z'/%3E%3Cpath d='M5 11h14v2H5z' fill='rgba(255,255,255,1)'/%3E%3C/svg%3E") !important;
   }
 }
-
-.fr-enlarge-link a:before {
-  display: none !important;
-}

--- a/frontend/src/views/Establishment/EstablishmentContactPoints.tsx
+++ b/frontend/src/views/Establishment/EstablishmentContactPoints.tsx
@@ -148,13 +148,8 @@ const EstablishmentContactPoints = ({ establishmentId }: Props) => {
           {settings && (
             <Toggle
               checked={settings.contactPoints?.public}
-              label={
-                settings.contactPoints?.public
-                  ? 'Informations publiées'
-                  : 'Informations non publiées'
-              }
+              label="Publication"
               onChange={togglePublishContactPoints}
-              className="fr-mt-0"
             />
           )}
           <div className="flex-1 flex-right">

--- a/frontend/src/views/Establishment/EstablishmentContactPoints.tsx
+++ b/frontend/src/views/Establishment/EstablishmentContactPoints.tsx
@@ -148,22 +148,26 @@ const EstablishmentContactPoints = ({ establishmentId }: Props) => {
           {settings && (
             <Toggle
               checked={settings.contactPoints?.public}
-              label="Informations publiées"
+              label={
+                settings.contactPoints?.public
+                  ? 'Informations publiées'
+                  : 'Informations non publiées'
+              }
               onChange={togglePublishContactPoints}
               className="fr-mt-0"
             />
           )}
-        </Col>
-        <Col className="flex-right flex-align-center">
-          <div className="fr-mx-2w">
-            <AppSearchBar onSearch={search} onKeySearch={searchAsync} />
+          <div className="flex-1 flex-right">
+            <div className="fr-mx-2w">
+              <AppSearchBar onSearch={search} onKeySearch={searchAsync} />
+            </div>
+            <Button
+              onClick={() => setEditingState({ step: ActionSteps.Init })}
+              className="float-right"
+            >
+              Ajouter un guichet
+            </Button>
           </div>
-          <Button
-            onClick={() => setEditingState({ step: ActionSteps.Init })}
-            className="float-right"
-          >
-            Ajouter un guichet
-          </Button>
         </Col>
       </Row>
       {editingState?.step === ActionSteps.Done && (

--- a/frontend/src/views/Establishment/EstablishmentContactPoints.tsx
+++ b/frontend/src/views/Establishment/EstablishmentContactPoints.tsx
@@ -148,7 +148,7 @@ const EstablishmentContactPoints = ({ establishmentId }: Props) => {
           {settings && (
             <Toggle
               checked={settings.contactPoints?.public}
-              label="Publication"
+              label="Publication des informations"
               onChange={togglePublishContactPoints}
             />
           )}

--- a/server/controllers/prospectController.test.ts
+++ b/server/controllers/prospectController.test.ts
@@ -59,10 +59,9 @@ describe('Prospect controller', () => {
       expect(status).toBe(constants.HTTP_STATUS_GONE);
     });
 
-    it('should create a prospect with first known establishment', async () => {
+    it('should create a prospect for the first known establishment with lovac ok', async () => {
       const email = genEmail();
       const link = genSignupLinkApi(email);
-      const siren = Establishment1.siren;
       await signupLinkRepository.insert(link);
       jest.spyOn(ceremaService, 'consultUsers').mockResolvedValue([
         {
@@ -73,7 +72,13 @@ describe('Prospect controller', () => {
         },
         {
           email,
-          establishmentSiren: siren,
+          establishmentSiren: Establishment1.siren,
+          hasAccount: true,
+          hasCommitment: false,
+        },
+        {
+          email,
+          establishmentSiren: Establishment2.siren,
           hasAccount: true,
           hasCommitment: true,
         },
@@ -84,13 +89,13 @@ describe('Prospect controller', () => {
       expect(status).toBe(constants.HTTP_STATUS_CREATED);
       expect(body).toMatchObject<ProspectApi>({
         email,
-        establishment: Establishment1,
+        establishment: Establishment2,
         hasAccount: true,
         hasCommitment: true,
       });
     });
 
-    it('should create a prospect with unknown establishment', async () => {
+    it('should create a prospect with an unknown establishment', async () => {
       const email = genEmail();
       const link = genSignupLinkApi(email);
       await signupLinkRepository.insert(link);

--- a/server/controllers/prospectController.test.ts
+++ b/server/controllers/prospectController.test.ts
@@ -2,7 +2,7 @@ import request from 'supertest';
 import { constants } from 'http2';
 import randomstring from 'randomstring';
 import { User1 } from '../../database/seeds/test/003-users';
-import { genEmail, genSignupLinkApi } from '../test/testFixtures';
+import { genEmail, genSignupLinkApi, genSiren } from '../test/testFixtures';
 import { createServer } from '../server';
 import signupLinkRepository from '../repositories/signupLinkRepository';
 import { ProspectApi } from '../models/ProspectApi';
@@ -10,6 +10,10 @@ import ceremaService from '../services/ceremaService';
 import { SignupLinkApi } from '../models/SignupLinkApi';
 import { subHours } from 'date-fns';
 import { Prospect1 } from '../../database/seeds/test/007-prospects';
+import {
+  Establishment1,
+  Establishment2,
+} from '../../database/seeds/test/001-establishments';
 
 describe('Prospect controller', () => {
   const { app } = createServer();
@@ -55,43 +59,80 @@ describe('Prospect controller', () => {
       expect(status).toBe(constants.HTTP_STATUS_GONE);
     });
 
-    it('should create a prospect', async () => {
+    it('should create a prospect with first known establishment', async () => {
       const email = genEmail();
       const link = genSignupLinkApi(email);
+      const siren = Establishment1.siren;
       await signupLinkRepository.insert(link);
-      jest.spyOn(ceremaService, 'consultUser').mockResolvedValue({
-        email,
-        hasAccount: true,
-        hasCommitment: true,
-      });
+      jest.spyOn(ceremaService, 'consultUsers').mockResolvedValue([
+        {
+          email,
+          establishmentSiren: genSiren(),
+          hasAccount: false,
+          hasCommitment: true,
+        },
+        {
+          email,
+          establishmentSiren: siren,
+          hasAccount: true,
+          hasCommitment: true,
+        },
+      ]);
 
       const { body, status } = await request(app).put(testRoute(link.id));
 
       expect(status).toBe(constants.HTTP_STATUS_CREATED);
-      expect(body).toStrictEqual<ProspectApi>({
+      expect(body).toMatchObject<ProspectApi>({
         email,
-        establishment: null,
+        establishment: Establishment1,
         hasAccount: true,
         hasCommitment: true,
+      });
+    });
+
+    it('should create a prospect with unknown establishment', async () => {
+      const email = genEmail();
+      const link = genSignupLinkApi(email);
+      await signupLinkRepository.insert(link);
+      jest.spyOn(ceremaService, 'consultUsers').mockResolvedValue([
+        {
+          email,
+          establishmentSiren: genSiren(),
+          hasAccount: true,
+          hasCommitment: true,
+        },
+      ]);
+
+      const { body, status } = await request(app).put(testRoute(link.id));
+
+      expect(status).toBe(constants.HTTP_STATUS_CREATED);
+      expect(body).toMatchObject<ProspectApi>({
+        email,
+        hasAccount: false,
+        hasCommitment: false,
       });
     });
 
     it('should update and return the prospect if they already exist', async () => {
       const email = Prospect1.email;
       const link = genSignupLinkApi(email);
+      const siren = Establishment2.siren;
       await signupLinkRepository.insert(link);
-      jest.spyOn(ceremaService, 'consultUser').mockResolvedValue({
-        email,
-        hasAccount: true,
-        hasCommitment: true,
-      });
+      jest.spyOn(ceremaService, 'consultUsers').mockResolvedValue([
+        {
+          email,
+          establishmentSiren: siren,
+          hasAccount: true,
+          hasCommitment: true,
+        },
+      ]);
 
       const { body, status } = await request(app).put(testRoute(link.id));
 
       expect(status).toBe(constants.HTTP_STATUS_OK);
-      expect(body).toStrictEqual<ProspectApi>({
+      expect(body).toMatchObject<ProspectApi>({
         email,
-        establishment: null,
+        establishment: Establishment2,
         hasAccount: true,
         hasCommitment: true,
       });

--- a/server/controllers/prospectController.test.ts
+++ b/server/controllers/prospectController.test.ts
@@ -113,8 +113,8 @@ describe('Prospect controller', () => {
       expect(status).toBe(constants.HTTP_STATUS_CREATED);
       expect(body).toMatchObject<ProspectApi>({
         email,
-        hasAccount: false,
-        hasCommitment: false,
+        hasAccount: true,
+        hasCommitment: true,
       });
     });
 

--- a/server/controllers/prospectController.ts
+++ b/server/controllers/prospectController.ts
@@ -35,7 +35,7 @@ async function upsert(request: Request, response: Response) {
 
   const ceremaUsers = await ceremaService.consultUsers(email);
 
-  const establishment: EstablishmentApi | undefined =
+  const knowEstablishmentWithCommitment: EstablishmentApi | undefined =
     await establishmentRepository
       .listWithFilters({
         sirens: ceremaUsers
@@ -44,15 +44,16 @@ async function upsert(request: Request, response: Response) {
       })
       .then((_) => _[0]);
 
-  const ceremaUser = ceremaUsers.find(
-    (_) => _.establishmentSiren === establishment?.siren
-  );
+  const ceremaUser =
+    ceremaUsers.find(
+      (_) => _.establishmentSiren === knowEstablishmentWithCommitment?.siren
+    ) ?? ceremaUsers[0];
 
   const exists = await prospectRepository.exists(email);
 
   const prospect: ProspectApi = {
     email,
-    establishment: establishment,
+    establishment: knowEstablishmentWithCommitment,
     hasAccount: ceremaUser?.hasAccount ?? false,
     hasCommitment: ceremaUser?.hasCommitment ?? false,
   };

--- a/server/controllers/prospectController.ts
+++ b/server/controllers/prospectController.ts
@@ -38,7 +38,9 @@ async function upsert(request: Request, response: Response) {
   const establishment: EstablishmentApi | undefined =
     await establishmentRepository
       .listWithFilters({
-        sirens: ceremaUsers.map((ceremaUser) => ceremaUser.establishmentSiren),
+        sirens: ceremaUsers
+          .filter((user) => user.hasCommitment)
+          .map((ceremaUser) => ceremaUser.establishmentSiren),
       })
       .then((_) => _[0]);
 

--- a/server/controllers/userController.test.ts
+++ b/server/controllers/userController.test.ts
@@ -26,10 +26,10 @@ import housingRepository, {
 } from '../repositories/housingRepository';
 import { Owner1 } from '../../database/seeds/test/004-owner';
 import { createServer } from '../server';
-import { TEST_ACCOUNTS } from '../models/ProspectApi';
 import fetchMock from 'jest-fetch-mock';
 import { CampaignIntent } from '../models/EstablishmentApi';
 import { Prospect1 } from '../../database/seeds/test/007-prospects';
+import { TEST_ACCOUNTS } from '../services/ceremaService/consultUserService';
 
 const { app } = createServer();
 

--- a/server/controllers/userController.ts
+++ b/server/controllers/userController.ts
@@ -15,11 +15,12 @@ import establishmentService from '../services/establishmentService';
 import prospectRepository from '../repositories/prospectRepository';
 import { v4 as uuidv4 } from 'uuid';
 import bcrypt from 'bcryptjs';
-import { isTestAccount, isValid } from '../models/ProspectApi';
+import { isValid } from '../models/ProspectApi';
 import TestAccountError from '../errors/testAccountError';
 import ProspectInvalidError from '../errors/prospectInvalidError';
 import ProspectMissingError from '../errors/prospectMissingError';
 import mailService from '../services/mailService';
+import { isTestAccount } from '../services/ceremaService/consultUserService';
 
 const createUserValidators = [
   body('email').isEmail().withMessage('Must be an email'),

--- a/server/models/EstablishmentFilterApi.ts
+++ b/server/models/EstablishmentFilterApi.ts
@@ -6,4 +6,5 @@ export interface EstablishmentFilterApi {
   geoCodes?: string[];
   kind?: EstablishmentKind;
   name?: string;
+  sirens?: number[];
 }

--- a/server/models/ProspectApi.ts
+++ b/server/models/ProspectApi.ts
@@ -1,5 +1,4 @@
 import { EstablishmentApi } from './EstablishmentApi';
-import { Establishment1 } from '../../database/seeds/test/001-establishments';
 
 type PartialEstablishment = Pick<
   EstablishmentApi,
@@ -11,43 +10,6 @@ export interface ProspectApi {
   establishment?: PartialEstablishment | null;
   hasAccount: boolean;
   hasCommitment: boolean;
-}
-
-export const TEST_ACCOUNTS: ReadonlyArray<
-  ProspectApi & { establishmentSiren: number }
-> = [
-  {
-    email: 'ok@beta.gouv.fr',
-    establishment: Establishment1,
-    establishmentSiren: Establishment1.siren,
-    hasAccount: true,
-    hasCommitment: true,
-  },
-  {
-    email: 'lovac_ko@beta.gouv.fr',
-    establishment: Establishment1,
-    establishmentSiren: Establishment1.siren,
-    hasAccount: true,
-    hasCommitment: false,
-  },
-  {
-    email: 'account_ko@beta.gouv.fr',
-    establishment: Establishment1,
-    establishmentSiren: Establishment1.siren,
-    hasAccount: false,
-    hasCommitment: false,
-  },
-];
-
-export function getTestAccount(
-  email: string
-): (ProspectApi & { establishmentSiren: number }) | null {
-  const testAccount = TEST_ACCOUNTS.find((account) => account.email === email);
-  return testAccount ?? null;
-}
-
-export function isTestAccount(email: string): boolean {
-  return getTestAccount(email) !== null;
 }
 
 export function isValid(prospect: ProspectApi): boolean {

--- a/server/models/ProspectApi.ts
+++ b/server/models/ProspectApi.ts
@@ -1,4 +1,5 @@
 import { EstablishmentApi } from './EstablishmentApi';
+import { Establishment1 } from '../../database/seeds/test/001-establishments';
 
 type PartialEstablishment = Pick<
   EstablishmentApi,
@@ -12,25 +13,35 @@ export interface ProspectApi {
   hasCommitment: boolean;
 }
 
-export const TEST_ACCOUNTS: ReadonlyArray<ProspectApi> = [
+export const TEST_ACCOUNTS: ReadonlyArray<
+  ProspectApi & { establishmentSiren: number }
+> = [
   {
     email: 'ok@beta.gouv.fr',
+    establishment: Establishment1,
+    establishmentSiren: Establishment1.siren,
     hasAccount: true,
     hasCommitment: true,
   },
   {
     email: 'lovac_ko@beta.gouv.fr',
+    establishment: Establishment1,
+    establishmentSiren: Establishment1.siren,
     hasAccount: true,
     hasCommitment: false,
   },
   {
     email: 'account_ko@beta.gouv.fr',
+    establishment: Establishment1,
+    establishmentSiren: Establishment1.siren,
     hasAccount: false,
     hasCommitment: false,
   },
 ];
 
-export function getTestAccount(email: string): ProspectApi | null {
+export function getTestAccount(
+  email: string
+): (ProspectApi & { establishmentSiren: number }) | null {
   const testAccount = TEST_ACCOUNTS.find((account) => account.email === email);
   return testAccount ?? null;
 }

--- a/server/repositories/establishmentRepository.ts
+++ b/server/repositories/establishmentRepository.ts
@@ -78,6 +78,9 @@ const listWithFilters = async (
         filters.name
       );
     }
+    if (filters.sirens) {
+      queryBuilder.whereIn('siren', filters.sirens);
+    }
   };
 
   return db(establishmentsTable)

--- a/server/services/ceremaService/__mocks__/mockCeremaService.ts
+++ b/server/services/ceremaService/__mocks__/mockCeremaService.ts
@@ -2,13 +2,15 @@ import { CeremaUser, ConsultUserService } from '../consultUserService';
 import { Establishment1 } from '../../../../database/seeds/test/001-establishments';
 
 class MockCeremaService implements ConsultUserService {
-  async consultUser(email: string): Promise<CeremaUser> {
-    return {
-      email,
-      establishmentSiren: Establishment1.siren,
-      hasAccount: true,
-      hasCommitment: true,
-    };
+  async consultUsers(email: string): Promise<CeremaUser[]> {
+    return [
+      {
+        email,
+        establishmentSiren: Establishment1.siren,
+        hasAccount: true,
+        hasCommitment: true,
+      },
+    ];
   }
 }
 

--- a/server/services/ceremaService/ceremaService.ts
+++ b/server/services/ceremaService/ceremaService.ts
@@ -3,7 +3,7 @@ import fetch from 'node-fetch';
 import config from '../../utils/config';
 
 class CeremaService implements ConsultUserService {
-  async consultUser(email: string): Promise<CeremaUser> {
+  async consultUsers(email: string): Promise<CeremaUser[]> {
     try {
       const response = await fetch(
         `${config.cerema.api.endpoint}/api/consult/utilisateurs/?email=${email}`,
@@ -16,28 +16,22 @@ class CeremaService implements ConsultUserService {
         }
       );
       const users = await response.json();
-      if (users.length) {
-        return {
-          email: users[0].email,
-          establishmentSiren: Number(users[0].siret.substring(0, 9)),
-          hasAccount: true,
-          hasCommitment: users[0].lovac_ok,
-        };
+      if (users) {
+        return users.map(
+          (user: { email: any; siret: string; lovac_ok: boolean }) => ({
+            email: user.email,
+            establishmentSiren: Number(user.siret.substring(0, 9)),
+            hasAccount: true,
+            hasCommitment: user.lovac_ok,
+          })
+        );
       }
-      return defaultUser(email);
+      return [];
     } catch (error) {
       console.error(error);
-      return defaultUser(email);
+      return [];
     }
   }
-}
-
-function defaultUser(email: string): CeremaUser {
-  return {
-    email,
-    hasAccount: false,
-    hasCommitment: false,
-  };
 }
 
 export default function createCeremaService(): ConsultUserService {

--- a/server/services/ceremaService/consultUserService.ts
+++ b/server/services/ceremaService/consultUserService.ts
@@ -1,10 +1,10 @@
 export interface CeremaUser {
   email: string;
-  establishmentSiren?: number;
+  establishmentSiren: number;
   hasAccount: boolean;
   hasCommitment: boolean;
 }
 
 export interface ConsultUserService {
-  consultUser(email: string): Promise<CeremaUser>;
+  consultUsers(email: string): Promise<CeremaUser[]>;
 }

--- a/server/services/ceremaService/consultUserService.ts
+++ b/server/services/ceremaService/consultUserService.ts
@@ -1,9 +1,41 @@
+import { Establishment1 } from '../../../database/seeds/test/001-establishments';
+
 export interface CeremaUser {
   email: string;
   establishmentSiren: number;
   hasAccount: boolean;
   hasCommitment: boolean;
 }
+
+export const TEST_ACCOUNTS: ReadonlyArray<CeremaUser> = [
+  {
+    email: 'ok@beta.gouv.fr',
+    establishmentSiren: Establishment1.siren,
+    hasAccount: true,
+    hasCommitment: true,
+  },
+  {
+    email: 'lovac_ko@beta.gouv.fr',
+    establishmentSiren: Establishment1.siren,
+    hasAccount: true,
+    hasCommitment: false,
+  },
+  {
+    email: 'account_ko@beta.gouv.fr',
+    establishmentSiren: Establishment1.siren,
+    hasAccount: false,
+    hasCommitment: false,
+  },
+];
+
+export const getTestAccount = (email: string): CeremaUser | null => {
+  const testAccount = TEST_ACCOUNTS.find((account) => account.email === email);
+  return testAccount ?? null;
+};
+
+export const isTestAccount = (email: string): boolean => {
+  return getTestAccount(email) !== null;
+};
 
 export interface ConsultUserService {
   consultUsers(email: string): Promise<CeremaUser[]>;

--- a/server/services/ceremaService/mockCeremaService.ts
+++ b/server/services/ceremaService/mockCeremaService.ts
@@ -1,5 +1,8 @@
-import { CeremaUser, ConsultUserService } from './consultUserService';
-import { getTestAccount } from '../../models/ProspectApi';
+import {
+  CeremaUser,
+  ConsultUserService,
+  getTestAccount,
+} from './consultUserService';
 import { SirenStrasbourg } from '../../../database/seeds/dummy/001-establishments';
 
 class MockCeremaService implements ConsultUserService {

--- a/server/services/ceremaService/mockCeremaService.ts
+++ b/server/services/ceremaService/mockCeremaService.ts
@@ -3,9 +3,9 @@ import { getTestAccount } from '../../models/ProspectApi';
 import { SirenStrasbourg } from '../../../database/seeds/dummy/001-establishments';
 
 class MockCeremaService implements ConsultUserService {
-  async consultUser(email: string): Promise<CeremaUser> {
+  async consultUsers(email: string): Promise<CeremaUser[]> {
     const testAccount = getTestAccount(email);
-    return testAccount ?? defaultOK(email);
+    return [testAccount ?? defaultOK(email)];
   }
 }
 


### PR DESCRIPTION
- Landing V.2 / Votre Territoitre:Guichets → Quand toggle désactivé, modifier texte accompagnant pour “Informations non publiées”
- Boite de réception / CTA → Modif texte CTA “Afficher la fiche contact” pour “Afficher le message →”
- Dans Fiche Logement / Tous les propriétaires, le CTA “Voir la Fiche →” ne fonctionne pas. Le CTA se trouve en fait sur le nom prénom → Mettre le CTA en fonction
- Rattachement de l’utilisateur à la première structure connue dans ZLV et qui a le droit LOVAC