### PR TITLE
Reduce build size

### DIFF
--- a/frontend/craco.config.js
+++ b/frontend/craco.config.js
@@ -6,8 +6,15 @@ module.exports = {
       // See https://github.com/alex3165/react-mapbox-gl/issues/931
       // See https://github.com/mapbox/mapbox-gl-js/issues/10565
       // eslint-disable-next-line import/no-webpack-loader-syntax
-      ignore: ['./node_modules/maplibre-gl/dist/maplibre-gl.js'],
-    },
+      ignore: ['./node_modules/maplibre-gl/dist/maplibre-gl.js']
+    }
+  },
+  typescript: {
+    // Disable type checking by react-scripts because it takes tsconfig.json
+    // blindlessly, and compiles tests and mocks, although it should not.
+    // Instead, we manually compile with tsconfig.build.json,
+    // as we would do using vite.
+    enableTypeChecking: false
   },
   jest: {
     configure(config) {
@@ -15,14 +22,14 @@ module.exports = {
       config.setupFiles = ['<rootDir>/jest.polyfills.js'];
       config.setupFilesAfterEnv = [
         'jest-extended/all',
-        '<rootDir>/src/setupTests.ts',
+        '<rootDir>/src/setupTests.ts'
       ];
       config.testTimeout = 30_000;
       config.transformIgnorePatterns = [
         '<rootDir>/node_modules/(?!@codegouvfr)/.+\\.js$',
-        '<rootDir>/node_modules/.store/(?!@codegouvfr)/.+\\.js$',
+        '<rootDir>/node_modules/.store/(?!@codegouvfr)/.+\\.js$'
       ];
       return config;
-    },
-  },
+    }
+  }
 };

--- a/frontend/craco.config.js
+++ b/frontend/craco.config.js
@@ -29,6 +29,8 @@ module.exports = {
         '<rootDir>/node_modules/(?!@codegouvfr)/.+\\.js$',
         '<rootDir>/node_modules/.store/(?!@codegouvfr)/.+\\.js$'
       ];
+      config.moduleNameMapper['^@zerologementvacant/models/fixtures$'] =
+        '<rootDir>/node_modules/@zerologementvacant/models/dist/test/fixtures.js';
       return config;
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -93,6 +93,7 @@
     "jest-fetch-mock": "^3.0.3",
     "jest-watch-typeahead": "^2.2.2",
     "randomstring": "^1.3.0",
+    "react-dev-utils": "^12.0.1",
     "rimraf": "^5.0.10",
     "sass": "^1.79.4",
     "typescript": "^5.6.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "clean": "rimraf build",
     "icons": "only-include-used-icons",
-    "build": "yarn clean && yarn icons && DISABLE_ESLINT_PLUGIN=true craco build",
+    "build": "yarn clean && yarn icons && tsc -b tsconfig.build.json && DISABLE_ESLINT_PLUGIN=true craco build",
     "dev": "yarn icons && DISABLE_ESLINT_PLUGIN=true craco start",
     "test": "DISABLE_ESLINT_PLUGIN=true craco test",
     "postinstall": "copy-dsfr-to-public"

--- a/frontend/src/components/GroupHeader/GroupHeader.test.tsx
+++ b/frontend/src/components/GroupHeader/GroupHeader.test.tsx
@@ -5,7 +5,8 @@ import { http, HttpResponse } from 'msw';
 import { Provider } from 'react-redux';
 import { MemoryRouter as Router } from 'react-router-dom';
 
-import { genGroupDTO, genUserDTO, GroupDTO } from '@zerologementvacant/models';
+import { GroupDTO } from '@zerologementvacant/models';
+import { genGroupDTO, genUserDTO } from '@zerologementvacant/models/fixtures';
 import GroupHeader, { DISPLAY_GROUPS } from './GroupHeader';
 import configureTestStore from '../../utils/test/storeUtils';
 import { mockAPI } from '../../mocks/mock-api';

--- a/frontend/src/mocks/handlers/data.ts
+++ b/frontend/src/mocks/handlers/data.ts
@@ -7,6 +7,13 @@ import {
   DatafoncierHousing,
   DraftDTO,
   EventDTO,
+  GroupDTO,
+  HousingDTO,
+  NoteDTO,
+  OwnerDTO,
+  UserDTO
+} from '@zerologementvacant/models';
+import {
   genCampaignDTO,
   genDatafoncierHousingDTO,
   genDraftDTO,
@@ -14,13 +21,8 @@ import {
   genHousingDTO,
   genOwnerDTO,
   genSenderDTO,
-  genUserDTO,
-  GroupDTO,
-  HousingDTO,
-  NoteDTO,
-  OwnerDTO,
-  UserDTO
-} from '@zerologementvacant/models';
+  genUserDTO
+} from '@zerologementvacant/models/fixtures';
 
 const campaigns: CampaignDTO[] = Array.from({ length: 10 }, genCampaignDTO);
 

