### PR TITLE
Prettify logs in development and leave as JSON in production

### DIFF
--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -1,4 +1,4 @@
-import pino from 'pino';
+import pino, { LoggerOptions as PinoLoggerOptions } from 'pino';
 import { LogLevel } from './log-level';
 
 interface LoggerOptions {
@@ -22,12 +22,15 @@ export interface Logger {
 
 export function createLogger(name: string, opts: LoggerOptions): Logger {
   const level = opts.level ?? LogLevel.DEBUG;
-  const logger = pino({
+  const developmentOptions: PinoLoggerOptions = {
     transport: {
-      target: 'pino-pretty',
-    },
+      target: 'pino-pretty'
+    }
+  };
+  const logger = pino({
+    ...(opts.isProduction ? {} : developmentOptions),
     name,
-    level,
+    level
   });
 
   return {
@@ -35,7 +38,7 @@ export function createLogger(name: string, opts: LoggerOptions): Logger {
     debug: toPinoLogFn(logger.debug.bind(logger)),
     info: toPinoLogFn(logger.info.bind(logger)),
     warn: toPinoLogFn(logger.warn.bind(logger)),
-    error: toPinoLogFn(logger.error.bind(logger)),
+    error: toPinoLogFn(logger.error.bind(logger))
   };
 }
 


### PR DESCRIPTION
Les messages sont pris un par un car _pino_ affiche tous les messages au format _pino-pretty_, quel que soit l’env. On garde le prettify pour le dev, on laisse le comportement par défaut (NDJSON) pour la prod.

<img width="596" alt="Screenshot 2024-06-27 at 10 22 24" src="https://github.com/MTES-MCT/zero-logement-vacant/assets/9626158/c720b2e6-0245-4012-9dfe-5d0d1aebf307">