### PR TITLE
Refactor Events API

### DIFF
--- a/frontend/src/services/event.service.ts
+++ b/frontend/src/services/event.service.ts
@@ -5,16 +5,14 @@ import { zlvApi } from './api.service';
 export const eventApi = zlvApi.injectEndpoints({
   endpoints: (builder) => ({
     findEventsByOwner: builder.query<Event[], string>({
-      query: (id) => `owner/${id}/events`,
+      query: (id) => `/owners/${id}/events`,
       providesTags: () => ['Event'],
-      transformResponse: (events: any[]) =>
-        events.map(parseEvent),
+      transformResponse: (events: any[]) => events.map(parseEvent),
     }),
     findEventsByHousing: builder.query<Event[], string>({
-      query: (id) => `housing/${id}/events`,
+      query: (id) => `/housing/${id}/events`,
       providesTags: () => ['Event'],
-      transformResponse: (events: any[]) =>
-        events.map(parseEvent),
+      transformResponse: (events: any[]) => events.map(parseEvent),
     }),
   }),
 });

--- a/frontend/src/services/event.service.ts
+++ b/frontend/src/services/event.service.ts
@@ -5,16 +5,16 @@ import { zlvApi } from './api.service';
 export const eventApi = zlvApi.injectEndpoints({
   endpoints: (builder) => ({
     findEventsByOwner: builder.query<Event[], string>({
-      query: (ownerId) => `events/owner/${ownerId}`,
+      query: (id) => `owner/${id}/events`,
       providesTags: () => ['Event'],
-      transformResponse: (response: any[]) =>
-        response.map((_) => parseEvent(_)),
+      transformResponse: (events: any[]) =>
+        events.map(parseEvent),
     }),
     findEventsByHousing: builder.query<Event[], string>({
-      query: (housingId) => `events/housing/${housingId}`,
+      query: (id) => `housing/${id}/events`,
       providesTags: () => ['Event'],
-      transformResponse: (response: any[]) =>
-        response.map((_) => parseEvent(_)),
+      transformResponse: (events: any[]) =>
+        events.map(parseEvent),
     }),
   }),
 });

