### PR TITLE
Added non breaking space in the "Ajouter un logement" helpmessage 

### DIFF
--- a/frontend/src/components/modals/HousingCreationModal/FillLocalId.tsx
+++ b/frontend/src/components/modals/HousingCreationModal/FillLocalId.tsx
@@ -80,7 +80,7 @@ const FillLocalId = forwardRef((props: StepProps, ref) => {
             >
               L’identifiant du logement
             </a>
-            est une concaténation du
+            &nbsp;est une concaténation du
             <a
               href="https://doc-datafoncier.cerema.fr/doc/dv3f/local/coddep"
               target="_blank"
@@ -88,7 +88,7 @@ const FillLocalId = forwardRef((props: StepProps, ref) => {
             >
               code département
             </a>
-            du logement et de
+            &nbsp;du logement et de
             <a
               href="https://doc-datafoncier.cerema.fr/doc/ff/pb0010_local/invar"
               target="_blank"
@@ -96,7 +96,7 @@ const FillLocalId = forwardRef((props: StepProps, ref) => {
             >
               l’invariant fiscal
             </a>
-            du logement, dans cet ordre-là.
+            &nbsp;du logement, dans cet ordre-là.
           </>
         }
       />


### PR DESCRIPTION
<img width="744" alt="Capture d’écran 2024-07-05 à 15 03 46" src="https://github.com/MTES-MCT/zero-logement-vacant/assets/138494307/c66c9601-64a8-48b0-8b82-ae65cfc0d302">
Missins spaces today in the text