### PR TITLE
fix: Filter mimetype for logos on server side

### DIFF
--- a/frontend/src/components/FileUpload/FileUpload.tsx
+++ b/frontend/src/components/FileUpload/FileUpload.tsx
@@ -6,7 +6,7 @@ import { useUploadFileMutation } from '../../services/file.service';
 import { useNotification } from '../../hooks/useNotification';
 import { FileUploadDTO } from '@zerologementvacant/models';
 
-const DEFAULT_TYPES = ['pdf', 'jpg', 'png'];
+const DEFAULT_TYPES = ['pdf', 'jpg', 'png', 'gif'];
 const MAX_SIZE = 5; // Mo
 
 interface Props {
@@ -43,7 +43,7 @@ function FileUpload(props: Readonly<Props>) {
         .unwrap()
         .then((fileUpload) => {
           props.onUpload?.(fileUpload);
-        });
+        }).catch(() => {});
     }
   }
 

--- a/frontend/src/components/FileUpload/FileUpload.tsx
+++ b/frontend/src/components/FileUpload/FileUpload.tsx
@@ -6,7 +6,7 @@ import { useUploadFileMutation } from '../../services/file.service';
 import { useNotification } from '../../hooks/useNotification';
 import { FileUploadDTO } from '@zerologementvacant/models';
 
-const DEFAULT_TYPES = ['pdf', 'jpg', 'png', 'gif'];
+const DEFAULT_TYPES = ['pdf', 'jpg', 'png'];
 const MAX_SIZE = 5; // Mo
 
 interface Props {

--- a/server/src/middlewares/upload.ts
+++ b/server/src/middlewares/upload.ts
@@ -5,8 +5,16 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { createS3 } from '@zerologementvacant/utils';
 import config from '~/infra/config';
+import BadRequestError from '~/errors/badRequestError';
 
 export function upload() {
+
+  const ALLOWED_MIMES = [
+    'image/png',
+    'image/jpeg',
+    'application/pdf',
+  ];
+
   const upload = multer({
     limits: {
       files: 1,
@@ -17,7 +25,9 @@ export function upload() {
       file: Express.Multer.File,
       callback: multer.FileFilterCallback,
     ) {
-      // TODO: check file.mimetype
+      if (!ALLOWED_MIMES.includes(file.mimetype)) {
+        return callback(new BadRequestError());
+      }
       return callback(null, true);
     },
     storage: multerS3({


### PR DESCRIPTION
Renvoi une 400 quand le format n'est pas autorisé, une alerte est affichée sur le front. Nécessaire pour les anciens navigateurs qui ne supportent pas l'attribut `accept` d'une `input` de type `file`.

![image](https://github.com/user-attachments/assets/5385bc3e-0b8a-441c-967d-100b62da3e12)