--- a/server/controllers/eventController.test.ts
+++ b/server/controllers/eventController.test.ts
@@ -13,62 +13,60 @@ describe('Event controller', () => {
   const { app } = createServer();
 
   describe('listByOwnerId', () => {
-    const testRoute = (ownerId: string) => `/api/events/owner/${ownerId}`;
+    const testRoute = (id: string) => `/api/owner/${id}/events`;
 
     it('should be forbidden for a not authenticated user', async () => {
-      await request(app)
-        .get(testRoute(Owner1.id))
-        .expect(constants.HTTP_STATUS_UNAUTHORIZED);
+      const { status } = await request(app).get(testRoute(Owner1.id));
+
+      expect(status).toBe(constants.HTTP_STATUS_UNAUTHORIZED);
     });
 
     it('should received a valid ownerId', async () => {
-      await withAccessToken(request(app).get(testRoute('id'))).expect(
-        constants.HTTP_STATUS_BAD_REQUEST
+      const { status } = await withAccessToken(
+        request(app).get(testRoute('id'))
       );
+
+      expect(status).toBe(constants.HTTP_STATUS_BAD_REQUEST);
     });
 
     it('should list the owner events', async () => {
-      const res = await withAccessToken(
+      const { body, status } = await withAccessToken(
         request(app).get(testRoute(Owner1.id))
-      ).expect(constants.HTTP_STATUS_OK);
-
-      expect(res.body).toMatchObject(
-        expect.arrayContaining([
-          expect.objectContaining({
-            id: OwnerEvent1.id,
-          }),
-        ])
       );
+
+      expect(status).toBe(constants.HTTP_STATUS_OK);
+      expect(body).toIncludeAllPartialMembers([{ id: OwnerEvent1.id }]);
     });
   });
 
   describe('listByHousingId', () => {
-    const testRoute = (housingId: string) => `/api/events/housing/${housingId}`;
+    const testRoute = (id: string) => `/api/housing/${id}/events`;
 
     it('should be forbidden for a not authenticated user', async () => {
-      await request(app)
-        .get(testRoute(Housing1.id))
-        .expect(constants.HTTP_STATUS_UNAUTHORIZED);
+      const { status } = await request(app).get(testRoute(Housing1.id));
+
+      expect(status).toBe(constants.HTTP_STATUS_UNAUTHORIZED);
     });
 
     it('should received a valid housingId', async () => {
-      await withAccessToken(request(app).get(testRoute('id'))).expect(
-        constants.HTTP_STATUS_BAD_REQUEST
+      const { status } = await withAccessToken(
+        request(app).get(testRoute('id'))
       );
+
+      expect(status).toBe(constants.HTTP_STATUS_BAD_REQUEST);
     });
 
     it('should list the housing events', async () => {
-      const res = await withAccessToken(
+      const { body, status } = await withAccessToken(
         request(app).get(testRoute(Housing1.id))
-      ).expect(constants.HTTP_STATUS_OK);
-
-      expect(res.body).toMatchObject(
-        expect.arrayContaining([
-          expect.objectContaining({
-            id: HousingEvent1.id,
-          }),
-        ])
       );
+
+      expect(status).toBe(constants.HTTP_STATUS_OK);
+      expect(body).toIncludeAllPartialMembers([
+        {
+          id: HousingEvent1.id,
+        },
+      ]);
     });
   });
 });

--- a/server/controllers/eventController.test.ts
+++ b/server/controllers/eventController.test.ts
@@ -13,7 +13,7 @@ describe('Event controller', () => {
   const { app } = createServer();
 
   describe('listByOwnerId', () => {
-    const testRoute = (id: string) => `/api/owner/${id}/events`;
+    const testRoute = (id: string) => `/api/owners/${id}/events`;
 
     it('should be forbidden for a not authenticated user', async () => {
       const { status } = await request(app).get(testRoute(Owner1.id));

--- a/server/routers/protected.ts
+++ b/server/routers/protected.ts
@@ -61,7 +61,7 @@ router.put('/owners/housing/:housingId', ownerController.updateHousingOwners);
 router.get('/owner-prospects', ownerProspectController.findOwnerProspectsValidators, validator.validate, ownerProspectController.find)
 router.put('/owner-prospects/:id', ownerProspectController.updateOwnerProspectValidators, validator.validate, ownerProspectController.update)
 
-router.get('/owner/:id/events', [isUUIDParam('id')], validator.validate, eventController.listByOwnerId);
+router.get('/owners/:id/events', [isUUIDParam('id')], validator.validate, eventController.listByOwnerId);
 router.get('/housing/:id/events', [isUUIDParam('id')], validator.validate, eventController.listByHousingId);
 
 router.get('/notes/housing/:housingId', [isUUIDParam('housingId')], validator.validate, noteController.listByHousingId);

--- a/server/routers/protected.ts
+++ b/server/routers/protected.ts
@@ -61,8 +61,8 @@ router.put('/owners/housing/:housingId', ownerController.updateHousingOwners);
 router.get('/owner-prospects', ownerProspectController.findOwnerProspectsValidators, validator.validate, ownerProspectController.find)
 router.put('/owner-prospects/:id', ownerProspectController.updateOwnerProspectValidators, validator.validate, ownerProspectController.update)
 
-router.get('/events/owner/:ownerId', [isUUIDParam('ownerId')], validator.validate, eventController.listByOwnerId);
-router.get('/events/housing/:housingId', [isUUIDParam('housingId')], validator.validate, eventController.listByHousingId);
+router.get('/owner/:id/events', [isUUIDParam('id')], validator.validate, eventController.listByOwnerId);
+router.get('/housing/:id/events', [isUUIDParam('id')], validator.validate, eventController.listByHousingId);
 
 router.get('/notes/housing/:housingId', [isUUIDParam('housingId')], validator.validate, noteController.listByHousingId);
 


### PR DESCRIPTION
Replace `/api/events/owner/${id}` by `/api/owners/${id}/events` to :
- comply with the REST standard
- make it easier to read in the browser dev tools

Same with `/api/events/housing/${id}`.

<img width="905" alt="Screenshot 2024-03-05 at 16 47 34" src="https://github.com/MTES-MCT/zero-logement-vacant/assets/9626158/fbfe3cc9-8752-4ed0-838d-390f2ccc9fdb">