### PR TITLE
Fix owner kind values and labels

### DIFF
--- a/frontend/src/models/HousingFilters.tsx
+++ b/frontend/src/models/HousingFilters.tsx
@@ -12,6 +12,7 @@ import {
   LocalityKind,
   Occupancy,
   OCCUPANCY_VALUES,
+  OWNER_KIND_LABELS,
   OWNER_KIND_VALUES,
   OwnerAge,
   OwnerKind,
@@ -66,9 +67,9 @@ export const noCampaignOption: SelectOption = {
 export type NoCampaign = typeof noCampaignOption.value;
 
 export const ownerKindOptions: SelectOption<OwnerKind>[] =
-  OWNER_KIND_VALUES.map((kind) => ({
-    value: kind,
-    label: kind
+  OWNER_KIND_VALUES.map((value) => ({
+    value: value,
+    label: OWNER_KIND_LABELS[value]
   }));
 
 export const campaignsCountOptions: SelectOption<CampaignCount>[] = [

--- a/packages/models/src/OwnerKind.ts
+++ b/packages/models/src/OwnerKind.ts
@@ -1,11 +1,21 @@
 export const OWNER_KIND_VALUES = [
-  'Particulier',
-  'SCI, Copropriété, Autres personnes morales',
-  'Promoteur, Investisseur privé',
-  'Etat et collectivité territoriale',
-  'Bailleur social, Aménageur, Investisseur public',
-  'Autres',
-  'Absence de propriétaire'
+  'particulier',
+  'sci-copro',
+  'promoteur',
+  'etat-collectivite',
+  'bailleur-social',
+  'autres',
+  'absent'
 ] as const;
 
 export type OwnerKind = (typeof OWNER_KIND_VALUES)[number];
+
+export const OWNER_KIND_LABELS: Record<OwnerKind, string> = {
+  particulier: 'Particulier',
+  'sci-copro': 'SCI, Copropriété, Autres personnes morales',
+  promoteur: 'Promoteur, Investisseur privé',
+  'etat-collectivite': 'Etat et collectivité territoriale',
+  'bailleur-social': 'Bailleur social, Aménageur, Investisseur public',
+  autres: 'Autres',
+  absent: 'Absence de propriétaire'
+};

--- a/packages/models/src/test/fixtures.ts
+++ b/packages/models/src/test/fixtures.ts
@@ -22,6 +22,7 @@ import { ProspectDTO } from '../ProspectDTO';
 import { EstablishmentDTO } from '../EstablishmentDTO';
 import { ESTABLISHMENT_KIND_VALUES } from '../EstablishmentKind';
 import { ESTABLISHMENT_SOURCE_VALUES } from '../EstablishmentSource';
+import { OWNER_KIND_LABELS } from '../OwnerKind';
 
 export function genGeoCode(): string {
   const geoCode = faker.helpers.arrayElement([
@@ -342,7 +343,7 @@ export function genOwnerDTO(): OwnerDTO {
       lastName
     }),
     phone: faker.phone.number(),
-    kind: 'PERSONNE PHYSIQUE'
+    kind: faker.helpers.arrayElement(Object.values(OWNER_KIND_LABELS))
   });
 }
 

--- a/server/src/models/HousingFiltersApi.ts
+++ b/server/src/models/HousingFiltersApi.ts
@@ -1,6 +1,7 @@
 import {
   HousingFiltersDTO,
   Occupancy,
+  OwnerKind,
   OwnershipKind
 } from '@zerologementvacant/models';
 import { EnergyConsumptionGradesApi } from './HousingApi';
@@ -12,7 +13,7 @@ export interface HousingFiltersApi
   housingIds?: string[];
   establishmentIds?: string[];
   groupIds?: string[];
-  ownerKinds?: string[];
+  ownerKinds?: OwnerKind[];
   ownerAges?: string[];
   multiOwners?: string[];
   /**

--- a/server/src/repositories/housingRepository.ts
+++ b/server/src/repositories/housingRepository.ts
@@ -12,6 +12,7 @@ import {
   INTERNAL_CO_CONDOMINIUM_VALUES,
   INTERNAL_MONO_CONDOMINIUM_VALUES,
   Occupancy,
+  OWNER_KIND_LABELS,
   PaginationOptions
 } from '@zerologementvacant/models';
 import db, { toRawArray, where } from '~/infra/database';
@@ -136,7 +137,11 @@ async function count(filters: HousingFiltersApi): Promise<HousingCountApi> {
 
   const [allowedGeoCodes, intercommunalities] = await Promise.all([
     fetchGeoCodes(filters.establishmentIds ?? []),
-    fetchGeoCodes(Array.isArray(filters.intercommunalities) ? filters.intercommunalities : [])
+    fetchGeoCodes(
+      Array.isArray(filters.intercommunalities)
+        ? filters.intercommunalities
+        : []
+    )
   ]);
   const localities = filters.localities ?? [];
   const geoCodes = Set(allowedGeoCodes)
@@ -480,7 +485,10 @@ function filteredQuery(opts: FilteredQueryOptions) {
       queryBuilder.whereIn(`${ownerTable}.id`, filters.ownerIds);
     }
     if (filters.ownerKinds?.length) {
-      queryBuilder.whereIn(`${ownerTable}.kind_class`, filters.ownerKinds);
+      const ownerKinds = filters.ownerKinds.map(
+        (kind) => OWNER_KIND_LABELS[kind]
+      );
+      queryBuilder.whereIn(`${ownerTable}.kind_class`, ownerKinds);
     }
     if (filters.ownerAges?.length) {
       queryBuilder.where((whereBuilder) => {

--- a/server/src/repositories/test/housingRepository.test.ts
+++ b/server/src/repositories/test/housingRepository.test.ts
@@ -68,6 +68,8 @@ import {
   isSecondaryOwner,
   Occupancy,
   OCCUPANCY_VALUES,
+  OWNER_KIND_LABELS,
+  OWNER_KIND_VALUES,
   OwnershipKind,
   ROOM_COUNT_VALUES
 } from '@zerologementvacant/models';
@@ -528,16 +530,18 @@ describe('Housing repository', () => {
       });
 
       describe('by owner kind', () => {
-        const kinds = ['Particulier', 'Investisseur', 'SCI'];
+        const kinds = OWNER_KIND_VALUES;
 
         beforeEach(async () => {
           const housings = Array.from({ length: kinds.length }, () =>
             genHousingApi()
           );
           await Housing().insert(housings.map(formatHousingRecordApi));
-          const owners: OwnerApi[] = kinds.map((kind, i) => {
-            return { ...housings[i].owner, kind };
-          });
+          const owners: OwnerApi[] = Object.values(OWNER_KIND_LABELS).map(
+            (kind, i) => {
+              return { ...housings[i].owner, kind };
+            }
+          );
           await Owners().insert(owners.map(formatOwnerApi));
           await HousingOwners().insert(
             housings.flatMap((housing) =>
@@ -553,8 +557,9 @@ describe('Housing repository', () => {
             }
           });
 
+          expect(actual.length).toBeGreaterThan(0);
           expect(actual).toSatisfyAll<HousingApi>((housing) => {
-            return housing.owner?.kind === kind;
+            return housing.owner?.kind === OWNER_KIND_LABELS[kind];
           });
         });
       });

--- a/server/src/test/testFixtures.ts
+++ b/server/src/test/testFixtures.ts
@@ -68,6 +68,7 @@ import {
   INTERNAL_MONO_CONDOMINIUM_VALUES,
   Occupancy,
   OCCUPANCY_VALUES,
+  OWNER_KIND_LABELS,
   UserAccountDTO
 } from '@zerologementvacant/models';
 
@@ -206,16 +207,7 @@ export const genOwnerApi = (): OwnerApi => {
     email: genEmail(),
     phone: faker.phone.number(),
     kind: faker.helpers.maybe(
-      () =>
-        faker.helpers.arrayElement([
-          'Particulier',
-          'Investisseur',
-          'Promoteur, Investisseur privé',
-          'SCI',
-          'SCI, Copropriété, Autres personnes morales',
-          'Autres',
-          'Etat et collectivité territoriale'
-        ]),
+      () => faker.helpers.arrayElement(Object.values(OWNER_KIND_LABELS)),
       { probability: 0.8 }
     ),
     kindDetail: randomstring.generate(),


### PR DESCRIPTION
When filtering housings by owner kind, some labels were refused by the API because they contained a comma, although they were a single option, for instance:
```
GET /housing?ownerKind=SCI, Copropriété, Autres personnes morales
```

This has been replaced by a value which is translated by the API, hence the HTTP call becomes:
```
GET /housing?ownerKind=sci-copro
```