--- a/frontend/src/mocks/handlers/group-handlers.ts
+++ b/frontend/src/mocks/handlers/group-handlers.ts
@@ -2,11 +2,9 @@ import { faker } from '@faker-js/faker';
 import { http, HttpResponse, RequestHandler } from 'msw';
 import { constants } from 'node:http2';
 
-import {
-  genGroupDTO,
-  GroupDTO,
-  GroupPayloadDTO
-} from '@zerologementvacant/models';
+import { GroupDTO, GroupPayloadDTO } from '@zerologementvacant/models';
+import { genGroupDTO } from '@zerologementvacant/models/fixtures';
+
 import config from '../../utils/config';
 import data from './data';
 

--- a/frontend/src/views/Campaign/test/CampaignView.test.tsx
+++ b/frontend/src/views/Campaign/test/CampaignView.test.tsx
@@ -11,15 +11,18 @@ import Notification from '../../../components/Notification/Notification';
 import {
   CampaignDTO,
   DraftDTO,
-  genCampaignDTO,
-  genDraftDTO,
-  genHousingDTO,
-  genOwnerDTO,
-  genSenderDTO,
   HousingDTO,
   OwnerDTO,
   SenderDTO
 } from '@zerologementvacant/models';
+import {
+  genCampaignDTO,
+  genDraftDTO,
+  genHousingDTO,
+  genOwnerDTO,
+  genSenderDTO
+} from '@zerologementvacant/models/fixtures';
+
 import data from '../../../mocks/handlers/data';
 import { sources } from '../../../../test/event-source-mock';
 import config from '../../../utils/config';
