### PR TITLE
Increase the analysis iframe’s height to avoid scrolling

### DIFF
--- a/frontend/src/views/Analysis/AnalysisView.tsx
+++ b/frontend/src/views/Analysis/AnalysisView.tsx
@@ -11,7 +11,7 @@ function AnalysisView() {
 
   return (
     <MainContainer>
-      <iframe src={dashboard?.url} width="100%" height={600} title="Analyses" />
+      <iframe src={dashboard?.url} width="100%" height="850" title="Analyses" />
     </MainContainer>
   );
 }


### PR DESCRIPTION
No more scroll

<img width="1289" alt="Screenshot 2025-01-08 at 14 56 59" src="https://github.com/user-attachments/assets/857bc121-5c57-417b-85c4-4edc3d8371f6" />