### PR TITLE
chore: staging and test data now using addresses according to owner/housing geoCode

### DIFF
--- a/server/src/controllers/campaignController.test.ts
+++ b/server/src/controllers/campaignController.test.ts
@@ -186,9 +186,9 @@ describe('Campaign API', () => {
     it('should create a new campaign', async () => {
       const title = randomstring.generate();
       const description = randomstring.generate();
-      const houses: HousingApi[] = Array.from({ length: 2 }).map(() =>
-        genHousingApi(oneOf(establishment.geoCodes))
-      );
+      const houses: HousingApi[] = await Promise.all(Array.from({ length: 2 }).map(async () =>
+        await genHousingApi(oneOf(establishment.geoCodes))
+      ));
       await Housing().insert(houses.map(formatHousingRecordApi));
       const payload: CampaignCreationPayloadDTO = {
         title,
@@ -239,16 +239,16 @@ describe('Campaign API', () => {
     });
   });
 
-  describe('POST /campaigns/{id}/groups', () => {
+  describe('POST /campaigns/{id}/groups', async () => {
     const testRoute = (id: string) => `/api/campaigns/${id}/groups`;
 
     const geoCode = oneOf(establishment.geoCodes);
     const group = genGroupApi(user, establishment);
-    const groupHousing = [
+    const groupHousing = await Promise.all([
       genHousingApi(geoCode),
       genHousingApi(geoCode),
       genHousingApi(geoCode)
-    ];
+    ]);
     const owners = groupHousing
       .map((housing) => housing.owner)
       .filter(isDefined);
@@ -591,9 +591,9 @@ describe('Campaign API', () => {
     });
 
     it('should delete linked events and campaign housing', async () => {
-      const houses: HousingApi[] = Array.from({ length: 2 }).map(() =>
+      const houses: HousingApi[] = await Promise.all(Array.from({ length: 2 }).map(() =>
         genHousingApi(oneOf(establishment.geoCodes))
-      );
+      ));
       await Housing().insert(houses.map(formatHousingRecordApi));
       const campaignHouses: CampaignHousingDBO[] = houses.map((housing) => ({
         campaign_id: campaign.id,

--- a/server/src/controllers/eventController.test.ts
+++ b/server/src/controllers/eventController.test.ts
@@ -43,10 +43,11 @@ describe('Event API', () => {
     await Users().insert(formatUserApi(user));
   });
 
-  describe('GET /owners/{id}/events', () => {
+  describe('GET /owners/{id}/events', async () => {
     const testRoute = (id: string) => `/api/owners/${id}/events`;
 
-    const owner = genOwnerApi();
+    const geoCode = '67268';
+    const owner = await genOwnerApi(geoCode);
 
     beforeAll(async () => {
       await Owners().insert(formatOwnerApi(owner));
@@ -67,9 +68,9 @@ describe('Event API', () => {
     });
 
     it('should list the owner events', async () => {
-      const events: OwnerEventApi[] = Array.from({ length: 3 }).map(() =>
-        genOwnerEventApi(owner, user)
-      );
+      const events: OwnerEventApi[] = await Promise.all(Array.from({ length: 3 }).map(() =>
+        genOwnerEventApi(owner, user, geoCode)
+      ));
       await Events().insert(events.map(formatEventApi));
       await OwnerEvents().insert(events.map(formatOwnerEventApi));
 
@@ -85,10 +86,10 @@ describe('Event API', () => {
     });
   });
 
-  describe('GET /housing/{id}/events', () => {
+  describe('GET /housing/{id}/events', async () => {
     const testRoute = (id: string) => `/api/housing/${id}/events`;
 
-    const housing = genHousingApi(oneOf(establishment.geoCodes));
+    const housing = await genHousingApi(oneOf(establishment.geoCodes));
 
     beforeAll(async () => {
       await Housing().insert(formatHousingRecordApi(housing));

--- a/server/src/controllers/housingController.test.ts
+++ b/server/src/controllers/housingController.test.ts
@@ -65,10 +65,10 @@ describe('Housing API', () => {
     await Users().insert([user, anotherUser].map(formatUserApi));
   });
 
-  describe('GET /housing/{id}', () => {
+  describe('GET /housing/{id}', async () => {
     const testRoute = (id: string) => `/api/housing/${id}`;
 
-    const housing = genHousingApi(oneOf(anotherEstablishment.geoCodes));
+    const housing = await genHousingApi(oneOf(anotherEstablishment.geoCodes));
 
     beforeAll(async () => {
       await Housing().insert(formatHousingRecordApi(housing));
@@ -107,12 +107,13 @@ describe('Housing API', () => {
     });
 
     it('should return the housing list for a query filter', async () => {
+      const housingApi = await genHousingApi(oneOf(establishment.geoCodes));
       const queriedHousing = {
-        ...genHousingApi(oneOf(establishment.geoCodes)),
+        ...housingApi,
         rawAddress: ['line1 with   many      spaces', 'line2'],
       };
       await Housing().insert(formatHousingRecordApi(queriedHousing));
-      const owner = genOwnerApi();
+      const owner = await genOwnerApi(oneOf(establishment.geoCodes));
       await Owners().insert(formatOwnerApi(owner));
       await HousingOwners().insert(
         formatHousingOwnersApi(queriedHousing, [owner]),
@@ -152,7 +153,7 @@ describe('Housing API', () => {
     });
 
     it('should fail if the housing already exists', async () => {
-      const housing = genHousingApi(oneOf(establishment.geoCodes));
+      const housing = await genHousingApi(oneOf(establishment.geoCodes));
       await Housing().insert(formatHousingRecordApi(housing));
       const payload = {
         localId: housing.localId,
@@ -259,7 +260,7 @@ describe('Housing API', () => {
     });
   });
 
-  describe('POST /housing/{id}', () => {
+  describe('POST /housing/{id}', async () => {
     const validBody: { housingUpdate: HousingUpdateBody } = {
       housingUpdate: {
         statusUpdate: {
@@ -279,7 +280,7 @@ describe('Housing API', () => {
 
     const testRoute = (housingId: string) => `/api/housing/${housingId}`;
 
-    const housing = genHousingApi(oneOf(establishment.geoCodes));
+    const housing = await genHousingApi(oneOf(establishment.geoCodes));
 
     beforeAll(async () => {
       await Housing().insert(formatHousingRecordApi(housing));

--- a/server/src/controllers/noteController.test.ts
+++ b/server/src/controllers/noteController.test.ts
@@ -27,12 +27,12 @@ import {
 } from '~/repositories/noteRepository';
 import { NoteApi } from '~/models/NoteApi';
 
-describe('Note API', () => {
+describe('Note API', async () => {
   const { app } = createServer();
 
   const establishment = genEstablishmentApi();
   const user = genUserApi(establishment.id);
-  const housing = genHousingApi(oneOf(establishment.geoCodes));
+  const housing = await genHousingApi(oneOf(establishment.geoCodes));
 
   beforeAll(async () => {
     await Establishments().insert(formatEstablishmentApi(establishment));

--- a/server/src/models/test/EventApi.test.ts
+++ b/server/src/models/test/EventApi.test.ts
@@ -10,14 +10,15 @@ import {
 import { UserApi } from '~/models/UserApi';
 
 describe('EventApi', () => {
-  describe('isUserModified', () => {
+  describe('isUserModified', async () => {
     const establishment = genEstablishmentApi();
-    const housing = genHousingApi();
+    const housing = await genHousingApi();
 
-    it('should throw an error if the event creator is missing', () => {
+    it('should throw an error if the event creator is missing', async () => {
       const creator: UserApi = genUserApi(establishment.id);
+      const housingApiEvent = await genHousingEventApi(housing, creator);
       const event: HousingEventApi = {
-        ...genHousingEventApi(housing, creator),
+        ...housingApiEvent,
         creator: undefined
       };
 
@@ -28,12 +29,12 @@ describe('EventApi', () => {
 
     it.each(['@zerologementvacant.beta.gouv.fr', '@beta.gouv.fr'])(
       'should return false if the event creator’s email ends with %s',
-      (domain) => {
+      async (domain) => {
         const creator: UserApi = {
           ...genUserApi(establishment.id),
           email: `admin${domain}`
         };
-        const event = genHousingEventApi(housing, creator);
+        const event = await genHousingEventApi(housing, creator);
 
         const actual = isUserModified(event);
 
@@ -45,9 +46,9 @@ describe('EventApi', () => {
       count: 10
     });
 
-    it.each(emails)('should return true otherwise (%s)', (email) => {
+    it.each(emails)('should return true otherwise (%s)', async (email) => {
       const creator: UserApi = { ...genUserApi(establishment.id), email };
-      const event = genHousingEventApi(housing, creator);
+      const event = await genHousingEventApi(housing, creator);
 
       const actual = isUserModified(event);
 

--- a/server/src/models/test/HousingApi.test.ts
+++ b/server/src/models/test/HousingApi.test.ts
@@ -16,9 +16,10 @@ import { UserApi } from '~/models/UserApi';
 
 describe('HousingApi', () => {
   describe('getBuildingLocation', () => {
-    it('should parse a building location', () => {
+    it('should parse a building location', async () => {
+      const housingApi = await genHousingApi();
       const housing: HousingApi = {
-        ...genHousingApi(),
+        ...housingApi,
         buildingLocation: 'B010002002'
       };
 
@@ -36,9 +37,10 @@ describe('HousingApi', () => {
   describe('isSupervised', () => {
     it.each(['En accompagnement', 'Intervention publique'])(
       `should return true if the housing status is "in progress" and the subStatus is %s`,
-      (subStatus) => {
+      async (subStatus) => {
+        const housingApi = await genHousingApi();
         const housing: HousingApi = {
-          ...genHousingApi(),
+          ...housingApi,
           status: HousingStatusApi.InProgress,
           subStatus
         };
@@ -54,9 +56,10 @@ describe('HousingApi', () => {
 
       it.each(['N’était pas vacant', 'Sortie de la vacance'])(
         'should return true if the substatus is %s and if the user modified the housing manually',
-        (subStatus) => {
+        async (subStatus) => {
+          const housingApi = await genHousingApi();
           const housing: HousingApi = {
-            ...genHousingApi(),
+            ...housingApi,
             status: HousingStatusApi.Completed,
             subStatus
           };
@@ -64,9 +67,9 @@ describe('HousingApi', () => {
             ...genUserApi(establishment.id),
             email: 'test@test.test'
           };
-          const events: HousingEventApi[] = Array.from({ length: 3 }, () =>
-            genHousingEventApi(housing, creator)
-          );
+          const events: HousingEventApi[] = await Promise.all(Array.from({ length: 3 }, async () =>
+            await genHousingEventApi(housing, creator)
+          ));
 
           const actual = isSupervised(housing, events);
 
@@ -74,9 +77,10 @@ describe('HousingApi', () => {
         }
       );
 
-      it('should return false if the user did not modify the housing', () => {
+      it('should return false if the user did not modify the housing', async () => {
+        const housingApi = await genHousingApi();
         const housing: HousingApi = {
-          ...genHousingApi(),
+          ...housingApi,
           status: HousingStatusApi.Completed,
           subStatus: 'Sortie de la vacance'
         };

--- a/server/src/models/test/HousingOwnerApi.test.ts
+++ b/server/src/models/test/HousingOwnerApi.test.ts
@@ -12,9 +12,10 @@ import {
 
 describe('HousingOwnerApi', () => {
   describe('toHousingOwnersApi', () => {
-    it('should map a housing and its owners to housing owners', () => {
-      const housing = genHousingApi();
-      const owners = new Array(5).fill(0).map(genOwnerApi);
+    it('should map a housing and its owners to housing owners', async () => {
+      const housing = await genHousingApi();
+      const geoCode = '67268';
+      const owners = await Promise.all(new Array(5).fill(0).map(async () => await genOwnerApi(geoCode)));
 
       const actual = toHousingOwnersApi(housing, owners);
 
@@ -24,8 +25,10 @@ describe('HousingOwnerApi', () => {
   });
 
   describe('compareHousingOwners', () => {
-    it('should return properties that differ', () => {
-      const a = genHousingOwnerApi(genHousingApi(), genOwnerApi());
+    it('should return properties that differ', async () => {
+      const housingApi = await genHousingApi();
+      const geoCode = '67268';
+      const a = genHousingOwnerApi(housingApi, await genOwnerApi(geoCode));
       const b: HousingOwnerApi = {
         ...a,
         rank: a.rank + 1,
@@ -40,8 +43,10 @@ describe('HousingOwnerApi', () => {
   });
 
   describe('equals', () => {
-    it('should return true if all properties are equal, false otherwise', () => {
-      const a = genHousingOwnerApi(genHousingApi(), genOwnerApi());
+    it('should return true if all properties are equal, false otherwise', async () => {
+      const housingApi = await genHousingApi();
+      const geoCode = '67268';
+      const a = genHousingOwnerApi(housingApi, await genOwnerApi(geoCode));
       const b: HousingOwnerApi = {
         ...a,
         rank: a.rank + 1,

--- a/server/src/repositories/conflict/test/conflictRepository.test.ts
+++ b/server/src/repositories/conflict/test/conflictRepository.test.ts
@@ -36,10 +36,11 @@ describe('Conflict repository', () => {
   describe('Owner conflicts', () => {
     const repository = conflictRepository.owners;
 
-    describe('find', () => {
-      const conflicts: OwnerConflictApi[] = Array.from({ length: 5 }, () =>
-        genOwnerConflictApi(),
-      );
+    describe('find', async () => {
+      const geoCode = '67268';
+      const conflicts: OwnerConflictApi[] = await Promise.all(Array.from({ length: 5 }, async () =>
+        await genOwnerConflictApi(geoCode),
+      ));
 
       beforeAll(async () => {
         await Conflicts().insert(conflicts.map(formatConflictApi));
@@ -63,8 +64,9 @@ describe('Conflict repository', () => {
       });
     });
 
-    describe('save', () => {
-      const conflict = genOwnerConflictApi();
+    describe('save', async () => {
+      const geoCode = '67268';
+      const conflict = await genOwnerConflictApi(geoCode);
 
       beforeAll(async () => {
         await Owners().insert(formatOwnerApi(conflict.existing));
@@ -88,12 +90,13 @@ describe('Conflict repository', () => {
     });
 
     describe('formatOwnerConflictApi', () => {
-      it('should format a owner conflict', () => {
+      it('should format a owner conflict', async () => {
+        const geoCode = '67268';
         const conflict: OwnerConflictApi = {
           id: uuidv4(),
           createdAt: new Date(),
-          existing: genOwnerApi(),
-          replacement: genOwnerApi(),
+          existing: await genOwnerApi(geoCode),
+          replacement: await genOwnerApi(geoCode),
         };
 
         const actual = formatOwnerConflictApi(conflict);

--- a/server/src/repositories/conflict/test/housingOwnerConflictRepository.test.ts
+++ b/server/src/repositories/conflict/test/housingOwnerConflictRepository.test.ts
@@ -25,8 +25,8 @@ import { OwnerApi } from '~/models/OwnerApi';
 import { HousingApi } from '~/models/HousingApi';
 
 describe('Housing owner conflict repository', () => {
-  describe('find', () => {
-    const housing = genHousingApi();
+  describe('find', async () => {
+    const housing = await genHousingApi();
     const owner = housing.owner;
     const conflicts = new Array(5)
       .fill(0)
@@ -62,8 +62,9 @@ describe('Housing owner conflict repository', () => {
     let conflict: HousingOwnerConflictApi;
 
     beforeEach(async () => {
-      housing = genHousingApi();
-      owners = Array.from({ length: 2 }, () => genOwnerApi());
+      housing = await genHousingApi();
+      const geoCode = '67268';
+      owners = await Promise.all(Array.from({ length: 2 }, async () => await genOwnerApi(geoCode)));
       conflict = genHousingOwnerConflictApi(
         housing,
         genHousingOwnerApi(housing, owners[0]),

--- a/server/src/repositories/test/banAddressesRepository.test.ts
+++ b/server/src/repositories/test/banAddressesRepository.test.ts
@@ -80,7 +80,7 @@ describe('BAN addresses repository', () => {
 
   describe('saveMany', () => {
     it('should save thousands of records', async () => {
-      const housings = Array.from({ length: 2_000 }, genHousingApi);
+      const housings = await Promise.all(Array.from({ length: 2_000 }, genHousingApi));
       await db.batchInsert(
         'fast_housing',
         housings.map(formatHousingRecordApi)
@@ -100,7 +100,7 @@ describe('BAN addresses repository', () => {
 
   describe('listAddressesToNormalize', () => {
     it('should list addresses to normalize', async () => {
-      const housings = Array.from({ length: 3 }, genHousingApi);
+      const housings = await Promise.all(Array.from({ length: 3 }, genHousingApi));
       await Housing().insert(housings.map(formatHousingRecordApi));
 
       const actual = await banAddressesRepository.listAddressesToNormalize();

--- a/server/src/repositories/test/eventRepository.test.ts
+++ b/server/src/repositories/test/eventRepository.test.ts
@@ -72,9 +72,9 @@ describe('Event repository', () => {
     });
 
     it('should return events linked to a group and a housing', async () => {
-      const houses = Array.from({ length: 3 }).map(() =>
+      const houses = await Promise.all(Array.from({ length: 3 }).map(() =>
         genHousingApi(oneOf(establishment.geoCodes))
-      );
+      ));
       const group = genGroupApi(user, establishment);
       const events: EventApi<GroupApi>[] = houses.map(() => ({
         id: uuidv4(),

--- a/server/src/repositories/test/groupRepository.test.ts
+++ b/server/src/repositories/test/groupRepository.test.ts
@@ -114,14 +114,14 @@ describe('Group repository', () => {
     });
   });
 
-  describe('save', () => {
+  describe('save', async () => {
     const establishment = genEstablishmentApi();
     const user = genUserApi(establishment.id);
-    const housingList: HousingApi[] = [
+    const housingList: HousingApi[] = await Promise.all([
       genHousingApi(),
       genHousingApi(),
       genHousingApi(),
-    ];
+    ]);
 
     beforeAll(async () => {
       await Establishments().insert(formatEstablishmentApi(establishment));
@@ -152,7 +152,7 @@ describe('Group repository', () => {
     it('should update a group that exists', async () => {
       const group = genGroupApi(user, establishment);
       await Groups().insert(formatGroupApi(group));
-      const newHousing = genHousingApi();
+      const newHousing = await genHousingApi();
       await Housing().insert(formatHousingRecordApi(newHousing));
       const newGroup: GroupApi = {
         ...group,
@@ -206,15 +206,15 @@ describe('Group repository', () => {
     });
   });
 
-  describe('remove', () => {
+  describe('remove', async () => {
     const establishment = genEstablishmentApi();
     const user = genUserApi(establishment.id);
     const group = genGroupApi(user, establishment);
-    const housingList: HousingApi[] = [
+    const housingList: HousingApi[] = await Promise.all([
       genHousingApi(),
       genHousingApi(),
       genHousingApi(),
-    ];
+    ]);
 
     beforeEach(async () => {
       await Establishments().insert(formatEstablishmentApi(establishment));

--- a/server/src/repositories/test/housingOwnerRepository.test.ts
+++ b/server/src/repositories/test/housingOwnerRepository.test.ts
@@ -15,8 +15,9 @@ import {
 describe('housingOwnerRepository', () => {
   describe('insert', () => {
     it('should ignore the conflict if the same owner is inserted twice at the same rank', async () => {
-      const owner = genOwnerApi();
-      const housing = genHousingApi();
+      const geoCode = '67268';
+      const owner = await genOwnerApi(geoCode);
+      const housing = await genHousingApi();
       await Promise.all([
         Owners().insert(formatOwnerApi(owner)),
         Housing().insert(formatHousingRecordApi(housing))
@@ -40,8 +41,9 @@ describe('housingOwnerRepository', () => {
     });
 
     it('should ignore the conflict if the same owner is inserted at two different ranks', async () => {
-      const owner = genOwnerApi();
-      const housing = genHousingApi();
+      const geoCode = '67268';
+      const owner = await genOwnerApi(geoCode);
+      const housing = await genHousingApi();
       await Promise.all([
         Owners().insert(formatOwnerApi(owner)),
         Housing().insert(formatHousingRecordApi(housing))
@@ -78,8 +80,9 @@ describe('housingOwnerRepository', () => {
 
   describe('saveMany', () => {
     it('should replace housing owners', async () => {
-      const existingOwner = genOwnerApi();
-      const housing = genHousingApi();
+      const geoCode = '67268';
+      const existingOwner = await genOwnerApi(geoCode);
+      const housing = await genHousingApi();
       await Promise.all([
         Owners().insert(formatOwnerApi(existingOwner)),
         Housing().insert(formatHousingRecordApi(housing))
@@ -93,7 +96,7 @@ describe('housingOwnerRepository', () => {
       };
       await HousingOwners().insert(formatHousingOwnerApi(existingHousingOwner));
 
-      const newOwner: OwnerApi = genOwnerApi();
+      const newOwner: OwnerApi = await genOwnerApi(geoCode);
       const newHousingOwner: HousingOwnerApi = {
         ...newOwner,
         rank: 1,

--- a/server/src/repositories/test/ownerMatchRepository.test.ts
+++ b/server/src/repositories/test/ownerMatchRepository.test.ts
@@ -19,7 +19,8 @@ describe('Owner match repository', () => {
 
     it('should return the match if it exists', async () => {
       const datafoncierOwner = genDatafoncierOwner();
-      const owner = genOwnerApi();
+      const geoCode = '67268';
+      const owner = await genOwnerApi(geoCode);
       const ownerMatch = genOwnerMatch(datafoncierOwner, owner);
       await Owners().insert(formatOwnerApi(owner));
       await OwnerMatches().insert(ownerMatch);

--- a/server/src/repositories/test/ownerRepository.test.ts
+++ b/server/src/repositories/test/ownerRepository.test.ts
@@ -10,7 +10,9 @@ import { OwnerApi } from '~/models/OwnerApi';
 describe('Owner repository', () => {
   describe('find', () => {
     it('should find owners by idpersonne', async () => {
-      const owners = Array.from({ length: 6 }, () => genOwnerApi());
+      const geoCode = '67268';
+      const owners = await Promise.all(Array.from({ length: 6 }, async () => await genOwnerApi(geoCode)));
+      
       await Owners().insert(owners.map(formatOwnerApi));
 
       const actual = await ownerRepository.find({
@@ -25,8 +27,9 @@ describe('Owner repository', () => {
 
   describe('findOne', () => {
     it('should find a owner without birth date', async () => {
+      const geoCode = '67268';
       const owner: OwnerApi = {
-        ...genOwnerApi(),
+        ...await genOwnerApi(geoCode),
         birthDate: undefined
       };
       await db(ownerTable).insert(formatOwnerApi(owner));
@@ -44,7 +47,8 @@ describe('Owner repository', () => {
     });
 
     it('should find a owner with birth date', async () => {
-      const owner: OwnerApi = genOwnerApi();
+      const geoCode = '67268';
+      const owner: OwnerApi = await genOwnerApi(geoCode);
       await db(ownerTable).insert(formatOwnerApi(owner));
 
       const actual = await ownerRepository.findOne({
@@ -64,13 +68,14 @@ describe('Owner repository', () => {
 
   describe('stream', () => {
     it('should group by full name', async () => {
-      const owners = new Array(4)
+      const geoCode = '67268';
+      const owners = await Promise.all(new Array(4)
         .fill('0')
-        .map(() => genOwnerApi())
+        .map(async () => await genOwnerApi(geoCode))
         .map<OwnerApi>((owner) => ({
           ...owner,
           fullName: 'Jean Dupont'
-        }));
+        })));
       await Owners().insert(owners.map(formatOwnerApi));
 
       const actual = await ownerRepository

--- a/server/src/scripts/import-datafoncier/test/existingHousingOwnersImporter.test.ts
+++ b/server/src/scripts/import-datafoncier/test/existingHousingOwnersImporter.test.ts
@@ -37,7 +37,7 @@ describe('Import housing owners from existing housing', () => {
     let owners: OwnerApi[];
 
     beforeEach(async () => {
-      housing = genHousingApi();
+      housing = await genHousingApi();
       datafoncierHousing = {
         ...genDatafoncierHousing(),
         idlocal: housing.localId,
@@ -51,7 +51,8 @@ describe('Import housing owners from existing housing', () => {
         idprocpte: datafoncierHousing.idprocpte,
         dnulp: (i + 1).toString()
       }));
-      owners = Array.from({ length: 6 }, () => genOwnerApi());
+      const geoCode = '67268';
+      owners = await Promise.all(Array.from({ length: 6 }, async () => genOwnerApi(geoCode)));
 
       await DatafoncierHouses().insert(datafoncierHousing);
       await DatafoncierOwners().insert(datafoncierOwners);

--- a/server/src/scripts/import-lovac/housings/test/housing-processor.test.ts
+++ b/server/src/scripts/import-lovac/housings/test/housing-processor.test.ts
@@ -24,9 +24,9 @@ describe('Housing processor', () => {
     ProcessorOptions['housingEventRepository']
   >;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     auth = genUserApi('');
-    housing = genHousingApi();
+    housing = await genHousingApi();
     housingRepository = {
       update: jest.fn().mockImplementation(() => Promise.resolve())
     };
@@ -249,40 +249,40 @@ describe('Housing processor', () => {
 
       it.each(['En accompagnement', 'Intervention publique'])(
         'should return true if the housing status is %s and the substatus is %s',
-        (subStatus) => {
+        async (subStatus) => {
           const housing = {
             ...genHousingApi(),
             status,
             subStatus
           };
 
-          const actual = isInProgress(housing);
+          const actual = isInProgress(await housing);
 
           expect(actual).toBeTrue();
         }
       );
     });
 
-    it('should return false if the substatus is not set', () => {
+    it('should return false if the substatus is not set', async () => {
       const housing = {
         ...genHousingApi(),
         status: HousingStatusApi.InProgress,
         subStatus: undefined
       };
 
-      const actual = isInProgress(housing);
+      const actual = isInProgress(await housing);
 
       expect(actual).toBeFalse();
     });
 
-    it('should return false if the substatus is irrelevant', () => {
+    it('should return false if the substatus is irrelevant', async () => {
       const housing = {
         ...genHousingApi(),
         status: HousingStatusApi.InProgress,
         subStatus: 'anything else'
       };
 
-      const actual = isInProgress(housing);
+      const actual = isInProgress(await housing);
 
       expect(actual).toBeFalse();
     });
@@ -293,13 +293,13 @@ describe('Housing processor', () => {
 
     it.each(otherStatuses)(
       'should return false for other statuses',
-      (status) => {
+      async (status) => {
         const housing = {
           ...genHousingApi(),
           status
         };
 
-        const actual = isInProgress(housing);
+        const actual = isInProgress(await housing);
 
         expect(actual).toBeFalse();
       }
@@ -307,13 +307,13 @@ describe('Housing processor', () => {
   });
 
   describe('isCompleted', () => {
-    it(`should return true if the housing status is ${HousingStatusApi.Completed}`, () => {
+    it(`should return true if the housing status is ${HousingStatusApi.Completed}`, async () => {
       const housing = {
         ...genHousingApi(),
         status: HousingStatusApi.Completed
       };
 
-      const actual = isCompleted(housing);
+      const actual = isCompleted(await housing);
 
       expect(actual).toBeTrue();
     });
@@ -322,13 +322,13 @@ describe('Housing processor', () => {
       (status) => status !== HousingStatusApi.Completed
     );
 
-    it.each(otherStatuses)('should return false otherwise', (status) => {
+    it.each(otherStatuses)('should return false otherwise', async (status) => {
       const housing = {
         ...genHousingApi(),
         status
       };
 
-      const actual = isCompleted(housing);
+      const actual = isCompleted(await housing);
 
       expect(actual).toBeFalse();
     });

--- a/server/src/scripts/import-lovac/source-housing-owners/test/source-housing-owner-processor.test.ts
+++ b/server/src/scripts/import-lovac/source-housing-owners/test/source-housing-owner-processor.test.ts
@@ -128,13 +128,14 @@ describe('Source housing owner processor', () => {
     let housing: HousingApi;
     let departmentalOwners: ReadonlyArray<OwnerApi>;
 
-    beforeEach(() => {
-      housing = genHousingApi();
+    beforeEach(async () => {
+      housing = await genHousingApi();
       housingRepository.findOne.mockResolvedValue(housing);
-      departmentalOwners = sourceOwners.map((sourceOwner) => ({
-        ...genOwnerApi(),
+      const geoCode = '67268';
+      departmentalOwners = await Promise.all(sourceOwners.map(async (sourceOwner) => ({
+        ...await genOwnerApi(geoCode),
         idpersonne: sourceOwner.idpersonne
-      }));
+      })));
       ownerRepository.findOne.mockImplementation(async (idpersonne) => {
         return (
           departmentalOwners.find((owner) => owner.idpersonne === idpersonne) ??
@@ -349,9 +350,10 @@ describe('Source housing owner processor', () => {
   });
 
   describe('isNewHousing', () => {
-    it('should return true if dataFileYears contains only "lovac-2024"', () => {
+    it('should return true if dataFileYears contains only "lovac-2024"', async () => {
+      const housingApi = await genHousingApi();
       const housing: HousingApi = {
-        ...genHousingApi(),
+        ...housingApi,
         dataFileYears: ['lovac-2024']
       };
 
@@ -360,9 +362,10 @@ describe('Source housing owner processor', () => {
       expect(actual).toBeTrue();
     });
 
-    it('should return false otherwise', () => {
+    it('should return false otherwise', async () => {
+      const housingApi = await genHousingApi();
       const housing: HousingApi = {
-        ...genHousingApi(),
+        ...housingApi,
         dataFileYears: ['lovac-2022', 'lovac-2024']
       };
 
@@ -373,9 +376,10 @@ describe('Source housing owner processor', () => {
   });
 
   describe('isSupervised', () => {
-    it('should return true if the status is "in progress" and the substatus is "En accompagnement" or "Intervention publique"', () => {
+    it('should return true if the status is "in progress" and the substatus is "En accompagnement" or "Intervention publique"', async () => {
+      const housingApi = await genHousingApi();
       const housing: HousingApi = {
-        ...genHousingApi(),
+        ...housingApi,
         status: HousingStatusApi.InProgress,
         subStatus: 'En accompagnement'
       };
@@ -385,9 +389,10 @@ describe('Source housing owner processor', () => {
       expect(actual).toBeTrue();
     });
 
-    it('should return false otherwise', () => {
+    it('should return false otherwise', async () => {
+      const housingApi = await genHousingApi();
       const housing: HousingApi = {
-        ...genHousingApi(),
+        ...housingApi,
         status: HousingStatusApi.InProgress,
         subStatus: 'En instruction'
       };
@@ -399,8 +404,8 @@ describe('Source housing owner processor', () => {
   });
 
   describe('isNationalOwner', () => {
-    it('should return true if the housing owner has no _idpersonne_', () => {
-      const housing = genHousingApi();
+    it('should return true if the housing owner has no _idpersonne_', async () => {
+      const housing = await genHousingApi();
       const owner = genOwnerApi();
       const housingOwner: HousingOwnerApi = {
         ...genHousingOwnerApi(housing, owner),
@@ -412,8 +417,8 @@ describe('Source housing owner processor', () => {
       expect(actual).toBeTrue();
     });
 
-    it('should return false if _idpersonne_ is defined', () => {
-      const housing = genHousingApi();
+    it('should return false if _idpersonne_ is defined', async () => {
+      const housing = await genHousingApi();
       const owner = genOwnerApi();
       const housingOwner: HousingOwnerApi = {
         ...genHousingOwnerApi(housing, owner),

--- a/server/src/scripts/import-lovac/source-housings/test/source-housing-command.test.ts
+++ b/server/src/scripts/import-lovac/source-housings/test/source-housing-command.test.ts
@@ -53,20 +53,22 @@ describe('Source housing command', () => {
     };
     await Users().insert(formatUserApi(auth));
     const housings: ReadonlyArray<HousingApi> = [
-      ...nonVacantUnsupervisedHousings.map<HousingApi>((sourceHousing) => ({
-        ...genHousingApi(),
+      ...(await Promise.all(nonVacantUnsupervisedHousings.map(async (sourceHousing) => ({
+        ...(await genHousingApi()),
         geoCode: sourceHousing.geo_code,
         localId: sourceHousing.local_id,
         occupancy: OccupancyKindApi.Rent
-      })),
-      ...vacantHousings.map<HousingApi>((sourceHousing) => ({
-        ...genHousingApi(),
+      })))),
+      
+      ...(await Promise.all(vacantHousings.map(async (sourceHousing) => ({
+        ...(await genHousingApi()),
         geoCode: sourceHousing.geo_code,
         localId: sourceHousing.local_id,
         occupancy: OccupancyKindApi.Vacant,
         dataFileYears: ['lovac-2022']
-      }))
+      }))))
     ];
+    
     await Housing().insert(housings.map(formatHousingRecordApi));
     await write(file, sourceHousings);
 

--- a/server/src/scripts/import-lovac/source-housings/test/source-housing-processor.test.ts
+++ b/server/src/scripts/import-lovac/source-housings/test/source-housing-processor.test.ts
@@ -116,9 +116,9 @@ describe('Source housing processor', () => {
     let events: HousingEventApi[];
     let notes: HousingNoteApi[];
 
-    beforeEach(() => {
+    beforeEach(async () => {
       sourceHousing = genSourceHousing();
-      housing = genHousingApi();
+      housing = await genHousingApi();
       events = [];
       notes = [];
       housingRepository.findOne.mockResolvedValue(housing);
@@ -186,8 +186,10 @@ describe('Source housing processor', () => {
 
     describe(`If the housing has no user notes, no user events about status or occupancy, has status ${HousingStatusApi.Completed} and substatus "Sortie de la vacance"`, () => {
       beforeEach(async () => {
+
+        const housingEventApi = await genHousingEventApi(housing, admin);
         events.push({
-          ...genHousingEventApi(housing, admin),
+          ...housingEventApi,
           name: 'Ajout dans une campagne'
         });
         notes.push(genHousingNoteApi(admin, housing));

--- a/server/src/scripts/shared/owner-processor/test/duplicates.test.ts
+++ b/server/src/scripts/shared/owner-processor/test/duplicates.test.ts
@@ -11,29 +11,30 @@ import { OwnerApi } from '~/models/OwnerApi';
 import { ScoredOwner } from '../../models/Comparison';
 
 describe('Duplicates', () => {
-  function genOwner(rawAddress: string[], birthDate?: Date): OwnerApi {
+  async function genOwner(rawAddress: string[], birthDate?: Date): Promise<OwnerApi> {
+    const geoCode = '67268';
     return {
-      ...genOwnerApi(),
+      ...await genOwnerApi(geoCode),
       rawAddress,
       birthDate: birthDate?.toJSON()
     };
   }
 
-  describe('compare', () => {
+  describe('compare', async () => {
     test.each`
       a                                                                                          | b
-      ${genOwner(['0017 RUE DE LA GABARRE', '64500 SAINT-JEAN-DE-LUZ'])}                         | ${genOwner(['17 RUE DE LA GABARRE', 'SAINT JEAN DE LUZ', '64500 ST JEAN DE LUZ'])}
-      ${genOwner(['0025 RUE DE MEAUX', '77950 SAINT-GERMAIN-LAXIS'])}                            | ${genOwner(['25 RUE DE MEAUX', 'SAINT GERMAIN LAXIS', '77950 ST GERMAIN LAXIS'])}
-      ${genOwner(['0017 BD  DES COTES', '73100 AIX LES BAINS'])}                                 | ${genOwner(['VILLA MIREILLE', '0017 BD  DES COTES', '73100 AIX LES BAINS'])}
-      ${genOwner(['CHE DE BRANTES', '84550 MORNAS'])}                                            | ${genOwner(['0152 CHE DE BRANTES', '84550 MORNAS'])}
-      ${genOwner(['BAT B', '0219 RUE DU COMMANDANT ROLLAND', '13008 MARSEILLE'])}                | ${genOwner(['219 RUE DU COMMANDANT ROLLAND', '13008 MARSEILLE'])}
-      ${genOwner(['218 RUE CLEMENCEAU', 'SAINTE MARIE AUX MINES', '68160 STE MARIE AUX MINES'])} | ${genOwner(['0218 RUE CLEMENCEAU', '68160 SAINTE-MARIE-AUX-MINES'])}
-      ${genOwner(["4 CARROI DU PLAT D'ETAIN", '37370 NEUVY LE ROI'])}                            | ${genOwner(["0004 RUE DU CARROI DU PLAT D'ETAIN", '37370 NEUVY LE ROI'], new Date('1944-02-17'))}
-      ${genOwner(['8 COUR DU TERTRE', '22100 ST SAMSON SUR RANCE'])}                             | ${genOwner(['0008 COURDU TERTRE', '22100 SAINT-SAMSON-SUR-RANCE'])}
-      ${genOwner(['8 COURDU TERTRE', 'SAINT SAMSON SUR RANCE', '22100 ST SAMSON SUR RANCE'])}    | ${genOwner(['0008 COURDU TERTRE', '22100 SAINT-SAMSON-SUR-RANCE'])}
-      ${genOwner(['0006 PL  JEANNINE MICHEAU', '31200 TOULOUSE'])}                               | ${genOwner(['PAR M NON', '6 PL JEANNINE MICHEAU', '31200 TOULOUSE'])}
-      ${genOwner(['PAR M DUPONT JEAN', '4 RUE LOUIS DEBRONS', '15000 AURILLAC'])}                | ${genOwner(['CHEZ DUPONT JEAN', '4T RUE LOUIS DEBRONS', '15000 AURILLAC'])}
-      ${genOwner(['1 RUE BERTHE', '93400 ST OUEN SUR SEINE'])}                                   | ${genOwner(['1 RUE BERTHE', 'SAINT OUEN SUR SEINE', '93400 ST OUEN SUR SEINE'])}
+      ${await genOwner(['0017 RUE DE LA GABARRE', '64500 SAINT-JEAN-DE-LUZ'])}                         | ${await genOwner(['17 RUE DE LA GABARRE', 'SAINT JEAN DE LUZ', '64500 ST JEAN DE LUZ'])}
+      ${await genOwner(['0025 RUE DE MEAUX', '77950 SAINT-GERMAIN-LAXIS'])}                            | ${await genOwner(['25 RUE DE MEAUX', 'SAINT GERMAIN LAXIS', '77950 ST GERMAIN LAXIS'])}
+      ${await genOwner(['0017 BD  DES COTES', '73100 AIX LES BAINS'])}                                 | ${await genOwner(['VILLA MIREILLE', '0017 BD  DES COTES', '73100 AIX LES BAINS'])}
+      ${await genOwner(['CHE DE BRANTES', '84550 MORNAS'])}                                            | ${await genOwner(['0152 CHE DE BRANTES', '84550 MORNAS'])}
+      ${await genOwner(['BAT B', '0219 RUE DU COMMANDANT ROLLAND', '13008 MARSEILLE'])}                | ${await genOwner(['219 RUE DU COMMANDANT ROLLAND', '13008 MARSEILLE'])}
+      ${await genOwner(['218 RUE CLEMENCEAU', 'SAINTE MARIE AUX MINES', '68160 STE MARIE AUX MINES'])} | ${await genOwner(['0218 RUE CLEMENCEAU', '68160 SAINTE-MARIE-AUX-MINES'])}
+      ${await genOwner(["4 CARROI DU PLAT D'ETAIN", '37370 NEUVY LE ROI'])}                            | ${await genOwner(["0004 RUE DU CARROI DU PLAT D'ETAIN", '37370 NEUVY LE ROI'], new Date('1944-02-17'))}
+      ${await genOwner(['8 COUR DU TERTRE', '22100 ST SAMSON SUR RANCE'])}                             | ${await genOwner(['0008 COURDU TERTRE', '22100 SAINT-SAMSON-SUR-RANCE'])}
+      ${await genOwner(['8 COURDU TERTRE', 'SAINT SAMSON SUR RANCE', '22100 ST SAMSON SUR RANCE'])}    | ${await genOwner(['0008 COURDU TERTRE', '22100 SAINT-SAMSON-SUR-RANCE'])}
+      ${await genOwner(['0006 PL  JEANNINE MICHEAU', '31200 TOULOUSE'])}                               | ${await genOwner(['PAR M NON', '6 PL JEANNINE MICHEAU', '31200 TOULOUSE'])}
+      ${await genOwner(['PAR M DUPONT JEAN', '4 RUE LOUIS DEBRONS', '15000 AURILLAC'])}                | ${await genOwner(['CHEZ DUPONT JEAN', '4T RUE LOUIS DEBRONS', '15000 AURILLAC'])}
+      ${await genOwner(['1 RUE BERTHE', '93400 ST OUEN SUR SEINE'])}                                   | ${await genOwner(['1 RUE BERTHE', 'SAINT OUEN SUR SEINE', '93400 ST OUEN SUR SEINE'])}
     `('should match $a.rawAddress with $b.rawAddress', async ({ a, b }) => {
       const actual = compare(a, b);
       expect(actual).toBeGreaterThanOrEqual(MATCH_THRESHOLD);
@@ -41,14 +42,14 @@ describe('Duplicates', () => {
 
     test.each`
       a                                                                            | b
-      ${genOwner(['62 AV DE LA ROUDET', 'RES LE PINTEY', '33500 LIBOURNE'])}       | ${genOwner(['0168 AV  DU PRESIDENT WILSON', '93100 MONTREUIL'])}
-      ${genOwner(['0015 RUE DES SEIGNEURS', '68740 BALGAU'])}                      | ${genOwner(['0014 RUE DES GLACIERES', '67000 STRASBOURG'])}
-      ${genOwner(['6 RUE DU DOLMEN', '79400 NANTEUIL'])}                           | ${genOwner(['10 RUE DU RONCEY', '78920 ECQUEVILLY'])}
-      ${genOwner(['PAR MR OLIVIER', '0067 RUE DES CHARRETIERS', '45000 ORLEANS'])} | ${genOwner(['600 R PIERRE BROSSOLETTE LABUISS', '62700 BRUAY LA BUISSIERE'])}
-      ${genOwner(['3 ALL DE LA BEAUCE', '78640 ST GERMAIN DE LA GRANGE'])}         | ${genOwner(['0001 PL  DE L ECOLE', '95400 VILLIERS LE BEL'])}
-      ${genOwner(['PAR M CLAUDE', '0125 RUE SAINT CHARLES', '75015 PARIS'])}       | ${genOwner(['0005 RUE DU COLONEL TIFFOINET', '51200 EPERNAY'])}
-      ${genOwner(['PAR MR JEAN', 'RUE DES LANDES', '72110 BEAUFAY'])}              | ${genOwner(['0602 RTE DES LANDES', '72110 BEAUFAY'])}
-      ${genOwner(['4 RUE ADRIEN SIMONNOT', '21700 COMBLANCHIEN'])}                 | ${genOwner(['PAR M INCONNU', 'LES COMBES', '71170 SAINT-IGNY-DE-ROCHE'])}
+      ${await genOwner(['62 AV DE LA ROUDET', 'RES LE PINTEY', '33500 LIBOURNE'])}       | ${await genOwner(['0168 AV  DU PRESIDENT WILSON', '93100 MONTREUIL'])}
+      ${await genOwner(['0015 RUE DES SEIGNEURS', '68740 BALGAU'])}                      | ${await genOwner(['0014 RUE DES GLACIERES', '67000 STRASBOURG'])}
+      ${await genOwner(['6 RUE DU DOLMEN', '79400 NANTEUIL'])}                           | ${await genOwner(['10 RUE DU RONCEY', '78920 ECQUEVILLY'])}
+      ${await genOwner(['PAR MR OLIVIER', '0067 RUE DES CHARRETIERS', '45000 ORLEANS'])} | ${await genOwner(['600 R PIERRE BROSSOLETTE LABUISS', '62700 BRUAY LA BUISSIERE'])}
+      ${await genOwner(['3 ALL DE LA BEAUCE', '78640 ST GERMAIN DE LA GRANGE'])}         | ${await genOwner(['0001 PL  DE L ECOLE', '95400 VILLIERS LE BEL'])}
+      ${await genOwner(['PAR M CLAUDE', '0125 RUE SAINT CHARLES', '75015 PARIS'])}       | ${await genOwner(['0005 RUE DU COLONEL TIFFOINET', '51200 EPERNAY'])}
+      ${await genOwner(['PAR MR JEAN', 'RUE DES LANDES', '72110 BEAUFAY'])}              | ${await genOwner(['0602 RTE DES LANDES', '72110 BEAUFAY'])}
+      ${await genOwner(['4 RUE ADRIEN SIMONNOT', '21700 COMBLANCHIEN'])}                 | ${await genOwner(['PAR M INCONNU', 'LES COMBES', '71170 SAINT-IGNY-DE-ROCHE'])}
     `('should not match $a.rawAddress with $b.rawAddress', async ({ a, b }) => {
       const actual = compare(a, b);
       expect(actual).toBeLessThan(MATCH_THRESHOLD);
@@ -78,20 +79,21 @@ describe('Duplicates', () => {
   });
 
   describe('needsManualReview', () => {
-    it('should need review if every duplicate needs a review', () => {
-      const source = genOwnerApi();
+    it('should need review if every duplicate needs a review', async () => {
+      const geoCode = '67268';
+      const source = await genOwnerApi(geoCode);
       const duplicates: ScoredOwner[] = [
         {
           score: REVIEW_THRESHOLD,
           value: {
-            ...genOwnerApi(),
+            ...await genOwnerApi(geoCode),
             birthDate: undefined
           }
         },
         {
           score: REVIEW_THRESHOLD,
           value: {
-            ...genOwnerApi(),
+            ...await genOwnerApi(geoCode),
             birthDate: undefined
           }
         }
@@ -103,21 +105,22 @@ describe('Duplicates', () => {
     });
 
     it('should need review if some matches have a different birth date', async () => {
+      const geoCode = '67268';
       const source: OwnerApi = {
-        ...genOwnerApi(),
+        ...await genOwnerApi(geoCode),
         birthDate: new Date('2000-01-01').toJSON()
       };
       const duplicates: ScoredOwner[] = [
         {
           score: MATCH_THRESHOLD,
           value: {
-            ...genOwnerApi(),
+            ...await genOwnerApi(geoCode),
             birthDate: new Date('1999-02-03').toJSON()
           }
         },
         {
           score: MATCH_THRESHOLD,
-          value: { ...genOwnerApi(), birthDate: undefined }
+          value: { ...await genOwnerApi(geoCode), birthDate: undefined }
         }
       ];
 
@@ -126,16 +129,17 @@ describe('Duplicates', () => {
       expect(actual).toBeTrue();
     });
 
-    it('should need review if there is a perfect match and it has a different birth date', () => {
+    it('should need review if there is a perfect match and it has a different birth date', async () => {
+      const geoCode = '67268';
       const source: OwnerApi = {
-        ...genOwnerApi(),
+        ...await genOwnerApi(geoCode),
         birthDate: new Date('2000-01-01').toJSON()
       };
       const duplicates: ScoredOwner[] = [
         {
           score: 1,
           value: {
-            ...genOwnerApi(),
+            ...await genOwnerApi(geoCode),
             birthDate: new Date('1999-01-01').toJSON()
           }
         }
@@ -146,19 +150,20 @@ describe('Duplicates', () => {
       expect(actual).toBeTrue();
     });
 
-    it('should not need review if at most one birth date is filled', () => {
-      const source: OwnerApi = { ...genOwnerApi(), birthDate: undefined };
+    it('should not need review if at most one birth date is filled', async () => {
+      const geoCode = '67268';
+      const source: OwnerApi = { ...await genOwnerApi(geoCode), birthDate: undefined };
       const duplicates: ScoredOwner[] = [
         {
           score: MATCH_THRESHOLD,
           value: {
-            ...genOwnerApi(),
+            ...await genOwnerApi(geoCode),
             birthDate: new Date('2000-01-01').toJSON()
           }
         },
         {
           score: MATCH_THRESHOLD,
-          value: { ...genOwnerApi(), birthDate: undefined }
+          value: { ...await genOwnerApi(geoCode), birthDate: undefined }
         }
       ];
 


### PR DESCRIPTION
TODO:
- L'API geo pour les codes INSEE a un comportement étrange avec de nombreux appels. La mécanique de cache et de délais entre chaque requête ne semble pas suffisant pour un grand volume de logements générés
- L'API geo ne reconnaît pas certains codes INSEE ce qui oblige à multiplier les appels avec d'autres. Exemple : https://geo.api.gouv.fr/communes?code=50750. Revoir le code pour retirer ces codes problématiques de la liste afin d'éviter de nouvelles tentatives.