@@ -96,7 +99,9 @@ describe('Campaign view', () => {
 
     renderComponent();
 
-    const rename = await screen.findByRole('button', { name: /^Modifier le nom/ });
+    const rename = await screen.findByRole('button', {
+      name: /^Modifier le nom/
+    });
     await user.click(rename);
     const modal = await screen.findByRole('dialog');
     const input = within(modal).getByRole('textbox', {

--- a/frontend/src/views/Group/GroupView.test.tsx
+++ b/frontend/src/views/Group/GroupView.test.tsx
@@ -5,12 +5,13 @@ import userEvent from '@testing-library/user-event';
 import { Provider } from 'react-redux';
 import { MemoryRouter as Router, Route } from 'react-router-dom';
 
+import { GroupDTO } from '@zerologementvacant/models';
 import {
   genCampaignDTO,
   genGroupDTO,
-  genUserDTO,
-  GroupDTO
-} from '@zerologementvacant/models';
+  genUserDTO
+} from '@zerologementvacant/models/fixtures';
+
 import data from '../../mocks/handlers/data';
 import configureTestStore from '../../utils/test/storeUtils';
 import GroupView from './GroupView';

--- a/frontend/src/views/Housing/test/HousingView.test.tsx
+++ b/frontend/src/views/Housing/test/HousingView.test.tsx
@@ -5,13 +5,15 @@ import { Provider } from 'react-redux';
 import { MemoryRouter as Router, Route } from 'react-router-dom';
 
 import {
-  genHousingDTO,
-  genHousingOwnerDTO,
-  genOwnerDTO,
   HousingDTO,
   HousingOwnerDTO,
   OwnerDTO
 } from '@zerologementvacant/models';
+import {
+  genHousingDTO,
+  genHousingOwnerDTO,
+  genOwnerDTO
+} from '@zerologementvacant/models/fixtures';
 import configureTestStore from '../../../utils/test/storeUtils';
 import HousingView from '../HousingView';
 import data from '../../../mocks/handlers/data';

--- a/frontend/src/views/HousingList/HousingListView.test.tsx
+++ b/frontend/src/views/HousingList/HousingListView.test.tsx
@@ -7,12 +7,13 @@ import * as randomstring from 'randomstring';
 import { Provider } from 'react-redux';
 import { MemoryRouter as Router, Route } from 'react-router-dom';
 
+import { HousingKind } from '@zerologementvacant/models';
 import {
   genDatafoncierHousingDTO,
   genGroupDTO,
-  genUserDTO,
-  HousingKind
-} from '@zerologementvacant/models';
+  genUserDTO
+} from '@zerologementvacant/models/fixtures';
+
 import HousingListView from './HousingListView';
 import config from '../../utils/config';
 import configureTestStore from '../../utils/test/storeUtils';

--- a/frontend/src/views/Login/LoginView.test.tsx
+++ b/frontend/src/views/Login/LoginView.test.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { Provider } from 'react-redux';
 import { MemoryRouter as Router, Route } from 'react-router-dom';
 
-import { genUserDTO } from '@zerologementvacant/models';
+import { genUserDTO } from '@zerologementvacant/models/fixtures';
 import { store } from '../../store/store';
 import LoginView from './LoginView';
 import data from '../../mocks/handlers/data';

--- a/frontend/test/fixtures.test.ts
+++ b/frontend/test/fixtures.test.ts
@@ -11,11 +11,9 @@ import { Prospect } from '../src/models/Prospect';
 import { LocalityKinds } from '../src/models/Locality';
 import { Group } from '../src/models/Group';
 import { DatafoncierHousing } from '../../shared';
-import {
-  AddressKinds,
-  genAddressDTO,
-  HousingStatus
-} from '@zerologementvacant/models';
+import { AddressKinds, HousingStatus } from '@zerologementvacant/models';
+import { genAddressDTO } from '@zerologementvacant/models/fixtures';
+
 import fp from 'lodash/fp';
 
 export const genBoolean = () => Math.random() < 0.5;

--- a/frontend/tsconfig.build.json
+++ b/frontend/tsconfig.build.json
@@ -1,5 +1,10 @@
 {
   "extends": "./tsconfig.json",
+  "references": [
+    { "path": "../packages/models/tsconfig.build.json" },
+    { "path": "../packages/utils/tsconfig.build.json" },
+    { "path": "../queue/tsconfig.build.json" }
+  ],
   "exclude": [
     "node_modules",
     "build",

--- a/frontend/tsconfig.build.json
+++ b/frontend/tsconfig.build.json
@@ -1,7 +1,12 @@
 {
   "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "moduleResolution": "bundler"
-  },
-  "exclude": ["node_modules", "dist","src/**/*.test.ts", "src/**/*.test.tsx"]
+  "exclude": [
+    "node_modules",
+    "build",
+    "src/mocks/**/*.ts",
+    "src/setupTests.ts",
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "test/fixtures.test.ts"
+  ]
 }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,7 +1,4 @@
 {
   "extends": "@tsconfig/create-react-app/tsconfig.json",
-  "compilerOptions": {
-    "moduleResolution": "node"
-  },
   "include": ["src"]
 }

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -1,7 +1,17 @@
 {
   "name": "@zerologementvacant/models",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./fixtures": {
+      "import": "./dist/test/fixtures.js",
+      "require": "./dist/test/fixtures.js",
+      "types": "./dist/test/fixtures.d.ts"
+    }
+  },
   "scripts": {
     "clean": "rimraf dist tsconfig.build.tsbuildinfo",
     "build": "tsc -b tsconfig.build.json",
@@ -9,11 +19,11 @@
     "dev": "nodemon --watch src -e ts --exec 'yarn build'"
   },
   "dependencies": {
-    "@faker-js/faker": "^8.4.1",
     "@zerologementvacant/draft": "workspace:*",
     "lodash": "^4.17.21"
   },
   "devDependencies": {
+    "@faker-js/faker": "^8.4.1",
     "@tsconfig/node20": "^20.1.4",
     "@types/geojson": "^7946.0.14",
     "@types/jest": "^29.5.13",

--- a/packages/models/src/index.ts
+++ b/packages/models/src/index.ts
@@ -1,4 +1,3 @@
-export * from './test/fixtures';
 export * from './AddressDTO';
 export * from './BeneficiaryCount';
 export * from './BuildingPeriod';

--- a/packages/models/tsconfig.build.json
+++ b/packages/models/tsconfig.build.json
@@ -1,5 +1,10 @@
 {
   "extends": "./tsconfig.json",
   "references": [{ "path": "../draft/tsconfig.build.json" }],
-  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
+  "exclude": [
+    "node_modules",
+    "dist",
+    "src/**/*.test.ts",
+    "src/test/setup-tests.ts"
+  ]
 }

--- a/server/jest.config.ts
+++ b/server/jest.config.ts
@@ -11,11 +11,7 @@ const config: JestConfigWithTsJest = {
   rootDir: '.',
   roots: ['<rootDir>'],
   moduleDirectories: ['node_modules', '<rootDir>'],
-  moduleNameMapper: {
-    ...pathsToModuleNameMapper(tsconfig.compilerOptions.paths),
-    '^@zerologementvacant/models/fixtures$':
-      '<rootDir>/node_modules/@zerologementvacant/models/dist/test/fixtures.js'
-  },
+  moduleNameMapper: pathsToModuleNameMapper(tsconfig.compilerOptions.paths),
   modulePathIgnorePatterns: [
     '<rootDir>/dist/',
     '<rootDir>/node_modules/',

--- a/server/jest.config.ts
+++ b/server/jest.config.ts
@@ -11,7 +11,11 @@ const config: JestConfigWithTsJest = {
   rootDir: '.',
   roots: ['<rootDir>'],
   moduleDirectories: ['node_modules', '<rootDir>'],
-  moduleNameMapper: pathsToModuleNameMapper(tsconfig.compilerOptions.paths),
+  moduleNameMapper: {
+    ...pathsToModuleNameMapper(tsconfig.compilerOptions.paths),
+    '^@zerologementvacant/models/fixtures$':
+      '<rootDir>/node_modules/@zerologementvacant/models/dist/test/fixtures.js'
+  },
   modulePathIgnorePatterns: [
     '<rootDir>/dist/',
     '<rootDir>/node_modules/',

--- a/server/src/controllers/ownerController.test.ts
+++ b/server/src/controllers/ownerController.test.ts
@@ -6,11 +6,11 @@ import { v4 as uuidv4 } from 'uuid';
 import {
   AddressDTO,
   AddressKinds,
-  genHousingOwnerDTO,
   HousingOwnerPayloadDTO,
   OwnerDTO,
   OwnerPayloadDTO
 } from '@zerologementvacant/models';
+import { genHousingOwnerDTO } from '@zerologementvacant/models/fixtures';
 import { createServer } from '~/infra/server';
 import { tokenProvider } from '~/test/testUtils';
 import {

--- a/server/src/controllers/ownerController.test.ts
+++ b/server/src/controllers/ownerController.test.ts
@@ -10,7 +10,6 @@ import {
   OwnerDTO,
   OwnerPayloadDTO
 } from '@zerologementvacant/models';
-import { genHousingOwnerDTO } from '@zerologementvacant/models/fixtures';
 import { createServer } from '~/infra/server';
 import { tokenProvider } from '~/test/testUtils';
 import {
@@ -31,7 +30,7 @@ import {
   OwnerEventDBO,
   ownerEventsTable
 } from '~/repositories/eventRepository';
-import { OwnerApi, toOwnerDTO } from '~/models/OwnerApi';
+import { OwnerApi } from '~/models/OwnerApi';
 import db from '~/infra/database';
 import {
   banAddressesTable,
@@ -309,8 +308,11 @@ describe('Owner API', () => {
       rank: number
     ): HousingOwnerPayloadDTO {
       return {
-        ...genHousingOwnerDTO(toOwnerDTO(owner)),
-        rank
+        id: owner.id,
+        rank: rank,
+        locprop: null,
+        idprocpte: null,
+        idprodroit: null
       };
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9414,6 +9414,7 @@ __metadata:
     prop-types: "npm:^15.8.1"
     randomstring: "npm:^1.3.0"
     react: "npm:^18.3.1"
+    react-dev-utils: "npm:^12.0.1"
     react-dom: "npm:^18.3.1"
     react-map-gl: "npm:^7.1.7"
     react-redux: "npm:^8.1.3"


### PR DESCRIPTION
`@faker-js/faker` was included with all of its locales in the front production build, which made it 11 MB ungzipped and 7.69 MB gzipped, taking up to 5.13 MB (66.7 % of the whole bundle size).

<img width="1435" alt="Screenshot 2024-10-09 at 09 47 15" src="https://github.com/user-attachments/assets/269ac53d-b80e-4bad-873f-2cc35c080383">

_react-scripts_ was compiling using `tsconfig.json`, which included test files, the mock API for frontend tests, etc. Typescript compilation was removed and replaced by a manual step before `react-scripts build`, using `tsconfig.build.json`.

Also, `@zerologementvacant/models` was split between `@zerologementvacant/models` (shared types) and `@zerologementvacant/models/fixtures` (shared factories for DTO types, for test purposes).

The resulting production bundle does not include `@faker-js/faker` from the build, as intended, which reduces its size down to 2.55 MB ungzipped, 530 KB gzipped.

<img width="1438" alt="Screenshot 2024-10-09 at 09 47 28" src="https://github.com/user-attachments/assets/b264e489-ab15-4260-8c9a-d603dc39386a">