### PR TITLE
Ajout licence MIT pour le frontend

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "prestart": "only-include-used-icons",
     "prebuild": "only-include-used-icons"
   },
+  "license": "MIT",
   "engines": {
     "node": "^16",
     "npm": "^8"


### PR DESCRIPTION
Permet d'éviter le warning:

![image](https://github.com/MTES-MCT/zero-logement-vacant/assets/55890/0d154fa1-31be-40cb-acb4-5d8404eea1a1)
