### PR TITLE
Updated-a-variable-campaign-name

### DIFF
--- a/frontend/src/components/RichEditor/variable-options.ts
+++ b/frontend/src/components/RichEditor/variable-options.ts
@@ -2,7 +2,7 @@ import { Variable } from './Variable';
 
 export const VARIABLE_OPTIONS: Variable[] = [
   {
-    label: 'Nom et prénom propriétaire',
+    label: 'Nom et prénom propriétaire principal',
     value: '{{owner.fullName}}',
   },
   {


### PR DESCRIPTION
Changed "Nom et prénom propriétaire" par "Nom et prénom propriétaire principal" pour mettre l'emphase sur le fait que c'est uniquement les infos du premier propriétaire.