### PR TITLE
Add draft sender

### DIFF
--- a/database/migrations/20240318223600-drafts-add-sender.ts
+++ b/database/migrations/20240318223600-drafts-add-sender.ts
@@ -1,0 +1,40 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.createTable('senders', (table) => {
+    table.uuid('id').primary();
+    table.string('name').notNullable();
+    table.string('service').notNullable();
+    table.string('first_name').notNullable();
+    table.string('last_name').notNullable();
+    table.string('address').notNullable();
+    table.string('email').nullable();
+    table.string('phone').nullable();
+    table.timestamp('created_at').notNullable();
+    table.timestamp('updated_at').notNullable();
+    table
+      .uuid('establishment_id')
+      .notNullable()
+      .references('id')
+      .inTable('establishments')
+      .onUpdate('CASCADE')
+      .onDelete('CASCADE');
+    table.unique(['name', 'establishment_id']);
+  });
+  await knex.schema.alterTable('drafts', (table) => {
+    table
+      .uuid('sender_id')
+      .nullable()
+      .references('id')
+      .inTable('senders')
+      .onUpdate('CASCADE')
+      .onDelete('RESTRICT');
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('drafts', (table) => {
+    table.dropColumn('sender_id');
+  });
+  await knex.schema.dropTable('senders');
+}

--- a/frontend/src/components/Draft/DraftBody.tsx
+++ b/frontend/src/components/Draft/DraftBody.tsx
@@ -1,14 +1,22 @@
+import { ChangeEvent } from 'react';
+
 import AppTextInput from '../_app/AppTextInput/AppTextInput';
 import { useForm } from '../../hooks/useForm';
 import styles from './draft.module.scss';
 
 interface Props {
   form: ReturnType<typeof useForm>;
-  value?: string;
-  onChangeValue?(value: string): void;
+  value: string;
+  onChange(value: string): void;
 }
 
 function DraftBody(props: Props) {
+  function onChange(
+    e: ChangeEvent<HTMLInputElement & HTMLTextAreaElement>
+  ): void {
+    props.onChange(e.target.value);
+  }
+
   return (
     <article className={styles.article}>
       <h6>Contenu de votre courrier</h6>
@@ -19,7 +27,7 @@ function DraftBody(props: Props) {
         state={props.form.hasError('body') ? 'error' : 'default'}
         textArea
         value={props.value}
-        onChange={(e) => props.onChangeValue?.(e.target.value)}
+        onChange={onChange}
       />
     </article>
   );

--- a/frontend/src/components/Draft/DraftBody.tsx
+++ b/frontend/src/components/Draft/DraftBody.tsx
@@ -19,8 +19,9 @@ function DraftBody(props: Props) {
 
   return (
     <article className={styles.article}>
-      <h6>Contenu de votre courrier</h6>
+      <h6 id="draft-body-label">Contenu de votre courrier</h6>
       <AppTextInput
+        aria-labelledby="draft-body-label"
         inputForm={props.form}
         inputKey="body"
         rows={6}

--- a/frontend/src/components/Draft/DraftSender.tsx
+++ b/frontend/src/components/Draft/DraftSender.tsx
@@ -1,0 +1,121 @@
+import { ChangeEvent, ChangeEventHandler } from 'react';
+import { object, string } from 'yup';
+
+import { useForm } from '../../hooks/useForm';
+import { Sender, SenderPayload } from '../../models/Sender';
+import styles from './draft.module.scss';
+import AppTextInput from '../_app/AppTextInput/AppTextInput';
+import { Col, Container, Row } from '../_dsfr';
+
+export const senderSchema = object({
+  name: string()
+    .required(
+      'Veuillez renseigner le nom de la collectivité ou de l’administration'
+    )
+    .trim(),
+  service: string().required('Veuillez renseigner le nom du service').trim(),
+  firstName: string().required('Veuillez renseigner un prénom').trim(),
+  lastName: string().required('Veuillez renseigner un nom').trim(),
+  address: string().required('Veuillez renseigner une adresse').trim(),
+  email: string().nullable().email('Veuillez renseigner un courriel valide'),
+  phone: string()
+    .optional()
+    .nullable()
+    .matches(/^\d{10}$/, {
+      message: 'Veuillez renseigner un numéro de téléphone valide',
+      excludeEmptyString: true,
+    }),
+});
+
+interface Props {
+  form: ReturnType<typeof useForm>;
+  value: SenderPayload;
+  onChange(value: SenderPayload): void;
+}
+
+function DraftSender(props: Props) {
+  const email = props.value.email ?? '';
+  const phone = props.value.phone ?? '';
+
+  function onChange(key: keyof Sender): ChangeEventHandler {
+    return (e: ChangeEvent<HTMLInputElement>) => {
+      if (props.value) {
+        props.onChange({
+          ...props.value,
+          [key]: e.target.value,
+        });
+      }
+    };
+  }
+
+  return (
+    <Container as="article" className={styles.article}>
+      <h6>Coordonnées de l’expéditeur</h6>
+      <AppTextInput
+        inputForm={props.form}
+        inputKey="sender.name"
+        label="Nom de la collectivité ou de l’administration*"
+        value={props.value.name}
+        onChange={onChange('name')}
+      />
+      <AppTextInput
+        inputForm={props.form}
+        inputKey="sender.service"
+        label="Service*"
+        value={props.value.service}
+        onChange={onChange('service')}
+      />
+      <Row className={styles.row} gutters>
+        <Col n="6">
+          <AppTextInput
+            inputForm={props.form}
+            inputKey="sender.lastName"
+            label="Nom*"
+            value={props.value.lastName}
+            onChange={onChange('lastName')}
+          />
+        </Col>
+        <Col n="6">
+          <AppTextInput
+            inputForm={props.form}
+            inputKey="sender.firstName"
+            label="Prénom*"
+            value={props.value.firstName}
+            onChange={onChange('firstName')}
+          />
+        </Col>
+      </Row>
+      <AppTextInput
+        inputForm={props.form}
+        inputKey="sender.address"
+        label="Adresse*"
+        value={props.value.address}
+        onChange={onChange('address')}
+      />
+      <Row gutters>
+        <Col n="6">
+          <AppTextInput
+            inputForm={props.form}
+            inputKey="sender.email"
+            label="Adresse courriel"
+            value={email}
+            type="email"
+            onChange={onChange('email')}
+          />
+        </Col>
+        <Col n="6">
+          <AppTextInput
+            inputForm={props.form}
+            inputKey="sender.phone"
+            label="Téléphone"
+            value={phone}
+            type="tel"
+            onChange={onChange('phone')}
+          />
+        </Col>
+      </Row>
+    </Container>
+  );
+}
+
+export default DraftSender;

--- a/frontend/src/components/Draft/SaveButton.tsx
+++ b/frontend/src/components/Draft/SaveButton.tsx
@@ -34,13 +34,20 @@ function SaveButton(props: Props) {
     }
 
     if (props.isSuccess) {
-      toast.update(toastId, {
-        autoClose: null,
-        isLoading: false,
-        render: 'Sauvegardé !',
-        type: 'success',
-        toastId,
-      });
+      if (toast.isActive(toastId)) {
+        toast.update(toastId, {
+          autoClose: null,
+          isLoading: false,
+          render: 'Sauvegardé !',
+          type: 'success',
+          toastId,
+        });
+      } else {
+        toast.success('Sauvegardé !', {
+          type: 'success',
+          toastId,
+        });
+      }
       return;
     }
 

--- a/frontend/src/components/Draft/SaveButton.tsx
+++ b/frontend/src/components/Draft/SaveButton.tsx
@@ -50,8 +50,6 @@ function SaveButton(props: Props) {
       }
       return;
     }
-
-    return () => toast.dismiss(toastId);
   }, [props.isError, props.isLoading, props.isSuccess]);
 
   return (

--- a/frontend/src/components/Draft/draft.module.scss
+++ b/frontend/src/components/Draft/draft.module.scss
@@ -2,3 +2,7 @@
   border: 1px solid var(--light-border-default-grey, #ddd);
   padding: 1rem;
 }
+
+.row {
+  margin-bottom: 0.75rem;
+}

--- a/frontend/src/hooks/useForm.tsx
+++ b/frontend/src/hooks/useForm.tsx
@@ -143,7 +143,6 @@ export function useForm<
       if (hasError(key)) {
         return 'error';
       }
-      return 'success';
     }
     return 'default';
   }

--- a/frontend/src/models/Draft.tsx
+++ b/frontend/src/models/Draft.tsx
@@ -1,9 +1,14 @@
-import { DraftDTO, DraftPayloadDTO } from '../../../shared/models/DraftDTO';
-import { Sender, SenderPayload } from './Sender';
+import {
+  DraftCreationPayloadDTO,
+  DraftDTO,
+  DraftUpdatePayloadDTO,
+} from '../../../shared/models/DraftDTO';
+import { SenderPayload } from './Sender';
 
 export interface Draft extends DraftDTO {}
 
-export interface DraftPayload extends DraftPayloadDTO {
-  id: string;
+export interface DraftCreationPayload extends DraftCreationPayloadDTO {
   sender: SenderPayload;
 }
+
+export type DraftUpdatePayload = DraftUpdatePayloadDTO;

--- a/frontend/src/models/Draft.tsx
+++ b/frontend/src/models/Draft.tsx
@@ -1,3 +1,9 @@
-import { DraftDTO } from '../../../shared/models/DraftDTO';
+import { DraftDTO, DraftPayloadDTO } from '../../../shared/models/DraftDTO';
+import { Sender, SenderPayload } from './Sender';
 
 export interface Draft extends DraftDTO {}
+
+export interface DraftPayload extends DraftPayloadDTO {
+  id: string;
+  sender: SenderPayload;
+}

--- a/frontend/src/models/Sender.tsx
+++ b/frontend/src/models/Sender.tsx
@@ -1,0 +1,5 @@
+import { SenderDTO, SenderPayloadDTO } from '../../../shared';
+
+export type Sender = SenderDTO;
+
+export type SenderPayload = SenderPayloadDTO;

--- a/frontend/src/services/draft.service.ts
+++ b/frontend/src/services/draft.service.ts
@@ -4,8 +4,10 @@ import {
   DraftDTO,
   DraftUpdatePayloadDTO,
 } from '../../../shared/models/DraftDTO';
-import { Draft } from '../models/Draft';
+import { Draft, DraftPayload } from '../models/Draft';
 import { getURLQuery } from '../utils/fetchUtils';
+import { SenderPayload } from '../models/Sender';
+import { SenderPayloadDTO } from '../../../shared';
 
 export interface FindOptions {
   campaign?: string;
@@ -39,7 +41,7 @@ export const draftApi = zlvApi.injectEndpoints({
       }),
       invalidatesTags: [{ type: 'Draft', id: 'LIST' }],
     }),
-    updateDraft: builder.mutation<void, DraftUpdatePayloadDTO>({
+    updateDraft: builder.mutation<void, DraftPayload>({
       query: (draft) => ({
         url: `/drafts/${draft.id}`,
         method: 'PUT',
@@ -56,8 +58,28 @@ function fromDraftDTO(draft: DraftDTO): Draft {
   return {
     id: draft.id,
     body: draft.body.replaceAll('<br />', '\n'),
+    sender: draft.sender ?? undefined,
     createdAt: draft.createdAt,
     updatedAt: draft.updatedAt,
+  };
+}
+
+function toDraftPayloadDTO(draft: DraftPayload): DraftPayloadDTO {
+  return {
+    body: draft.body ? draft.body.replaceAll('\n', '<br />') : null,
+    sender: toSenderPayloadDTO(draft.sender),
+  };
+}
+
+function toSenderPayloadDTO(sender: SenderPayload): SenderPayloadDTO {
+  return {
+    name: sender.name,
+    service: sender.service,
+    firstName: sender.firstName,
+    lastName: sender.lastName,
+    address: sender.address,
+    email: sender.email,
+    phone: sender.phone,
   };
 }
 

--- a/frontend/src/utils/test/requestUtils.ts
+++ b/frontend/src/utils/test/requestUtils.ts
@@ -52,7 +52,9 @@ export const mockRequests = (matches: RequestMatch[]): void => {
       return predicates(match).every((predicate) => predicate(request));
     });
     if (!match) {
-      return Promise.reject(new MockError(request));
+      const error = new MockError(request);
+      console.error(error);
+      return Promise.reject(error);
     }
 
     if (!match.persist) {
@@ -71,7 +73,7 @@ const isMockResponseInitFunction = (
 
 class MockError extends Error {
   constructor(request: Request) {
-    super(`Request to ${request.url} must be mocked`);
+    super(`Request to ${request.method} ${request.url} must be mocked`);
     this.name = 'MockError';
   }
 }

--- a/frontend/src/views/Campaign/CampaignDraft.tsx
+++ b/frontend/src/views/Campaign/CampaignDraft.tsx
@@ -52,7 +52,11 @@ function CampaignDraft(props: Props) {
 
   useEffect(() => {
     if (draft) {
-      setValues({ ...draft, campaign: props.campaign.id });
+      setValues({
+        body: draft.body,
+        sender: draft.sender,
+        campaign: props.campaign.id,
+      });
     }
   }, [draft, props.campaign.id]);
 

--- a/frontend/src/views/Campaign/CampaignDraft.tsx
+++ b/frontend/src/views/Campaign/CampaignDraft.tsx
@@ -6,7 +6,6 @@ import { useDocumentTitle } from '../../hooks/useDocumentTitle';
 import { useCampaign } from '../../hooks/useCampaign';
 import { useForm } from '../../hooks/useForm';
 import DraftBody from '../../components/Draft/DraftBody';
-import NotFoundView from '../NotFoundView';
 import { Campaign } from '../../models/Campaign';
 import { DraftCreationPayloadDTO } from '../../../../shared/models/DraftDTO';
 import SaveButton from '../../components/Draft/SaveButton';

--- a/frontend/src/views/Campaign/test/CampaignView.test.tsx
+++ b/frontend/src/views/Campaign/test/CampaignView.test.tsx
@@ -20,8 +20,8 @@ describe('Campaign view', () => {
   const user = userEvent.setup();
 
   const campaign = genCampaign();
-  const draft = genDraft();
   const sender = genSender();
+  const draft = genDraft(sender);
 
   let store: AppStore;
   let router: History;
@@ -173,7 +173,7 @@ describe('Campaign view', () => {
     expect(modal).not.toBeVisible();
   });
 
-  it('should save the draft on button click', async () => {
+  it('should update the draft on button click', async () => {
     const updated: Draft = {
       ...draft,
       body: 'New body',
@@ -221,24 +221,36 @@ describe('Campaign view', () => {
 
     // Fill the form
     const form = await screen.findByRole('form');
+    const body = await within(form).findByRole('textbox', {
+      name: /^Contenu de votre courrier/,
+    });
+    await user.clear(body);
+    await user.type(body, draft.body);
     const name = await within(form).findByLabelText(
       'Nom de la collectivité ou de l’administration*'
     );
+    await user.clear(name);
     await user.type(name, sender.name);
     const service = await within(form).findByLabelText('Service*');
+    await user.clear(service);
     await user.type(service, sender.service);
     const lastName = await within(form).findByLabelText('Nom*');
+    await user.clear(lastName);
     await user.type(lastName, sender.lastName);
     const firstName = await within(form).findByLabelText('Prénom*');
+    await user.clear(firstName);
     await user.type(firstName, sender.firstName);
     const address = await within(form).findByLabelText('Adresse*');
+    await user.clear(address);
     await user.type(address, sender.address);
     if (sender.email) {
       const email = await within(form).findByLabelText('Adresse courriel');
+      await user.clear(email);
       await user.type(email, sender.email);
     }
     if (sender.phone) {
       const phone = await within(form).findByLabelText('Téléphone');
+      await user.clear(phone);
       await user.type(phone, sender.phone);
     }
 

--- a/frontend/test/fixtures.test.ts
+++ b/frontend/test/fixtures.test.ts
@@ -13,6 +13,7 @@ import { HousingStatus } from '../src/models/HousingState';
 import { Group } from '../src/models/Group';
 import { DatafoncierHousing } from '../../shared';
 import { Draft } from '../src/models/Draft';
+import { Sender } from '../src/models/Sender';
 
 const randomstring = require('randomstring');
 
@@ -21,17 +22,15 @@ export const genBoolean = () => Math.random() < 0.5;
 export const genSiren = () => genNumber(9);
 
 export function genEmail() {
-  return (
-    randomstring.generate({
-      length: 10,
-      charset: 'alphabetic',
-    }) +
-    '@' +
-    randomstring.generate({
-      length: 10,
-      charset: 'alphabetic',
-    })
-  );
+  const name = randomstring.generate({
+    length: 10,
+    charset: 'alphabetic',
+  });
+  const domain = randomstring.generate({
+    length: 10,
+    charset: 'alphabetic',
+  });
+  return `${name}@${domain}.com`;
 }
 
 export function genNumber(length = 10) {
@@ -125,6 +124,24 @@ export function genDraft(): Draft {
   return {
     id: randomstring.generate(),
     body: randomstring.generate(),
+    createdAt: new Date().toJSON(),
+    updatedAt: new Date().toJSON(),
+  };
+}
+
+export function genSender(): Sender {
+  return {
+    id: randomstring.generate(),
+    name: randomstring.generate(),
+    service: randomstring.generate(),
+    firstName: randomstring.generate(),
+    lastName: randomstring.generate(),
+    address: randomstring.generate(),
+    email: genEmail(),
+    phone: randomstring.generate({
+      length: 10,
+      charset: 'numeric',
+    }),
     createdAt: new Date().toJSON(),
     updatedAt: new Date().toJSON(),
   };

--- a/frontend/test/fixtures.test.ts
+++ b/frontend/test/fixtures.test.ts
@@ -23,12 +23,14 @@ export const genSiren = () => genNumber(9);
 
 export function genEmail() {
   const name = randomstring.generate({
-    length: 10,
+    length: 4,
     charset: 'alphabetic',
+    readable: true,
   });
   const domain = randomstring.generate({
-    length: 10,
+    length: 4,
     charset: 'alphabetic',
+    readable: true,
   });
   return `${name}@${domain}.com`;
 }
@@ -120,10 +122,11 @@ export const genCampaign = (): Campaign => ({
   exportURL: randomstring.generate(),
 });
 
-export function genDraft(): Draft {
+export function genDraft(sender: Sender): Draft {
   return {
     id: randomstring.generate(),
     body: randomstring.generate(),
+    sender,
     createdAt: new Date().toJSON(),
     updatedAt: new Date().toJSON(),
   };

--- a/server/controllers/draftController.ts
+++ b/server/controllers/draftController.ts
@@ -143,36 +143,14 @@ async function update(request: Request, response: Response<DraftDTO>) {
   response.status(constants.HTTP_STATUS_OK).json(toDraftDTO(updated));
 }
 const updateSenderValidators: ValidationChain[] = [
-  body('sender.name')
-    .isString()
-    .withMessage('Name must be a string')
-    .trim()
-    .notEmpty()
-    .withMessage('Name is required'),
-  body('sender.service')
-    .isString()
-    .withMessage('Service must be a string')
-    .trim()
-    .notEmpty()
-    .withMessage('Service is required'),
-  body('sender.firstName')
-    .isString()
-    .withMessage('First name must be a string')
-    .trim()
-    .notEmpty()
-    .withMessage('First name is required'),
-  body('sender.lastName')
-    .isString()
-    .withMessage('Last name must be a string')
-    .trim()
-    .notEmpty()
-    .withMessage('Last name is required'),
-  body('sender.address')
-    .isString()
-    .withMessage('Address must be a string')
-    .trim()
-    .notEmpty()
-    .withMessage('Address is required'),
+  ...['name', 'service', 'firstName', 'lastName', 'address'].map((prop) =>
+    body(`sender.${prop}`)
+      .isString()
+      .withMessage(`${prop} must be a string`)
+      .trim()
+      .notEmpty()
+      .withMessage(`${prop} is required`)
+  ),
   body('sender.email').isString().withMessage('Email must be a string').trim(),
   body('sender.phone').isString().withMessage('Phone must be a string').trim(),
 ];

--- a/server/controllers/draftController.ts
+++ b/server/controllers/draftController.ts
@@ -105,15 +105,17 @@ async function update(request: Request, response: Response<DraftDTO>) {
     throw new DraftMissingError(params.id);
   }
 
-  const existingSender: SenderApi | null =
-    draft.sender ??
-    (await senderRepository.findOne({
-      name: body.sender.name,
-      establishmentId: auth.establishmentId,
-    }));
+  const changeSender = !!draft.sender && draft.sender.name !== body.sender.name;
+  const existingSender: SenderApi | null = changeSender
+    ? await senderRepository.findOne({
+        name: body.sender.name,
+        establishmentId: auth.establishmentId,
+      })
+    : draft.sender;
+
   const sender: SenderApi = {
     id: existingSender?.id ?? uuidv4(),
-    name: existingSender?.name ?? body.sender.name,
+    name: body.sender.name,
     service: body.sender.service,
     firstName: body.sender.firstName,
     lastName: body.sender.lastName,

--- a/server/controllers/draftController.ts
+++ b/server/controllers/draftController.ts
@@ -92,7 +92,7 @@ async function create(request: Request, response: Response) {
   await senderRepository.save(sender);
   await draftRepository.save(draft);
   await campaignDraftRepository.save(campaign, draft);
-  response.status(constants.HTTP_STATUS_CREATED).json(draft);
+  response.status(constants.HTTP_STATUS_CREATED).json(toDraftDTO(draft));
 }
 const createValidators: ValidationChain[] = [
   body('body').isString().notEmpty().withMessage('body is required'),

--- a/server/controllers/draftController.ts
+++ b/server/controllers/draftController.ts
@@ -9,8 +9,8 @@ import { DraftApi, toDraftDTO } from '../models/DraftApi';
 import draftRepository, { DraftFilters } from '../repositories/draftRepository';
 import {
   DraftCreationPayloadDTO,
-  DraftUpdatePayloadDTO,
   DraftDTO,
+  DraftUpdatePayloadDTO,
 } from '../../shared/models/DraftDTO';
 import campaignDraftRepository from '../repositories/campaignDraftRepository';
 import campaignRepository from '../repositories/campaignRepository';
@@ -20,7 +20,7 @@ import { isUUIDParam } from '../utils/validators';
 import { logger } from '../utils/logger';
 import pdf from '../utils/pdf';
 import DRAFT_TEMPLATE_FILE from '../templates/draft';
-import { SenderApi } from '../models/SenderApi';
+import { createOrReplaceSender, SenderApi } from '../models/SenderApi';
 import senderRepository from '../repositories/senderRepository';
 
 interface DraftQuery {
@@ -75,19 +75,11 @@ async function create(request: Request, response: Response) {
     name: body.sender.name,
     establishmentId: auth.establishmentId,
   });
-  const sender: SenderApi = {
-    id: existingSender?.id ?? uuidv4(),
-    name: body.sender.name,
-    service: body.sender.service,
-    firstName: body.sender.firstName,
-    lastName: body.sender.lastName,
-    address: body.sender.address,
-    email: body.sender.email,
-    phone: body.sender.phone,
-    createdAt: existingSender?.createdAt ?? new Date().toJSON(),
-    updatedAt: new Date().toJSON(),
-    establishmentId: auth.establishmentId,
-  };
+  const sender: SenderApi = createOrReplaceSender(
+    body.sender,
+    existingSender,
+    auth.establishmentId
+  );
   const draft: DraftApi = {
     id: uuidv4(),
     body: body.body,
@@ -153,19 +145,11 @@ async function update(request: Request, response: Response<DraftDTO>) {
       })
     : draft.sender;
 
-  const sender: SenderApi = {
-    id: existingSender?.id ?? uuidv4(),
-    name: body.sender.name,
-    service: body.sender.service,
-    firstName: body.sender.firstName,
-    lastName: body.sender.lastName,
-    address: body.sender.address,
-    email: body.sender.email,
-    phone: body.sender.phone,
-    createdAt: existingSender?.createdAt ?? new Date().toJSON(),
-    updatedAt: new Date().toJSON(),
-    establishmentId: auth.establishmentId,
-  };
+  const sender: SenderApi = createOrReplaceSender(
+    body.sender,
+    existingSender,
+    auth.establishmentId
+  );
 
   // If the sender exists, update it
   // Otherwise create a new sender

--- a/server/controllers/draftController.ts
+++ b/server/controllers/draftController.ts
@@ -50,16 +50,13 @@ const senderValidators: ValidationChain[] = [
       .notEmpty()
       .withMessage(`${prop} is required`)
   ),
-  body('sender.email')
-    .optional({ checkFalsy: true })
-    .isString()
-    .withMessage('Email must be a string')
-    .trim(),
-  body('sender.phone')
-    .optional({ checkFalsy: true })
-    .isString()
-    .withMessage('Phone must be a string')
-    .trim(),
+  ...['email', 'phone'].map((prop) =>
+    body(`sender.${prop}`)
+      .optional({ checkFalsy: true })
+      .isString()
+      .withMessage(`${prop} must be a string`)
+      .trim()
+  ),
 ];
 
 async function create(request: Request, response: Response) {

--- a/server/models/DraftApi.ts
+++ b/server/models/DraftApi.ts
@@ -1,13 +1,17 @@
 import { DraftDTO } from '../../shared/models/DraftDTO';
+import { SenderApi, toSenderDTO } from './SenderApi';
 
 export interface DraftApi extends DraftDTO {
   establishmentId: string;
+  senderId: string | null;
+  sender: SenderApi | null;
 }
 
 export function toDraftDTO(draft: DraftApi): DraftDTO {
   return {
     id: draft.id,
     body: draft.body,
+    sender: draft.sender ? toSenderDTO(draft.sender) : null,
     createdAt: draft.createdAt,
     updatedAt: draft.updatedAt,
   };

--- a/server/models/DraftApi.ts
+++ b/server/models/DraftApi.ts
@@ -3,15 +3,15 @@ import { SenderApi, toSenderDTO } from './SenderApi';
 
 export interface DraftApi extends DraftDTO {
   establishmentId: string;
-  senderId: string | null;
-  sender: SenderApi | null;
+  senderId: string;
+  sender: SenderApi;
 }
 
 export function toDraftDTO(draft: DraftApi): DraftDTO {
   return {
     id: draft.id,
     body: draft.body,
-    sender: draft.sender ? toSenderDTO(draft.sender) : null,
+    sender: toSenderDTO(draft.sender),
     createdAt: draft.createdAt,
     updatedAt: draft.updatedAt,
   };

--- a/server/models/SenderApi.ts
+++ b/server/models/SenderApi.ts
@@ -1,0 +1,20 @@
+import { SenderDTO } from '../../shared/models/SenderDTO';
+
+export interface SenderApi extends SenderDTO {
+  establishmentId: string;
+}
+
+export function toSenderDTO(sender: SenderApi): SenderDTO {
+  return {
+    id: sender.id,
+    name: sender.name,
+    service: sender.service,
+    firstName: sender.firstName,
+    lastName: sender.lastName,
+    address: sender.address,
+    email: sender.email,
+    phone: sender.phone,
+    createdAt: sender.createdAt,
+    updatedAt: sender.updatedAt,
+  };
+}

--- a/server/models/SenderApi.ts
+++ b/server/models/SenderApi.ts
@@ -1,4 +1,5 @@
-import { SenderDTO } from '../../shared/models/SenderDTO';
+import { SenderDTO, SenderPayloadDTO } from '../../shared/models/SenderDTO';
+import { v4 as uuidv4 } from 'uuid';
 
 export interface SenderApi extends SenderDTO {
   establishmentId: string;
@@ -16,5 +17,25 @@ export function toSenderDTO(sender: SenderApi): SenderDTO {
     phone: sender.phone,
     createdAt: sender.createdAt,
     updatedAt: sender.updatedAt,
+  };
+}
+
+export function createOrReplaceSender(
+  payload: SenderPayloadDTO,
+  existing: SenderApi | null,
+  establishmentId: string
+): SenderApi {
+  return {
+    id: existing?.id ?? uuidv4(),
+    name: payload.name,
+    service: payload.service,
+    firstName: payload.firstName,
+    lastName: payload.lastName,
+    address: payload.address,
+    email: payload.email,
+    phone: payload.phone,
+    createdAt: existing?.createdAt ?? new Date().toJSON(),
+    updatedAt: new Date().toJSON(),
+    establishmentId,
   };
 }

--- a/server/repositories/draftRepository.ts
+++ b/server/repositories/draftRepository.ts
@@ -96,11 +96,11 @@ export interface DraftRecordDBO {
   created_at: Date;
   updated_at: Date;
   establishment_id: string;
-  sender_id: string | null;
+  sender_id: string;
 }
 
 export interface DraftDBO extends DraftRecordDBO {
-  sender: SenderDBO | null;
+  sender: SenderDBO;
 }
 
 export const formatDraftApi = (draft: DraftApi): DraftRecordDBO => ({
@@ -119,7 +119,7 @@ export const parseDraftApi = (draft: DraftDBO): DraftApi => ({
   updatedAt: draft.updated_at.toJSON(),
   establishmentId: draft.establishment_id,
   senderId: draft.sender_id,
-  sender: draft.sender ? parseSenderApi(draft.sender) : null,
+  sender: parseSenderApi(draft.sender),
 });
 
 export default {

--- a/server/repositories/draftRepository.ts
+++ b/server/repositories/draftRepository.ts
@@ -4,9 +4,10 @@ import db from './db';
 import { DraftApi } from '../models/DraftApi';
 import { campaignsDraftsTable } from './campaignDraftRepository';
 import { logger } from '../utils/logger';
+import { parseSenderApi, SenderDBO, sendersTable } from './senderRepository';
 
 export const draftsTable = 'drafts';
-export const Drafts = (transaction: Knex<DraftDBO> = db) =>
+export const Drafts = (transaction: Knex<DraftRecordDBO> = db) =>
   transaction(draftsTable);
 
 export interface DraftFilters {
@@ -53,11 +54,18 @@ async function save(draft: DraftApi): Promise<void> {
   await Drafts()
     .insert(formatDraftApi(draft))
     .onConflict('id')
-    .merge(['body', 'updated_at']);
+    .merge(['body', 'updated_at', 'sender_id']);
 }
 
 function listQuery(query: Knex.QueryBuilder): void {
-  query.select(`${draftsTable}.*`);
+  query
+    .select(`${draftsTable}.*`)
+    .leftJoin<SenderDBO>(
+      sendersTable,
+      `${draftsTable}.sender_id`,
+      `${sendersTable}.id`
+    )
+    .select(db.raw(`to_json(${sendersTable}.*) AS sender`));
 }
 
 function filterQuery(filters?: DraftFilters) {
@@ -82,20 +90,26 @@ function filterQuery(filters?: DraftFilters) {
   };
 }
 
-export interface DraftDBO {
+export interface DraftRecordDBO {
   id: string;
   body: string;
   created_at: Date;
   updated_at: Date;
   establishment_id: string;
+  sender_id: string | null;
 }
 
-export const formatDraftApi = (draft: DraftApi): DraftDBO => ({
+export interface DraftDBO extends DraftRecordDBO {
+  sender: SenderDBO | null;
+}
+
+export const formatDraftApi = (draft: DraftApi): DraftRecordDBO => ({
   id: draft.id,
   body: draft.body,
   created_at: new Date(draft.createdAt),
   updated_at: new Date(draft.updatedAt),
   establishment_id: draft.establishmentId,
+  sender_id: draft.senderId,
 });
 
 export const parseDraftApi = (draft: DraftDBO): DraftApi => ({
@@ -104,6 +118,8 @@ export const parseDraftApi = (draft: DraftDBO): DraftApi => ({
   createdAt: draft.created_at.toJSON(),
   updatedAt: draft.updated_at.toJSON(),
   establishmentId: draft.establishment_id,
+  senderId: draft.sender_id,
+  sender: draft.sender ? parseSenderApi(draft.sender) : null,
 });
 
 export default {

--- a/server/repositories/senderRepository.ts
+++ b/server/repositories/senderRepository.ts
@@ -1,0 +1,91 @@
+import { SenderApi } from '../models/SenderApi';
+import db, { where } from './db';
+import { logger } from '../utils/logger';
+
+export const sendersTable = 'senders';
+export const Senders = (transaction = db) =>
+  transaction<SenderDBO>(sendersTable);
+
+type FindOneOptions = Partial<
+  Pick<SenderApi, 'id' | 'name' | 'establishmentId'>
+>;
+
+async function findOne(opts: FindOneOptions): Promise<SenderApi | null> {
+  logger.debug('Finding sender...', opts);
+  const whereOptions = where<FindOneOptions>(
+    ['id', 'name', 'establishmentId'],
+    { table: sendersTable }
+  );
+
+  const sender = await Senders().where(whereOptions(opts)).first();
+  if (!sender) {
+    return null;
+  }
+
+  logger.debug('Found sender', sender);
+  return parseSenderApi(sender);
+}
+
+async function save(sender: SenderApi): Promise<void> {
+  logger.debug('Saving sender...', sender);
+  await Senders()
+    .insert(formatSenderApi(sender))
+    .onConflict(['name', 'establishment_id'])
+    .merge([
+      'service',
+      'first_name',
+      'last_name',
+      'address',
+      'email',
+      'phone',
+      'updated_at',
+    ]);
+  logger.debug('Saved sender', sender);
+}
+
+export interface SenderDBO {
+  id: string;
+  name: string;
+  service: string;
+  first_name: string;
+  last_name: string;
+  address: string;
+  email: string | null;
+  phone: string | null;
+  created_at: Date | string;
+  updated_at: Date | string;
+  establishment_id: string;
+}
+
+export const formatSenderApi = (sender: SenderApi): SenderDBO => ({
+  id: sender.id,
+  name: sender.name,
+  service: sender.service,
+  first_name: sender.firstName,
+  last_name: sender.lastName,
+  address: sender.address,
+  email: sender.email,
+  phone: sender.phone,
+  created_at: new Date(sender.createdAt),
+  updated_at: new Date(sender.updatedAt),
+  establishment_id: sender.establishmentId,
+});
+
+export const parseSenderApi = (sender: SenderDBO): SenderApi => ({
+  id: sender.id,
+  name: sender.name,
+  service: sender.service,
+  firstName: sender.first_name,
+  lastName: sender.last_name,
+  address: sender.address,
+  email: sender.email,
+  phone: sender.phone,
+  createdAt: new Date(sender.created_at).toJSON(),
+  updatedAt: new Date(sender.updated_at).toJSON(),
+  establishmentId: sender.establishment_id,
+});
+
+export default {
+  findOne,
+  save,
+};

--- a/server/repositories/test/draftRepository.test.ts
+++ b/server/repositories/test/draftRepository.test.ts
@@ -4,6 +4,7 @@ import {
   genCampaignApi,
   genDraftApi,
   genEstablishmentApi,
+  genSenderApi,
   genUserApi,
 } from '../../test/testFixtures';
 import draftRepository, { Drafts, formatDraftApi } from '../draftRepository';
@@ -16,6 +17,7 @@ import {
   formatEstablishmentApi,
 } from '../establishmentRepository';
 import { formatUserApi, Users } from '../userRepository';
+import { SenderApi } from '../../models/SenderApi';
 
 describe('Draft repository', () => {
   const establishment = genEstablishmentApi();
@@ -29,9 +31,13 @@ describe('Draft repository', () => {
 
   describe('find', () => {
     let drafts: DraftApi[];
+    let sender: SenderApi;
 
     beforeAll(async () => {
-      drafts = Array.from({ length: 5 }, () => genDraftApi(establishment));
+      sender = genSenderApi(establishment);
+      drafts = Array.from({ length: 5 }, () =>
+        genDraftApi(establishment, sender)
+      );
       await Drafts().insert(drafts.map(formatDraftApi));
     });
 
@@ -62,7 +68,8 @@ describe('Draft repository', () => {
   });
 
   describe('findOne', () => {
-    const draft = genDraftApi(establishment);
+    const sender = genSenderApi(establishment);
+    const draft = genDraftApi(establishment, sender);
 
     beforeAll(async () => {
       await Drafts().insert(formatDraftApi(draft));
@@ -97,7 +104,8 @@ describe('Draft repository', () => {
   });
 
   describe('save', () => {
-    const draft = genDraftApi(establishment);
+    const sender = genSenderApi(establishment);
+    const draft = genDraftApi(establishment, sender);
 
     it('should create a draft that does not exist', async () => {
       await draftRepository.save(draft);

--- a/server/repositories/test/draftRepository.test.ts
+++ b/server/repositories/test/draftRepository.test.ts
@@ -18,6 +18,7 @@ import {
 } from '../establishmentRepository';
 import { formatUserApi, Users } from '../userRepository';
 import { SenderApi } from '../../models/SenderApi';
+import { formatSenderApi, Senders } from '../senderRepository';
 
 describe('Draft repository', () => {
   const establishment = genEstablishmentApi();
@@ -30,14 +31,13 @@ describe('Draft repository', () => {
   const anotherEstablishment = Establishment2;
 
   describe('find', () => {
-    let drafts: DraftApi[];
-    let sender: SenderApi;
+    const sender: SenderApi = genSenderApi(establishment);
+    const drafts: DraftApi[] = Array.from({ length: 5 }, () =>
+      genDraftApi(establishment, sender)
+    );
 
     beforeAll(async () => {
-      sender = genSenderApi(establishment);
-      drafts = Array.from({ length: 5 }, () =>
-        genDraftApi(establishment, sender)
-      );
+      await Senders().insert(formatSenderApi(sender));
       await Drafts().insert(drafts.map(formatDraftApi));
     });
 
@@ -72,6 +72,7 @@ describe('Draft repository', () => {
     const draft = genDraftApi(establishment, sender);
 
     beforeAll(async () => {
+      await Senders().insert(formatSenderApi(sender));
       await Drafts().insert(formatDraftApi(draft));
     });
 
@@ -108,6 +109,8 @@ describe('Draft repository', () => {
     const draft = genDraftApi(establishment, sender);
 
     it('should create a draft that does not exist', async () => {
+      await Senders().insert(formatSenderApi(sender));
+
       await draftRepository.save(draft);
 
       const actual = await Drafts().where({ id: draft.id }).first();

--- a/server/templates/draft.css
+++ b/server/templates/draft.css
@@ -1,3 +1,31 @@
 body {
   padding: 3rem 2.5rem;
 }
+
+header {
+  display: flex;
+  flex-flow: column nowrap;
+  justify-content: space-around;
+  margin-bottom: 1rem;
+}
+
+main {
+  text-align: justify;
+  font-size: 0.6875rem;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 0.875rem;
+}
+
+p {
+  margin: 0;
+  padding: 0;
+}
+
+.header__sender {
+  text-align: right;
+  font-size: 0.6875rem;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 0.875rem;
+}

--- a/server/templates/draft.hbs
+++ b/server/templates/draft.hbs
@@ -1,14 +1,25 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta name="theme-color" content="#000000" />
-</head>
-<body>
-  <noscript>You need to enable JavaScript to run this app.</noscript>
-  <div id="root">
-    {{{body}}}
-  </div>
-</body>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#000000" />
+    <title>Zéro Logement Vacant</title>
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <header>
+      <section class="header__sender">
+        <p>{{sender.name}}</p>
+        <p>{{sender.service}}</p>
+        <p>{{sender.firstName}} {{sender.lastName}}</p>
+        <p>{{sender.address}}</p>
+        <p>{{sender.email}}</p>
+        <p>{{sender.phone}}</p>
+      </section>
+    </header>
+    <main>
+      {{{body}}}
+    </main>
+  </body>
 </html>

--- a/server/test/testFixtures.ts
+++ b/server/test/testFixtures.ts
@@ -749,7 +749,7 @@ export function genSenderApi(establishment: EstablishmentApi): SenderApi {
   const lastName = faker.person.lastName();
   return {
     id: uuidv4(),
-    name: faker.location.city(),
+    name: `${faker.location.zipCode()} ${faker.location.city()}`,
     service: faker.company.name(),
     firstName,
     lastName,

--- a/server/test/testFixtures.ts
+++ b/server/test/testFixtures.ts
@@ -68,6 +68,7 @@ import { AddressApi } from '../models/AddressApi';
 import { AddressKinds } from '../../shared/models/AdresseDTO';
 import { HousingNoteApi, NoteApi } from '../models/NoteApi';
 import { DraftApi } from '../models/DraftApi';
+import { SenderApi } from '../models/SenderApi';
 
 logger.debug(`Seed: ${faker.seed()}`);
 
@@ -734,6 +735,26 @@ export function genDraftApi(establishment: EstablishmentApi): DraftApi {
     body: faker.lorem.paragraph(),
     createdAt: new Date().toJSON(),
     updatedAt: new Date().toJSON(),
+    sender: null,
+    senderId: null,
+    establishmentId: establishment.id,
+  };
+}
+
+export function genSenderApi(establishment: EstablishmentApi): SenderApi {
+  const firstName = faker.person.firstName();
+  const lastName = faker.person.lastName();
+  return {
+    id: uuidv4(),
+    name: faker.location.city(),
+    service: faker.company.name(),
+    firstName,
+    lastName,
+    address: faker.location.streetAddress({ useFullAddress: true }),
+    email: faker.internet.email({ firstName, lastName }),
+    phone: faker.phone.number(),
+    createdAt: faker.date.past().toJSON(),
+    updatedAt: faker.date.recent().toJSON(),
     establishmentId: establishment.id,
   };
 }

--- a/server/test/testFixtures.ts
+++ b/server/test/testFixtures.ts
@@ -729,14 +729,17 @@ export const genHousingNoteApi = (
   housingId: housing.id,
 });
 
-export function genDraftApi(establishment: EstablishmentApi): DraftApi {
+export function genDraftApi(
+  establishment: EstablishmentApi,
+  sender: SenderApi
+): DraftApi {
   return {
     id: uuidv4(),
     body: faker.lorem.paragraph(),
     createdAt: new Date().toJSON(),
     updatedAt: new Date().toJSON(),
-    sender: null,
-    senderId: null,
+    sender,
+    senderId: sender.id,
     establishmentId: establishment.id,
   };
 }

--- a/shared/models/DraftDTO.ts
+++ b/shared/models/DraftDTO.ts
@@ -1,18 +1,18 @@
-import { SenderDTO } from './SenderDTO';
+import { SenderDTO, SenderPayloadDTO } from './SenderDTO';
 
 export interface DraftDTO {
   id: string;
   body: string;
-  sender: SenderDTO | null;
+  sender: SenderDTO;
   createdAt: string;
   updatedAt: string;
 }
 
 export interface DraftCreationPayloadDTO extends Pick<DraftDTO, 'body'> {
   campaign: string;
+  sender: SenderPayloadDTO;
 }
 
-export type DraftUpdatePayloadDTO = Pick<DraftDTO, 'id' | 'body'>;
-export interface DraftPayloadDTO extends Pick<DraftDTO, 'body'> {
-  sender: Omit<SenderDTO, 'id' | 'createdAt' | 'updatedAt'>;
+export interface DraftUpdatePayloadDTO extends Pick<DraftDTO, 'id' | 'body'> {
+  sender: SenderPayloadDTO;
 }

--- a/shared/models/DraftDTO.ts
+++ b/shared/models/DraftDTO.ts
@@ -1,6 +1,9 @@
+import { SenderDTO } from './SenderDTO';
+
 export interface DraftDTO {
   id: string;
   body: string;
+  sender: SenderDTO | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -10,3 +13,6 @@ export interface DraftCreationPayloadDTO extends Pick<DraftDTO, 'body'> {
 }
 
 export type DraftUpdatePayloadDTO = Pick<DraftDTO, 'id' | 'body'>;
+export interface DraftPayloadDTO extends Pick<DraftDTO, 'body'> {
+  sender: Omit<SenderDTO, 'id' | 'createdAt' | 'updatedAt'>;
+}

--- a/shared/models/SenderDTO.ts
+++ b/shared/models/SenderDTO.ts
@@ -1,0 +1,17 @@
+export interface SenderDTO {
+  id: string;
+  name: string;
+  service: string;
+  firstName: string;
+  lastName: string;
+  address: string;
+  email: string | null;
+  phone: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type SenderPayloadDTO = Pick<
+  SenderDTO,
+  'name' | 'service' | 'firstName' | 'lastName' | 'address' | 'email' | 'phone'
+>;

--- a/shared/models/index.ts
+++ b/shared/models/index.ts
@@ -8,5 +8,6 @@ export * from './HousingDTO';
 export * from './OwnerDTO';
 export * from './Pagination';
 export * from './RolesDTO';
+export * from './SenderDTO';
 export * from './SettingsDTO';
 export * from './UserDTO';


### PR DESCRIPTION
## Features
- Add sender form
- When updating a draft
  - update the sender if it exists (unique (name, establishment) pair)
  - create a sender if not
  - link the sender to the draft
- Add sender to the PDF preview

Merge this **after** #644

Recreated to avoid commit duplication when rebasing.