### PR TITLE
fix: update establishments_localities table during CEREMA automation script execution and set available=true

### DIFF
--- a/server/src/repositories/establishmentLocalityRepository.ts
+++ b/server/src/repositories/establishmentLocalityRepository.ts
@@ -31,5 +31,5 @@ async function updateLocalities(establishment: EstablishmentDBO): Promise<void> 
 }
 
 export default {
-  updateLocalities
+  updateLocalities,
 }

--- a/server/src/repositories/establishmentLocalityRepository.ts
+++ b/server/src/repositories/establishmentLocalityRepository.ts
@@ -18,7 +18,7 @@ async function updateLocalities(establishment: EstablishmentDBO): Promise<void> 
   .where('establishments.id', establishment.id)
   .select('localities.id as locality_id', 'establishments.id as establishment_id');
 
-  EstablishmentLocalities()
+  await EstablishmentLocalities()
   .insert(subquery)
   .onConflict()
   .ignore()

--- a/server/src/repositories/establishmentLocalityRepository.ts
+++ b/server/src/repositories/establishmentLocalityRepository.ts
@@ -1,4 +1,7 @@
 import db from '~/infra/database';
+import { EstablishmentDBO } from './establishmentRepository';
+import { Localities } from './localityRepository';
+import { logger } from '~/infra/logger';
 
 export const establishmentsLocalitiesTable = 'establishments_localities';
 export const EstablishmentLocalities = (transaction = db) =>
@@ -7,4 +10,26 @@ export const EstablishmentLocalities = (transaction = db) =>
 export interface EstablishmentLocalityDBO {
   establishment_id: string;
   locality_id: string;
+}
+
+async function updateLocalities(establishment: EstablishmentDBO): Promise<void> {
+  const subquery = await Localities()
+  .join('establishments', 'localities.geo_code', db.raw('ANY(establishments.localities_geo_code)'))
+  .where('establishments.id', establishment.id)
+  .select('localities.id as locality_id', 'establishments.id as establishment_id');
+
+  EstablishmentLocalities()
+  .insert(subquery)
+  .onConflict()
+  .ignore()
+  .then(() => {
+    logger.info('Insert successful');
+  })
+  .catch(err => {
+    logger.error('Error during insert', err);
+  });
+}
+
+export default {
+  updateLocalities
 }

--- a/server/src/repositories/establishmentLocalityRepository.ts
+++ b/server/src/repositories/establishmentLocalityRepository.ts
@@ -32,4 +32,4 @@ async function updateLocalities(establishment: EstablishmentDBO): Promise<void> 
 
 export default {
   updateLocalities,
-}
+};

--- a/server/src/tasks/ceremaTask.ts
+++ b/server/src/tasks/ceremaTask.ts
@@ -27,6 +27,7 @@ const createEstablishment = async (establishment: EstablishmentApi[] | undefined
         timestamp: new Date().toISOString()
       });
     }
+    establishment.available = true;
     await establishmentRepository.save(establishment);
     await establishmentLocalityRepository.updateLocalities(establishment);
   }

--- a/server/src/tasks/ceremaTask.ts
+++ b/server/src/tasks/ceremaTask.ts
@@ -10,6 +10,7 @@ import config from '../infra/config';
 import { logger } from '../infra/logger';
 import { CeremaDossier } from '../services/ceremaService/consultDossiersLovacService';
 import establishmentRepository from '~/repositories/establishmentRepository';
+import establishmentLocalityRepository from '~/repositories/establishmentLocalityRepository';
 import { Structure, structureToEstablishment } from '../services/ceremaService/consultStructureService';
 import { getLastScriptExecutionDate, logScriptExecution } from '~/infra/elastic';
 import { wait } from '@zerologementvacant/utils';
@@ -27,6 +28,7 @@ const createEstablishment = async (establishment: EstablishmentApi[] | undefined
       });
     }
     await establishmentRepository.save(establishment);
+    await establishmentLocalityRepository.updateLocalities(establishment);
   }
 };
 


### PR DESCRIPTION
En m'appuyant sur le script original `server/src/infra/database/scripts/001-load-establishments_com_epci_reg_dep.sql`:

```
-- Link establishments <-> localities
INSERT INTO establishments_localities (
    SELECT l.id, e.id
    FROM localities l, establishments e
    WHERE l.geo_code = any(e.localities_geo_code)
) ON conflict do nothing;
```

