### PR TITLE
Replace Aside buggy width transition by a translation transition

### DIFF
--- a/frontend/src/components/Aside/aside.module.scss
+++ b/frontend/src/components/Aside/aside.module.scss
@@ -9,7 +9,6 @@
   background-color: var(--background-default-grey);
   box-shadow: var(--overlap-shadow);
   overflow-x: hidden;
-  visibility: visible;
 
   @media (min-width: 1280px) {
     width: 600px;
@@ -23,15 +22,15 @@
 }
 
 .aside.collapsed {
-  transition: width 0.2s var(--material-transition-curve);
+  transition: transform 0.2s var(--material-transition-curve);
 }
 
 .aside:not(.collapsed) {
-  transition: width 0.2s var(--material-transition-curve);
+  transition: transform 0.2s var(--material-transition-curve);
 }
 
 .collapsed {
-  width: 0;
+  transform: translateX(100%);
 }
 
 .article {


### PR DESCRIPTION
Replace the `width` transition by a `transform: translateX` transition to avoid a cluttered visual effect when closing the side panel.