### PR TITLE
Scalingo : ignore node_modules for frontend

### DIFF
--- a/.slugignore
+++ b/.slugignore
@@ -1,0 +1,1 @@
+frontend/node_modules


### PR DESCRIPTION
Permet d'économiser la copie `node_modules` pour le déploiement de l'image.

**Taille de l'image**
Avant: 834Mo
Après: 480Mo