### PR TITLE
Rename endpoint to create a group from a campaign

### DIFF
--- a/frontend/src/services/campaign.service.ts
+++ b/frontend/src/services/campaign.service.ts
@@ -75,7 +75,7 @@ export const campaignApi = zlvApi.injectEndpoints({
       }
     >({
       query: (payload) => ({
-        url: `campaigns/groups/${payload.group.id}`,
+        url: `campaigns/${payload.group.id}/groups`,
         method: 'POST',
         body: {
           title: payload.campaign.title,

--- a/frontend/src/views/Group/GroupView.test.tsx
+++ b/frontend/src/views/Group/GroupView.test.tsx
@@ -94,7 +94,7 @@ describe('Group view', () => {
           },
         },
         {
-          pathname: `/api/campaigns/groups/${group.id}`,
+          pathname: `/api/campaigns/${group.id}/groups`,
           method: 'POST',
           response: {
             status: 201,

--- a/server/controllers/campaignController.test.ts
+++ b/server/controllers/campaignController.test.ts
@@ -200,7 +200,7 @@ describe('Campaign controller', () => {
   });
 
   describe('createCampaignFromGroup', () => {
-    const testRoute = (id: string) => `/api/campaigns/groups/${id}`;
+    const testRoute = (id: string) => `/api/campaigns/${id}/groups`;
 
     const geoCode = Establishment1.geoCodes[0];
     const group = genGroupApi(User1, Establishment1);

--- a/server/routers/protected.ts
+++ b/server/routers/protected.ts
@@ -45,7 +45,7 @@ router.delete('/groups/:id/housing', groupController.removeHousingValidators, va
 router.get('/campaigns', campaignController.listValidators, validator.validate, campaignController.listCampaigns);
 router.get('/campaigns/:id', campaignController.getCampaignValidators, validator.validate, campaignController.getCampaign);
 router.post('/campaigns', campaignController.createCampaignValidators, validator.validate, campaignController.createCampaign);
-router.post('/campaigns/groups/:id', campaignController.createCampaignFromGroupValidators, validator.validate, campaignController.createCampaignFromGroup)
+router.post('/campaigns/:id/groups', campaignController.createCampaignFromGroupValidators, validator.validate, campaignController.createCampaignFromGroup)
 router.get('/campaigns/:id/export', housingExportController.exportCampaignValidators, validator.validate, housingExportController.exportCampaign)
 router.put('/campaigns/:id', campaignController.updateCampaignValidators, validator.validate, campaignController.updateCampaign, campaignController.updateCampaign);
 router.delete('/campaigns/:id', [isUUIDParam('id')], validator.validate, campaignController.removeCampaign);


### PR DESCRIPTION
Comply more with the REST API spec on Campaign API :
- rename `/api/campaigns/groups/:id` to `/api/campaigns/:id/groups`

It's also more readable in browser dev tools.