### PR TITLE
Rework housing update side menu

### DIFF
--- a/frontend/src/components/Aside/AsideNext.tsx
+++ b/frontend/src/components/Aside/AsideNext.tsx
@@ -43,7 +43,9 @@ function Aside(props: AsideProps) {
           </Grid>
         </Grid>
 
-        <Grid xs>{props.main}</Grid>
+        <Grid sx={{ overflowY: 'auto' }} xs>
+          {props.main}
+        </Grid>
 
         <Grid className={fr.cx('fr-mt-3w', 'fr-mb-1w')}>
           <hr style={{ margin: `0 -${fr.spacing('3w')}` }} />

--- a/frontend/src/components/Aside/AsideNext.tsx
+++ b/frontend/src/components/Aside/AsideNext.tsx
@@ -1,4 +1,6 @@
+import { fr } from '@codegouvfr/react-dsfr';
 import Button from '@codegouvfr/react-dsfr/Button';
+import ButtonsGroup from '@codegouvfr/react-dsfr/ButtonsGroup';
 import Drawer, { DrawerProps } from '@mui/material/Drawer';
 import Grid from '@mui/material/Unstable_Grid2';
 import { ReactNode } from 'react';
@@ -10,6 +12,7 @@ interface AsideProps {
   footer?: ReactNode;
   open: boolean;
   onClose(): void;
+  onSave(): void;
 }
 
 function Aside(props: AsideProps) {
@@ -20,7 +23,7 @@ function Aside(props: AsideProps) {
       onClose={props.onClose}
       {...props.drawerProps}
     >
-      <Grid container sx={{ flexDirection: 'column' }}>
+      <Grid container sx={{ flexDirection: 'column' }} xs>
         <Grid container sx={{ justifyContent: 'space-between', mb: 3 }}>
           {props.header && <Grid xs>{props.header}</Grid>}
 
@@ -35,10 +38,27 @@ function Aside(props: AsideProps) {
           </Grid>
         </Grid>
 
-        {props.main}
+        <Grid xs>{props.main}</Grid>
 
-        <Grid>
-          {props.footer ?? <Button priority="secondary">Annuler</Button>}
+        <Grid className={fr.cx('fr-mt-3w', 'fr-mb-1w')}>
+          <hr style={{ margin: `0 -${fr.spacing('3w')}` }} />
+          {props.footer ?? (
+            <ButtonsGroup
+              buttons={[
+                {
+                  priority: 'secondary',
+                  children: 'Annuler',
+                  onClick: props.onClose
+                },
+                {
+                  priority: 'primary',
+                  children: 'Enregistrer',
+                  onClick: props.onSave
+                }
+              ]}
+              inlineLayoutWhen="always"
+            />
+          )}
         </Grid>
       </Grid>
     </Drawer>

--- a/frontend/src/components/Aside/AsideNext.tsx
+++ b/frontend/src/components/Aside/AsideNext.tsx
@@ -21,6 +21,11 @@ function Aside(props: AsideProps) {
       anchor="right"
       open={props.open}
       onClose={props.onClose}
+      slotProps={{
+        backdrop: {
+          invisible: true
+        }
+      }}
       {...props.drawerProps}
     >
       <Grid container sx={{ flexDirection: 'column' }} xs>

--- a/frontend/src/components/Aside/AsideNext.tsx
+++ b/frontend/src/components/Aside/AsideNext.tsx
@@ -1,0 +1,48 @@
+import Button from '@codegouvfr/react-dsfr/Button';
+import Drawer, { DrawerProps } from '@mui/material/Drawer';
+import Grid from '@mui/material/Unstable_Grid2';
+import { ReactNode } from 'react';
+
+interface AsideProps {
+  drawerProps?: Omit<DrawerProps, 'open' | 'onClose'>;
+  header?: ReactNode;
+  main?: ReactNode;
+  footer?: ReactNode;
+  open: boolean;
+  onClose(): void;
+}
+
+function Aside(props: AsideProps) {
+  return (
+    <Drawer
+      anchor="right"
+      open={props.open}
+      onClose={props.onClose}
+      {...props.drawerProps}
+    >
+      <Grid container sx={{ flexDirection: 'column' }}>
+        <Grid container sx={{ justifyContent: 'space-between', mb: 3 }}>
+          {props.header && <Grid xs>{props.header}</Grid>}
+
+          <Grid xs="auto">
+            <Button
+              iconId="fr-icon-close-line"
+              priority="tertiary no outline"
+              onClick={props.onClose}
+            >
+              Fermer
+            </Button>
+          </Grid>
+        </Grid>
+
+        {props.main}
+
+        <Grid>
+          {props.footer ?? <Button priority="secondary">Annuler</Button>}
+        </Grid>
+      </Grid>
+    </Drawer>
+  );
+}
+
+export default Aside;

--- a/frontend/src/components/HousingDetails/HousingDetailsCard.tsx
+++ b/frontend/src/components/HousingDetails/HousingDetailsCard.tsx
@@ -8,20 +8,17 @@ import classNames from 'classnames';
 import { useState } from 'react';
 
 import styles from './housing-details-card.module.scss';
-import { Housing, HousingUpdate } from '../../models/Housing';
+import { Housing } from '../../models/Housing';
 import HousingDetailsSubCardBuilding from './HousingDetailsSubCardBuilding';
 import HousingDetailsSubCardProperties from './HousingDetailsSubCardProperties';
 import HousingDetailsSubCardLocation from './HousingDetailsSubCardLocation';
 import EventsHistory from '../EventsHistory/EventsHistory';
 import { Event } from '../../models/Event';
 import HousingEditionSideMenu from '../HousingEdition/HousingEditionSideMenu';
-import { useFindNotesByHousingQuery } from '../../services/note.service';
-import { useFindEventsByHousingQuery } from '../../services/event.service';
 import { Note } from '../../models/Note';
 import HousingDetailsCardOccupancy from './HousingDetailsSubCardOccupancy';
 import HousingDetailsCardMobilisation from './HousingDetailsSubCardMobilisation';
 import { Campaign } from '../../models/Campaign';
-import { useUpdateHousingMutation } from '../../services/housing.service';
 import AppLink from '../_app/AppLink/AppLink';
 import { useUser } from '../../hooks/useUser';
 
@@ -39,31 +36,8 @@ function HousingDetailsCard({
   housingCampaigns
 }: Props) {
   const { isVisitor } = useUser();
-  const [updateHousing] = useUpdateHousingMutation();
-
   const [isHousingListEditionExpand, setIsHousingListEditionExpand] =
     useState(false);
-
-  const { refetch: refetchHousingEvents } = useFindEventsByHousingQuery(
-    housing.id
-  );
-  const { refetch: refetchHousingNotes } = useFindNotesByHousingQuery(
-    housing.id
-  );
-
-  const submitHousingUpdate = async (
-    housing: Housing,
-    housingUpdate: HousingUpdate
-  ) => {
-    await updateHousing({
-      housing,
-      housingUpdate
-    });
-    await refetchHousingEvents();
-    await refetchHousingNotes();
-
-    setIsHousingListEditionExpand(false);
-  };
 
   return (
     <Paper component="article" elevation={0} sx={{ padding: 3 }}>
@@ -100,7 +74,6 @@ function HousingDetailsCard({
               <HousingEditionSideMenu
                 housing={housing}
                 expand={isHousingListEditionExpand}
-                onSubmit={submitHousingUpdate}
                 onClose={() => setIsHousingListEditionExpand(false)}
               />
             </>
@@ -111,21 +84,24 @@ function HousingDetailsCard({
         <>
           <HousingDetailsCardOccupancy
             housing={housing}
-            lastOccupancyEvent={housing.source !== 'datafoncier-import' ? housingEvents.find(
-              (event) =>
-                event.category === 'Followup' &&
-                event.kind === 'Update' &&
-                event.section === 'Situation' &&
-                event.name === "Modification du statut d'occupation" &&
-                event.old.occupancy !== event.new.occupancy
-              ) :
-              housingEvents.find(
-              (event) =>
-                event.category === 'Group' &&
-                event.kind === 'Create' &&
-                event.section === 'Ajout d’un logement dans un groupe' &&
-                event.name === "Ajout dans un groupe"
-            )}
+            lastOccupancyEvent={
+              housing.source !== 'datafoncier-import'
+                ? housingEvents.find(
+                    (event) =>
+                      event.category === 'Followup' &&
+                      event.kind === 'Update' &&
+                      event.section === 'Situation' &&
+                      event.name === "Modification du statut d'occupation" &&
+                      event.old.occupancy !== event.new.occupancy
+                  )
+                : housingEvents.find(
+                    (event) =>
+                      event.category === 'Group' &&
+                      event.kind === 'Create' &&
+                      event.section === 'Ajout d’un logement dans un groupe' &&
+                      event.name === 'Ajout dans un groupe'
+                  )
+            }
           />
           <HousingDetailsCardMobilisation
             housing={housing}

--- a/frontend/src/components/HousingDetails/HousingDetailsSubCardOccupancy.tsx
+++ b/frontend/src/components/HousingDetails/HousingDetailsSubCardOccupancy.tsx
@@ -3,6 +3,9 @@ import Badge from '@codegouvfr/react-dsfr/Badge';
 import Tag from '@codegouvfr/react-dsfr/Tag';
 import Typography from '@mui/material/Typography';
 import Grid from '@mui/material/Unstable_Grid2';
+import classNames from 'classnames';
+import { getYear } from 'date-fns';
+
 import {
   getOccupancy,
   getSource,
@@ -12,10 +15,8 @@ import {
 } from '../../models/Housing';
 import HousingDetailsSubCard from './HousingDetailsSubCard';
 import DPE from '../DPE/DPE';
-import classNames from 'classnames';
 import styles from './housing-details-card.module.scss';
 import { Event } from '../../models/Event';
-import { getYear } from 'date-fns';
 import LabelNext from '../Label/LabelNext';
 
 interface Props {
@@ -57,7 +58,7 @@ function HousingDetailsCardOccupancy({ housing, lastOccupancyEvent }: Props) {
             >
               Occupation :
             </Typography>
-            <Badge className="bg-975">
+            <Badge aria-label="Occupation" className="bg-975">
               {OccupancyKindLabels[getOccupancy(housing.occupancy)]}
             </Badge>
           </Grid>

--- a/frontend/src/components/HousingEdition/HousingEditionSideMenu.tsx
+++ b/frontend/src/components/HousingEdition/HousingEditionSideMenu.tsx
@@ -1,97 +1,120 @@
-import Button from '@codegouvfr/react-dsfr/Button';
-import { useRef } from 'react';
-
-import { Container, Text } from '../_dsfr';
-import { Housing, HousingUpdate } from '../../models/Housing';
-import Aside from '../Aside/Aside';
-import HousingEditionForm from './HousingEditionForm';
-import styles from './housing-edition.module.scss';
-import AppLink from '../_app/AppLink/AppLink';
-import Label from '../Label/Label';
+import Tabs, { TabsProps } from '@codegouvfr/react-dsfr/Tabs';
+import { yupResolver } from '@hookform/resolvers/yup';
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
+import { FormProvider, useForm } from 'react-hook-form';
+import { ElementOf } from 'ts-essentials';
+import * as yup from 'yup';
 
-interface Props {
+import { Occupancy, OCCUPANCY_VALUES } from '@zerologementvacant/models';
+import { Housing, HousingUpdate } from '../../models/Housing';
+import AppLink from '../_app/AppLink/AppLink';
+import AsideNext from '../Aside/AsideNext';
+import LabelNext from '../Label/LabelNext';
+import AppSelectNext from '../_app/AppSelect/AppSelectNext';
+import { allOccupancyOptions } from '../../models/HousingFilters';
+
+interface HousingEditionSideMenuProps {
   housing?: Housing;
   expand: boolean;
   onSubmit: (housing: Housing, housingUpdate: HousingUpdate) => void;
   onClose: () => void;
 }
 
-function HousingEditionSideMenu({ housing, expand, onSubmit, onClose }: Props) {
-  const statusFormRef = useRef<{ submit: () => void }>();
+const WIDTH = '700px';
 
-  const submit = (housingUpdate: HousingUpdate) => {
+const schema = yup.object({
+  occupancy: yup
+    .string()
+    .required('Veuillez renseigner l’occupation actuelle')
+    .oneOf(OCCUPANCY_VALUES),
+  occupancyIntented: yup
+    .string()
+    .required('Veuillez renseigner l’occupation prévisionnelle')
+    .oneOf(OCCUPANCY_VALUES)
+});
+
+function HousingEditionSideMenu(props: HousingEditionSideMenuProps) {
+  const form = useForm<yup.InferType<typeof schema>>({
+    values: {
+      occupancy: props.housing?.occupancy ?? Occupancy.UNKNOWN,
+      occupancyIntented: props.housing?.occupancyIntended ?? Occupancy.UNKNOWN
+    },
+    mode: 'onSubmit',
+    resolver: yupResolver(schema)
+  });
+
+  const { housing, expand, onSubmit, onClose } = props;
+
+  // TODO
+  function submit() {
     if (housing) {
-      onSubmit(housing, housingUpdate);
+      onSubmit(housing, form.getValues() as HousingUpdate);
     }
-  };
+  }
+
+  function OccupationTab(): ElementOf<TabsProps.Uncontrolled['tabs']> {
+    return {
+      content: (
+        <Stack rowGap={2}>
+          <AppSelectNext
+            label="Occupation actuelle"
+            multiple={false}
+            name="occupancy"
+            options={allOccupancyOptions}
+          />
+          <AppSelectNext
+            label="Occupation prévisionnelle"
+            multiple={false}
+            name="occupancyIntended"
+            options={allOccupancyOptions}
+          />
+        </Stack>
+      ),
+      isDefault: true,
+      label: 'Occupation'
+    };
+  }
 
   return (
-    <div className={styles.sideMenu}>
-      <Aside
-        expand={expand}
-        onClose={onClose}
-        title={
-          housing && (
-            <>
-              <Container as="header" className="d-flex" fluid spacing="pb-0">
-                <Typography component="h6" className="fr-mb-0 fr-pt-1w">
-                  {housing.rawAddress.join(' - ')}
-                </Typography>
-                <Button
-                  priority="tertiary no outline"
-                  iconId="ri-close-line"
-                  iconPosition="right"
-                  onClick={onClose}
-                >
-                  Fermer
-                </Button>
-              </Container>
-              <Container as="section" spacing="p-0 mb-3w">
-                <Text size="sm" spacing="m-0">
-                  <Label as="span">Identifiant fiscal national :</Label>
-                  {housing.localId}
-                </Text>
-                <AppLink
-                  to={'/logements/' + housing.id}
-                  isSimple
-                  target="_blank"
-                >
-                  Voir la fiche logement
-                </AppLink>
-              </Container>
-            </>
-          )
-        }
-        content={
-          housing && (
-            <Container as="section" spacing="p-0">
-              <HousingEditionForm
-                housing={housing}
-                onSubmit={submit}
-                ref={statusFormRef}
-              />
-            </Container>
-          )
-        }
-        footer={
-          <>
-            <Button
-              priority="secondary"
-              className="fr-mr-2w"
-              onClick={() => onClose()}
-            >
-              Annuler
-            </Button>
-            {
-              <Button onClick={() => statusFormRef.current?.submit()}>
-                Enregistrer
-              </Button>
-            }
-          </>
-        }
-      />
-    </div>
+    <FormProvider {...form}>
+      <form onSubmit={form.handleSubmit(submit)}>
+        <AsideNext
+          drawerProps={{
+            sx: (theme) => ({
+              zIndex: theme.zIndex.appBar + 1,
+              '& .MuiDrawer-paper': {
+                px: '1.5rem',
+                py: '2rem',
+                width: WIDTH
+              }
+            })
+          }}
+          header={
+            <Box component="header">
+              <Typography variant="h6">
+                {props.housing?.rawAddress.join(' - ')}
+              </Typography>
+              <LabelNext>
+                Identifiant fiscal national : {props.housing?.localId}
+              </LabelNext>
+              <AppLink
+                style={{ display: 'block' }}
+                to={`/logements/${props.housing?.id}`}
+                isSimple
+                target="_blank"
+              >
+                Voir la fiche logement dans un nouvel onglet
+              </AppLink>
+            </Box>
+          }
+          main={<Tabs tabs={[OccupationTab()]} />}
+          open={expand}
+          onClose={onClose}
+        />
+      </form>
+    </FormProvider>
   );
 }
 

--- a/frontend/src/components/HousingEdition/HousingEditionSideMenu.tsx
+++ b/frontend/src/components/HousingEdition/HousingEditionSideMenu.tsx
@@ -133,6 +133,7 @@ function HousingEditionSideMenu(props: HousingEditionSideMenuProps) {
     }
 
     onClose();
+    form.reset();
   }
 
   function OccupationTab(): ElementOf<TabsProps.Uncontrolled['tabs']> {

--- a/frontend/src/components/HousingEdition/HousingEditionSideMenu.tsx
+++ b/frontend/src/components/HousingEdition/HousingEditionSideMenu.tsx
@@ -79,7 +79,7 @@ function HousingEditionSideMenu(props: HousingEditionSideMenuProps) {
 
   return (
     <FormProvider {...form}>
-      <form onSubmit={form.handleSubmit(submit)}>
+      <form id="aside-form" onSubmit={form.handleSubmit(submit)}>
         <AsideNext
           drawerProps={{
             sx: (theme) => ({
@@ -112,6 +112,7 @@ function HousingEditionSideMenu(props: HousingEditionSideMenuProps) {
           main={<Tabs tabs={[OccupationTab()]} />}
           open={expand}
           onClose={onClose}
+          onSave={form.handleSubmit(submit)}
         />
       </form>
     </FormProvider>

--- a/frontend/src/components/HousingEdition/HousingEditionSideMenu.tsx
+++ b/frontend/src/components/HousingEdition/HousingEditionSideMenu.tsx
@@ -29,6 +29,7 @@ import {
 } from '../../models/HousingFilters';
 import HousingStatusSelect from './HousingStatusSelect';
 import { getSubStatusOptions } from '../../models/HousingState';
+import AppTextInputNext from '../_app/AppTextInput/AppTextInputNext';
 
 interface HousingEditionSideMenuProps {
   housing?: Housing;
@@ -51,7 +52,9 @@ const schema = yup.object({
   status: yup
     .number()
     .required('Veuillez renseigner le statut de suivi')
-    .oneOf(HOUSING_STATUS_VALUES)
+    .oneOf(HOUSING_STATUS_VALUES),
+  subStatus: yup.string(),
+  note: yup.string()
 });
 
 function HousingEditionSideMenu(props: HousingEditionSideMenuProps) {
@@ -59,7 +62,9 @@ function HousingEditionSideMenu(props: HousingEditionSideMenuProps) {
     values: {
       occupancy: props.housing?.occupancy ?? Occupancy.UNKNOWN,
       occupancyIntented: props.housing?.occupancyIntended ?? Occupancy.UNKNOWN,
-      status: props.housing?.status ?? HousingStatus.NEVER_CONTACTED
+      status: props.housing?.status ?? HousingStatus.NEVER_CONTACTED,
+      subStatus: props.housing?.subStatus ?? '',
+      note: ''
     },
     mode: 'onSubmit',
     resolver: yupResolver(schema)
@@ -232,6 +237,20 @@ function HousingEditionSideMenu(props: HousingEditionSideMenuProps) {
     };
   }
 
+  function NoteTab(): ElementOf<TabsProps.Uncontrolled['tabs']> {
+    return {
+      content: (
+        <AppTextInputNext
+          label="Nouvelle note"
+          name="note"
+          nativeTextAreaProps={{ rows: 8 }}
+          textArea
+        />
+      ),
+      label: 'Note'
+    };
+  }
+
   return (
     <AsideNext
       drawerProps={{
@@ -264,7 +283,7 @@ function HousingEditionSideMenu(props: HousingEditionSideMenuProps) {
       }
       main={
         <FormProvider {...form}>
-          <Tabs tabs={[OccupationTab(), MobilisationTab()]} />
+          <Tabs tabs={[OccupationTab(), MobilisationTab(), NoteTab()]} />
         </FormProvider>
       }
       open={expand}

--- a/frontend/src/components/HousingEdition/HousingEditionSideMenu.tsx
+++ b/frontend/src/components/HousingEdition/HousingEditionSideMenu.tsx
@@ -1,19 +1,34 @@
+import Button from '@codegouvfr/react-dsfr/Button';
 import Tabs, { TabsProps } from '@codegouvfr/react-dsfr/Tabs';
+import Tag from '@codegouvfr/react-dsfr/Tag';
 import { yupResolver } from '@hookform/resolvers/yup';
 import Box from '@mui/material/Box';
+import Grid from '@mui/material/Unstable_Grid2';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import { FormProvider, useForm } from 'react-hook-form';
 import { ElementOf } from 'ts-essentials';
 import * as yup from 'yup';
 
-import { Occupancy, OCCUPANCY_VALUES } from '@zerologementvacant/models';
+import {
+  HOUSING_STATUS_VALUES,
+  HousingStatus,
+  Occupancy,
+  OCCUPANCY_VALUES,
+  PRECISION_MECHANISM_CATEGORY_VALUES,
+  PrecisionCategory
+} from '@zerologementvacant/models';
 import { Housing, HousingUpdate } from '../../models/Housing';
 import AppLink from '../_app/AppLink/AppLink';
 import AsideNext from '../Aside/AsideNext';
 import LabelNext from '../Label/LabelNext';
 import AppSelectNext from '../_app/AppSelect/AppSelectNext';
-import { allOccupancyOptions } from '../../models/HousingFilters';
+import {
+  allOccupancyOptions,
+  statusOptions
+} from '../../models/HousingFilters';
+import HousingStatusSelect from './HousingStatusSelect';
+import { getSubStatusOptions } from '../../models/HousingState';
 
 interface HousingEditionSideMenuProps {
   housing?: Housing;
@@ -32,14 +47,19 @@ const schema = yup.object({
   occupancyIntented: yup
     .string()
     .required('Veuillez renseigner l’occupation prévisionnelle')
-    .oneOf(OCCUPANCY_VALUES)
+    .oneOf(OCCUPANCY_VALUES),
+  status: yup
+    .number()
+    .required('Veuillez renseigner le statut de suivi')
+    .oneOf(HOUSING_STATUS_VALUES)
 });
 
 function HousingEditionSideMenu(props: HousingEditionSideMenuProps) {
   const form = useForm<yup.InferType<typeof schema>>({
     values: {
       occupancy: props.housing?.occupancy ?? Occupancy.UNKNOWN,
-      occupancyIntented: props.housing?.occupancyIntended ?? Occupancy.UNKNOWN
+      occupancyIntented: props.housing?.occupancyIntended ?? Occupancy.UNKNOWN,
+      status: props.housing?.status ?? HousingStatus.NEVER_CONTACTED
     },
     mode: 'onSubmit',
     resolver: yupResolver(schema)
@@ -77,45 +97,180 @@ function HousingEditionSideMenu(props: HousingEditionSideMenuProps) {
     };
   }
 
-  return (
-    <FormProvider {...form}>
-      <form id="aside-form" onSubmit={form.handleSubmit(submit)}>
-        <AsideNext
-          drawerProps={{
-            sx: (theme) => ({
-              zIndex: theme.zIndex.appBar + 1,
-              '& .MuiDrawer-paper': {
-                px: '1.5rem',
-                py: '2rem',
-                width: WIDTH
+  function MobilisationTab(): ElementOf<TabsProps.Uncontrolled['tabs']> {
+    const status = form.watch('status');
+    // TODO: fetch `GET /precisions`
+    const precisions: ReadonlyArray<PrecisionCategory> = [];
+    const mechanisms = precisions.filter((precision) =>
+      PRECISION_MECHANISM_CATEGORY_VALUES.includes(precision)
+    );
+
+    return {
+      content: (
+        <Grid component="section" container sx={{ rowGap: 2 }}>
+          <Grid
+            component="article"
+            sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}
+            xs={12}
+          >
+            <Typography
+              component="h3"
+              sx={{ fontSize: '1.125rem', fontWeight: 700 }}
+            >
+              Statut de suivi
+            </Typography>
+            <HousingStatusSelect
+              selected={status}
+              message={form.getFieldState('status').error?.message}
+              messageType={
+                form.getFieldState('status').invalid ? 'error' : 'default'
               }
-            })
-          }}
-          header={
-            <Box component="header">
-              <Typography variant="h6">
-                {props.housing?.rawAddress.join(' - ')}
-              </Typography>
-              <LabelNext>
-                Identifiant fiscal national : {props.housing?.localId}
-              </LabelNext>
-              <AppLink
-                style={{ display: 'block' }}
-                to={`/logements/${props.housing?.id}`}
-                isSimple
-                target="_blank"
+              options={statusOptions()}
+              onChange={(status) => {
+                form.setValue('status', status);
+              }}
+            />
+            <AppSelectNext
+              disabled={getSubStatusOptions(status) === undefined}
+              label="Sous-statut de suivi"
+              name="subStatus"
+              multiple={false}
+              options={getSubStatusOptions(status) ?? []}
+            />
+          </Grid>
+
+          <Grid
+            component="article"
+            container
+            sx={{ alignItems: 'center', columnGap: 2, rowGap: 1 }}
+            xs={12}
+          >
+            <Grid
+              sx={{ display: 'flex', alignItems: 'center', gap: 2 }}
+              xs={12}
+            >
+              <Typography
+                component="h3"
+                sx={{
+                  display: 'inline-block',
+                  fontSize: '1.125rem',
+                  fontWeight: 700
+                }}
               >
-                Voir la fiche logement dans un nouvel onglet
-              </AppLink>
-            </Box>
+                Dispositifs ({mechanisms.length})
+              </Typography>
+              <Button priority="secondary" title="Modifier les dispositifs">
+                Modifier
+              </Button>
+            </Grid>
+            <Grid>
+              <Tag>Ma Prime Renov’</Tag>
+              <Tag>Aides aux travaux</Tag>
+            </Grid>
+          </Grid>
+
+          <Grid
+            component="article"
+            container
+            sx={{ alignItems: 'center', columnGap: 2, rowGap: 1 }}
+            xs={12}
+          >
+            <Grid
+              sx={{ display: 'flex', alignItems: 'center', gap: 2 }}
+              xs={12}
+            >
+              <Typography
+                component="h3"
+                sx={{
+                  display: 'inline-block',
+                  fontSize: '1.125rem',
+                  fontWeight: 700
+                }}
+              >
+                Points de blocages (0)
+              </Typography>
+              <Button
+                priority="secondary"
+                title="Modifier les points de blocage"
+              >
+                Modifier
+              </Button>
+            </Grid>
+            <Grid>Badges</Grid>
+          </Grid>
+
+          <Grid
+            component="article"
+            container
+            sx={{ alignItems: 'center', columnGap: 2 }}
+            xs={12}
+          >
+            <Grid
+              sx={{ display: 'flex', alignItems: 'center', gap: 2 }}
+              xs={12}
+            >
+              <Typography
+                component="h3"
+                sx={{ fontSize: '1.125rem', fontWeight: 700 }}
+              >
+                Évolutions du logement (1)
+              </Typography>
+              <Button
+                priority="secondary"
+                title="Modifier les évolutions du logement"
+              >
+                Modifier
+              </Button>
+            </Grid>
+            <Grid>
+              <Tag>Travaux : en cours</Tag>
+            </Grid>
+          </Grid>
+        </Grid>
+      ),
+      label: 'Mobilisation'
+    };
+  }
+
+  return (
+    <AsideNext
+      drawerProps={{
+        sx: (theme) => ({
+          zIndex: theme.zIndex.appBar + 1,
+          '& .MuiDrawer-paper': {
+            px: '1.5rem',
+            py: '2rem',
+            width: WIDTH
           }
-          main={<Tabs tabs={[OccupationTab()]} />}
-          open={expand}
-          onClose={onClose}
-          onSave={form.handleSubmit(submit)}
-        />
-      </form>
-    </FormProvider>
+        })
+      }}
+      header={
+        <Box component="header">
+          <Typography variant="h6">
+            {props.housing?.rawAddress.join(' - ')}
+          </Typography>
+          <LabelNext>
+            Identifiant fiscal national : {props.housing?.localId}
+          </LabelNext>
+          <AppLink
+            style={{ display: 'block' }}
+            to={`/logements/${props.housing?.id}`}
+            isSimple
+            target="_blank"
+          >
+            Voir la fiche logement dans un nouvel onglet
+          </AppLink>
+        </Box>
+      }
+      main={
+        <FormProvider {...form}>
+          <Tabs tabs={[OccupationTab(), MobilisationTab()]} />
+        </FormProvider>
+      }
+      open={expand}
+      onClose={onClose}
+      onSave={form.handleSubmit(submit)}
+    />
   );
 }
 

--- a/frontend/src/components/HousingEdition/HousingStatusSelect.tsx
+++ b/frontend/src/components/HousingEdition/HousingStatusSelect.tsx
@@ -13,6 +13,10 @@ interface Props {
   messageType?: string;
   message?: string;
 }
+
+/**
+ * @deprecated Will be replaced by a custom AppSelectNext
+ */
 const HousingStatusSelect = ({
   selected,
   options,

--- a/frontend/src/components/HousingList/HousingList.tsx
+++ b/frontend/src/components/HousingList/HousingList.tsx
@@ -11,7 +11,6 @@ import {
   Housing,
   HousingSort,
   HousingSortable,
-  HousingUpdate,
   OccupancyKindLabels,
   SelectedHousing
 } from '../../models/Housing';
@@ -32,10 +31,7 @@ import { DefaultPagination } from '../../store/reducers/housingReducer';
 import { Pagination } from '@zerologementvacant/models';
 import HousingSubStatusBadge from '../HousingStatusBadge/HousingSubStatusBadge';
 import HousingEditionSideMenu from '../HousingEdition/HousingEditionSideMenu';
-import {
-  useCountHousingQuery,
-  useUpdateHousingMutation
-} from '../../services/housing.service';
+import { useCountHousingQuery } from '../../services/housing.service';
 import { isDefined } from '../../utils/compareUtils';
 import Badge from '@codegouvfr/react-dsfr/Badge';
 import Button from '@codegouvfr/react-dsfr/Button';
@@ -59,14 +55,11 @@ const HousingList = ({
   const header = findChild(children, SelectableListHeader);
 
   const campaignList = useCampaignList();
-
   const { isVisitor } = useUser();
-
-  const [updateHousing] = useUpdateHousingMutation();
 
   const [pagination, setPagination] = useState<Pagination>(DefaultPagination);
   const [sort, setSort] = useState<HousingSort>();
-  const [updatingHousing, setUpdatingHousing] = useState<Housing>();
+  const [updatingHousing, setUpdatingHousing] = useState<Housing | null>(null);
 
   const { housingList } = useHousingList({
     filters,
@@ -270,17 +263,6 @@ const HousingList = ({
     columns = [selectColumn, ...columns, actionColumn];
   }
 
-  const submitHousingUpdate = async (
-    housing: Housing,
-    housingUpdate: HousingUpdate
-  ) => {
-    await updateHousing({
-      housing,
-      housingUpdate
-    });
-    setUpdatingHousing(undefined);
-  };
-
   return (
     <div>
       <header>
@@ -357,8 +339,9 @@ const HousingList = ({
       <HousingEditionSideMenu
         housing={updatingHousing}
         expand={!!updatingHousing}
-        onSubmit={submitHousingUpdate}
-        onClose={() => setUpdatingHousing(undefined)}
+        onClose={() => {
+          setUpdatingHousing(null);
+        }}
       />
     </div>
   );

--- a/frontend/src/components/_app/AppSelect/AppSelectNext.tsx
+++ b/frontend/src/components/_app/AppSelect/AppSelectNext.tsx
@@ -1,0 +1,135 @@
+import { fr } from '@codegouvfr/react-dsfr';
+import Checkbox from '@codegouvfr/react-dsfr/Checkbox';
+import {
+  BaseSelectProps,
+  Box,
+  MenuItem,
+  Select as MuiSelect
+} from '@mui/material';
+import { ReactNode, useId } from 'react';
+import { noop } from 'ts-essentials';
+import { match, Pattern } from 'ts-pattern';
+import { useController } from 'react-hook-form';
+
+interface Option<Value> {
+  id?: string;
+  label: string;
+  value: Value;
+}
+
+type AppSelectNextProps<Value> = BaseSelectProps<Value> & {
+  disabled?: boolean;
+  name: string;
+  options: ReadonlyArray<Option<Value>>;
+};
+
+function AppSelectNext<
+  Multiple extends boolean = false,
+  Value extends string | string[] = Multiple extends true ? string[] : string
+>(props: AppSelectNextProps<Value>) {
+  const labelId = `fr-label-${useId()}`;
+  const selectId = `fr-select-${useId()}`;
+
+  const multiple = props.multiple ?? false;
+
+  // Form handling
+  const { field, fieldState } = useController({
+    name: props.name,
+    disabled: props.disabled
+  });
+
+  const isControlled = props.value !== undefined;
+  const value: Value | null = isControlled ? props.value : field.value;
+  const onChange = isControlled ? props.onChange : field.onChange;
+
+  return (
+    <Box>
+      <label className="fr-label" id={labelId}>
+        {props.label}
+      </label>
+      <MuiSelect
+        classes={{
+          root: fr.cx('fr-mt-1w'),
+          select: fr.cx('fr-select', 'fr-pt-1w', 'fr-pr-5w'),
+          icon: fr.cx('fr-hidden')
+        }}
+        sx={{ width: '100%' }}
+        displayEmpty
+        label={props.label}
+        id={selectId}
+        labelId={labelId}
+        multiple={multiple}
+        MenuProps={{
+          anchorOrigin: {
+            vertical: 'bottom',
+            horizontal: 'left'
+          },
+          elevation: 0,
+          marginThreshold: null,
+          disableScrollLock: true,
+          sx: {
+            filter: 'drop-shadow(var(--raised-shadow))',
+            maxHeight: '40rem'
+          },
+          transformOrigin: {
+            vertical: 'top',
+            horizontal: 'left'
+          }
+        }}
+        native={false}
+        renderValue={(values) => {
+          return match(values)
+            .returnType<ReactNode>()
+            .with(Pattern.string, (value) => {
+              return props.options.find((option) => option.value === value)
+                ?.label;
+            })
+            .with(Pattern.array(Pattern.string), (values) => {
+              match(values.length).with(1, () => 'Une valeur sélectionnée');
+            })
+            .otherwise(() => '');
+        }}
+        value={value ?? ''}
+        variant="standard"
+        onChange={onChange}
+      >
+        {props.options.map((option) => (
+          <MenuItem
+            disableRipple
+            dense
+            key={option.value as Value}
+            value={option.value}
+          >
+            {!props.multiple ? (
+              option.label
+            ) : (
+              <Checkbox
+                classes={{
+                  root: fr.cx('fr-mb-0'),
+                  inputGroup: fr.cx('fr-mt-0')
+                }}
+                options={[
+                  {
+                    label: 'Vacant',
+                    nativeInputProps: {
+                      checked: (value as Value[]).some(
+                        (value) => value === option.value
+                      ),
+                      value: 'vacant',
+                      onClick: noop,
+                      onChange: noop
+                    }
+                  }
+                ]}
+                orientation="vertical"
+                small
+              />
+            )}
+          </MenuItem>
+        ))}
+      </MuiSelect>
+    </Box>
+  );
+}
+
+export default AppSelectNext;

--- a/frontend/src/components/_app/AppSelect/AppSelectNext.tsx
+++ b/frontend/src/components/_app/AppSelect/AppSelectNext.tsx
@@ -85,7 +85,8 @@ function AppSelectNext<Value extends string, Multiple extends boolean = false>(
           transformOrigin: {
             vertical: 'top',
             horizontal: 'left'
-          }
+          },
+          transitionDuration: 0
         }}
         native={false}
         renderValue={(values) => {

--- a/frontend/src/components/_app/AppSelect/AppSelectNext.tsx
+++ b/frontend/src/components/_app/AppSelect/AppSelectNext.tsx
@@ -53,6 +53,7 @@ function AppSelectNext<
           select: fr.cx('fr-select', 'fr-pt-1w', 'fr-pr-5w'),
           icon: fr.cx('fr-hidden')
         }}
+        disabled={props.disabled}
         sx={{ width: '100%' }}
         displayEmpty
         label={props.label}

--- a/frontend/src/components/_app/AppSelect/AppSelectNext.tsx
+++ b/frontend/src/components/_app/AppSelect/AppSelectNext.tsx
@@ -33,7 +33,7 @@ function AppSelectNext<
   const multiple = props.multiple ?? false;
 
   // Form handling
-  const { field, fieldState } = useController({
+  const { field } = useController({
     name: props.name,
     disabled: props.disabled
   });

--- a/frontend/src/mocks/handlers/housing-handlers.ts
+++ b/frontend/src/mocks/handlers/housing-handlers.ts
@@ -7,6 +7,7 @@ import {
   HousingDTO,
   HousingFiltersDTO,
   HousingPayloadDTO,
+  HousingUpdatePayloadDTO,
   Paginated
 } from '@zerologementvacant/models';
 import {
@@ -134,6 +135,7 @@ export const housingHandlers: RequestHandler[] = [
     }
   ),
 
+  // Get a housing by id
   http.get<HousingParams, never, HousingDTO | null>(
     `${config.apiEndpoint}/api/housing/:id`,
     ({ params }) => {
@@ -182,6 +184,34 @@ export const housingHandlers: RequestHandler[] = [
           owner
         )
       });
+    }
+  ),
+
+  // Update a housing
+  http.put<HousingParams, HousingUpdatePayloadDTO, HousingDTO>(
+    `${config.apiEndpoint}/api/housing/:id`,
+    async ({ params, request }) => {
+      const payload = await request.json();
+      const housing = data.housings.find((housing) => housing.id === params.id);
+      if (!housing) {
+        throw HttpResponse.json(
+          {
+            name: 'HousingMissingError',
+            message: `Housing ${params.id} missing`
+          },
+          { status: constants.HTTP_STATUS_NOT_FOUND }
+        );
+      }
+
+      const updated: HousingDTO = {
+        ...housing,
+        ...payload
+      };
+      data.housings = data.housings.map((housing) => {
+        return housing.id === updated.id ? updated : housing;
+      });
+
+      return HttpResponse.json(updated);
     }
   )
 ];

--- a/frontend/src/mocks/handlers/note-handlers.ts
+++ b/frontend/src/mocks/handlers/note-handlers.ts
@@ -1,7 +1,8 @@
 import { http, HttpResponse, RequestHandler } from 'msw';
 import { constants } from 'node:http2';
 
-import { NoteDTO } from '@zerologementvacant/models';
+import { NoteDTO, NotePayloadDTO } from '@zerologementvacant/models';
+import { genNoteDTO, genUserDTO } from '@zerologementvacant/models/fixtures';
 import config from '../../utils/config';
 import data from './data';
 
@@ -11,7 +12,7 @@ interface PathParams {
 
 export const noteHandlers: RequestHandler[] = [
   http.get<PathParams, never, NoteDTO[]>(
-    `${config.apiEndpoint}/api/notes/housing/:id`,
+    `${config.apiEndpoint}/api/housing/:id/notes`,
     async ({ params }) => {
       const housing = data.housings.find((housing) => housing.id === params.id);
       if (!housing) {
@@ -23,6 +24,33 @@ export const noteHandlers: RequestHandler[] = [
       const notes = data.housingNotes.get(housing.id) || [];
       return HttpResponse.json(notes, {
         status: constants.HTTP_STATUS_OK
+      });
+    }
+  ),
+
+  // Create a note for a housing
+  http.post<PathParams, NotePayloadDTO, NoteDTO>(
+    `${config.apiEndpoint}/api/housing/:id/notes`,
+    async ({ params, request }) => {
+      const housing = data.housings.find((housing) => housing.id === params.id);
+      if (!housing) {
+        throw HttpResponse.json(null, {
+          status: constants.HTTP_STATUS_NOT_FOUND
+        });
+      }
+
+      const payload = await request.json();
+      const creator = genUserDTO();
+      const note: NoteDTO = {
+        ...genNoteDTO(creator),
+        ...payload
+      };
+      data.housingNotes.set(
+        housing.id,
+        (data.housingNotes.get(housing.id) ?? []).concat(note)
+      );
+      return HttpResponse.json(note, {
+        status: constants.HTTP_STATUS_CREATED
       });
     }
   )

--- a/frontend/src/models/Housing.tsx
+++ b/frontend/src/models/Housing.tsx
@@ -299,8 +299,8 @@ export function toHousingDTO(housing: Housing): HousingDTO {
     // TODO: fix this by making Housing extend HousingDTO
     ownershipKind: housing.ownershipKind,
     status: housing.status as unknown as HousingStatus,
-    subStatus: housing.subStatus,
-    precisions: housing.precisions,
+    subStatus: housing.subStatus ?? null,
+    precisions: housing.precisions ?? null,
     energyConsumption:
       housing.energyConsumption as unknown as EnergyConsumption,
     energyConsumptionAt: housing.energyConsumptionAt,

--- a/frontend/src/models/Housing.tsx
+++ b/frontend/src/models/Housing.tsx
@@ -21,7 +21,9 @@ import { Compare } from '../utils/compareUtils';
 
 export interface Housing {
   id: string;
+  // Identifiant fiscal départemental
   invariant: string;
+  // Identifiant fiscal national
   localId: string;
   geoCode: string;
   cadastralReference: string;

--- a/frontend/src/services/housing.service.ts
+++ b/frontend/src/services/housing.service.ts
@@ -6,7 +6,9 @@ import { parseISO } from 'date-fns';
 import { SortOptions, toQuery } from '../models/Sort';
 import { AbortOptions } from '../utils/fetchUtils';
 import {
+  HousingDTO,
   HousingFiltersDTO,
+  HousingUpdatePayloadDTO,
   PaginationOptions
 } from '@zerologementvacant/models';
 import { parseOwner } from './owner.service';
@@ -130,6 +132,21 @@ export const housingApi = zlvApi.injectEndpoints({
         }
       ]
     }),
+    updateHousingNext: builder.mutation<
+      HousingDTO,
+      HousingUpdatePayloadDTO & Pick<Housing, 'id'>
+    >({
+      query: ({ id, ...payload }) => ({
+        url: `housing/${id}`,
+        method: 'PUT',
+        body: payload
+      }),
+      invalidatesTags: (result, error, payload) => [
+        { type: 'Housing', id: payload.id },
+        'HousingByStatus',
+        'HousingCountByStatus'
+      ]
+    }),
     updateHousingList: builder.mutation<
       number,
       {
@@ -185,5 +202,6 @@ export const {
   useCountHousingQuery,
   useCreateHousingMutation,
   useUpdateHousingMutation,
+  useUpdateHousingNextMutation,
   useUpdateHousingListMutation
 } = housingApi;

--- a/frontend/src/services/housing.service.ts
+++ b/frontend/src/services/housing.service.ts
@@ -144,7 +144,8 @@ export const housingApi = zlvApi.injectEndpoints({
       invalidatesTags: (result, error, payload) => [
         { type: 'Housing', id: payload.id },
         'HousingByStatus',
-        'HousingCountByStatus'
+        'HousingCountByStatus',
+        'Event'
       ]
     }),
     updateHousingList: builder.mutation<

--- a/frontend/src/services/note.service.ts
+++ b/frontend/src/services/note.service.ts
@@ -11,9 +11,9 @@ import { zlvApi } from './api.service';
 export const noteApi = zlvApi.injectEndpoints({
   endpoints: (builder) => ({
     findNotesByHousing: builder.query<Note[], string>({
-      query: (housingId) => `notes/housing/${housingId}`,
+      query: (id) => `housing/${id}/notes`,
       providesTags: () => ['Note'],
-      transformResponse: (response: any[]) => response.map((_) => parseNote(_))
+      transformResponse: (notes: ReadonlyArray<NoteDTO>) => notes.map(parseNote)
     }),
     createNoteByHousing: builder.mutation<
       NoteDTO,

--- a/frontend/src/services/note.service.ts
+++ b/frontend/src/services/note.service.ts
@@ -1,6 +1,11 @@
-import { Note } from '../models/Note';
-import { NoteDTO } from '@zerologementvacant/models';
 import { parseISO } from 'date-fns';
+
+import {
+  HousingDTO,
+  NoteDTO,
+  NotePayloadDTO
+} from '@zerologementvacant/models';
+import { Note } from '../models/Note';
 import { zlvApi } from './api.service';
 
 export const noteApi = zlvApi.injectEndpoints({
@@ -9,6 +14,17 @@ export const noteApi = zlvApi.injectEndpoints({
       query: (housingId) => `notes/housing/${housingId}`,
       providesTags: () => ['Note'],
       transformResponse: (response: any[]) => response.map((_) => parseNote(_))
+    }),
+    createNoteByHousing: builder.mutation<
+      NoteDTO,
+      Pick<HousingDTO, 'id'> & NotePayloadDTO
+    >({
+      query: ({ id, ...payload }) => ({
+        url: `housing/${id}/notes`,
+        method: 'POST',
+        body: payload
+      }),
+      invalidatesTags: () => ['Note']
     })
   })
 });
@@ -18,4 +34,5 @@ const parseNote = (noteDTO: NoteDTO): Note => ({
   createdAt: parseISO(noteDTO.createdAt)
 });
 
-export const { useFindNotesByHousingQuery } = noteApi;
+export const { useFindNotesByHousingQuery, useCreateNoteByHousingMutation } =
+  noteApi;

--- a/frontend/src/views/Housing/test/HousingView.test.tsx
+++ b/frontend/src/views/Housing/test/HousingView.test.tsx
@@ -87,7 +87,9 @@ describe('Housing view', () => {
         const vacancyStartYear = await screen
           .findByText(/^Dans cette situation depuis/)
           .then((label) => label.nextElementSibling);
-        expect(vacancyStartYear).toHaveTextContent(`1 an (${format(subYears(new Date(), 1), 'yyyy')})`);
+        expect(vacancyStartYear).toHaveTextContent(
+          `1 an (${format(subYears(new Date(), 1), 'yyyy')})`
+        );
       });
     });
 
@@ -225,6 +227,62 @@ describe('Housing view', () => {
         name: newOwner.fullName
       });
       expect(link).toBeVisible();
+    });
+  });
+
+  describe('Update the housing', () => {
+    it('should update the occupancy', async () => {
+      renderView(housing);
+
+      const [update] = await screen.findAllByRole('button', {
+        name: /Mettre à jour/
+      });
+      await user.click(update);
+      const occupancy = await screen.findByLabelText('Occupation actuelle');
+      await user.click(occupancy);
+      const options = await screen.findByRole('listbox');
+      const option = await within(options).findByRole('option', {
+        name: 'En location'
+      });
+      await user.click(option);
+      const save = await screen.findByRole('button', {
+        name: 'Enregistrer'
+      });
+      await user.click(save);
+      const newOccupancy = await screen.findByLabelText('Occupation');
+      expect(newOccupancy).toHaveTextContent(/En location/i);
+    });
+
+    it('should create a note', async () => {
+      renderView(housing);
+
+      const [update] = await screen.findAllByRole('button', {
+        name: /Mettre à jour/
+      });
+      await user.click(update);
+      const noteTab = await screen.findByRole('tab', {
+        name: 'Note'
+      });
+      await user.click(noteTab);
+      const notePanel = await screen.findByRole('tabpanel', {
+        name: 'Note'
+      });
+      const textbox = await within(notePanel).findByLabelText('Nouvelle note');
+      await user.type(textbox, faker.lorem.paragraph());
+      const save = await screen.findByRole('button', {
+        name: 'Enregistrer'
+      });
+      await user.click(save);
+      const history = await screen.findByRole('tab', {
+        name: 'Historique de suivi'
+      });
+      await user.click(history);
+      const panel = await screen.findByRole('tabpanel', {
+        name: 'Historique de suivi'
+      });
+      screen.logTestingPlaygroundURL();
+      const note = await within(panel).findByText('Note');
+      expect(note).toBeVisible();
     });
   });
 });

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -23,7 +23,8 @@
   "dependencies": {
     "@zerologementvacant/draft": "workspace:*",
     "@zerologementvacant/utils": "workspace:*",
-    "lodash": "^4.17.21"
+    "lodash": "^4.17.21",
+    "ts-essentials": "^10.0.2"
   },
   "devDependencies": {
     "@faker-js/faker": "^8.4.1",

--- a/packages/models/src/HousingDTO.ts
+++ b/packages/models/src/HousingDTO.ts
@@ -1,8 +1,8 @@
-import { OwnerDTO } from './OwnerDTO';
-import { HousingStatus } from './HousingStatus';
 import { EnergyConsumption } from './EnergyConsumption';
-import { Occupancy } from './Occupancy';
 import { HousingKind } from './HousingKind';
+import { HousingStatus } from './HousingStatus';
+import { Occupancy } from './Occupancy';
+import { OwnerDTO } from './OwnerDTO';
 
 // TODO: complete this type
 export interface HousingDTO {
@@ -44,6 +44,16 @@ export interface HousingDTO {
 }
 
 export type HousingPayloadDTO = Pick<HousingDTO, 'localId'>;
+
+export type HousingUpdatePayloadDTO =
+  // Required keys
+  Pick<HousingDTO, 'status' | 'occupancy'> & {
+    // Optional, nullable keys
+    subStatus?: string | null;
+    precisions?: string[] | null;
+    vacancyReasons?: string[] | null;
+    occupancyIntended?: Occupancy | null;
+  };
 
 export interface HousingCountDTO {
   housing: number;

--- a/packages/models/src/HousingDTO.ts
+++ b/packages/models/src/HousingDTO.ts
@@ -22,7 +22,7 @@ export interface HousingDTO {
   cadastralReference?: string;
   buildingYear?: number;
   taxed?: boolean;
-  vacancyReasons?: string[];
+  vacancyReasons: string[] | null;
   /**
    * @deprecated See {@link dataFileYears}
    */
@@ -33,12 +33,12 @@ export interface HousingDTO {
   rentalValue?: number;
   ownershipKind?: string;
   status: HousingStatus;
-  subStatus?: string;
-  precisions?: string[];
+  subStatus: string | null;
+  precisions: string[] | null;
   energyConsumption?: EnergyConsumption;
   energyConsumptionAt?: Date;
   occupancy: Occupancy;
-  occupancyIntended?: Occupancy;
+  occupancyIntended: Occupancy | null;
   source: HousingSource | null;
   owner: OwnerDTO;
 }

--- a/packages/models/src/NoteDTO.ts
+++ b/packages/models/src/NoteDTO.ts
@@ -1,9 +1,12 @@
+import { UserDTO } from './UserDTO';
+
 export interface NoteDTO {
   id: string;
   content: string;
   noteKind: string;
   createdBy: string;
   createdAt: string;
+  creator?: UserDTO;
 }
 
 export type NotePayloadDTO = Pick<NoteDTO, 'content'>;

--- a/packages/models/src/NoteDTO.ts
+++ b/packages/models/src/NoteDTO.ts
@@ -1,6 +1,9 @@
 export interface NoteDTO {
+  id: string;
   content: string;
   noteKind: string;
   createdBy: string;
   createdAt: string;
 }
+
+export type NotePayloadDTO = Pick<NoteDTO, 'content'>;

--- a/packages/models/src/Precision.ts
+++ b/packages/models/src/Precision.ts
@@ -13,6 +13,22 @@ export const PRECISION_CATEGORY_VALUES = [
 
 export type PrecisionCategory = (typeof PRECISION_CATEGORY_VALUES)[number];
 
+export const PRECISION_MECHANISM_CATEGORY_VALUES: ReadonlyArray<PrecisionCategory> =
+  [
+    'dispositifs-incitatifs',
+    'dispositifs-coercitifs',
+    'hors-dispositif-public'
+  ];
+export const PRECISION_BLOCKING_POINT_CATEGORY_VALUES: ReadonlyArray<PrecisionCategory> =
+  [
+    'blocage-involontaire',
+    'blocage-volontaire',
+    'immeuble-environnement',
+    'tiers-en-cause'
+  ];
+export const PRECISION_EVOLUTION_CATEGORY_VALUES: ReadonlyArray<PrecisionCategory> =
+  ['travaux', 'occupation', 'mutation'];
+
 export interface Precision {
   id: string;
   category: PrecisionCategory;

--- a/packages/models/src/test/fixtures.ts
+++ b/packages/models/src/test/fixtures.ts
@@ -23,6 +23,7 @@ import { EstablishmentDTO } from '../EstablishmentDTO';
 import { ESTABLISHMENT_KIND_VALUES } from '../EstablishmentKind';
 import { ESTABLISHMENT_SOURCE_VALUES } from '../EstablishmentSource';
 import { OWNER_KIND_LABELS } from '../OwnerKind';
+import { NoteDTO } from '../NoteDTO';
 
 export function genGeoCode(): string {
   const geoCode = faker.helpers.arrayElement([
@@ -322,6 +323,17 @@ export function genInvariant(locality: string): string {
 
 export function genLocalId(department: string, invariant: string): string {
   return department + invariant;
+}
+
+export function genNoteDTO(creator: UserDTO): NoteDTO {
+  return {
+    id: faker.string.uuid(),
+    content: faker.lorem.paragraph(),
+    noteKind: 'Note courante',
+    createdBy: creator.id,
+    createdAt: new Date().toJSON(),
+    creator
+  };
 }
 
 export function genOwnerDTO(): OwnerDTO {

--- a/packages/models/src/test/fixtures.ts
+++ b/packages/models/src/test/fixtures.ts
@@ -296,9 +296,13 @@ export function genHousingDTO(owner: OwnerDTO): HousingDTO {
       .streetAddress({ useFullAddress: true })
       .split(' '),
     occupancy: faker.helpers.arrayElement(OCCUPANCY_VALUES),
+    occupancyIntended: faker.helpers.arrayElement(OCCUPANCY_VALUES),
     housingKind: faker.helpers.arrayElement(HOUSING_KIND_VALUES),
     status: faker.helpers.arrayElement(HOUSING_STATUS_VALUES),
-    owner
+    subStatus: null,
+    owner,
+    precisions: null,
+    vacancyReasons: null
   };
 }
 

--- a/packages/schemas/src/housing-update-payload.ts
+++ b/packages/schemas/src/housing-update-payload.ts
@@ -16,17 +16,23 @@ export const housingUpdatePayload: ObjectSchema<HousingUpdatePayloadDTO> =
       .required('Veuillez renseigner l’occupation actuelle')
       .oneOf(OCCUPANCY_VALUES),
     // Optional, nullable keys
-    subStatus: string().trim().nullable().optional().default(null),
+    subStatus: string().trim().min(1).nullable().optional().default(null),
     precisions: array()
       .of(string().trim().required())
       .nullable()
       .optional()
-      .default(null),
+      .default(null)
+      .transform((value) =>
+        Array.isArray(value) && value.length === 0 ? null : value
+      ),
     vacancyReasons: array()
       .of(string().trim().required())
       .nullable()
       .optional()
-      .default(null),
+      .default(null)
+      .transform((value) =>
+        Array.isArray(value) && value.length === 0 ? null : value
+      ),
     occupancyIntended: string()
       .oneOf(OCCUPANCY_VALUES)
       .nullable()

--- a/packages/schemas/src/housing-update-payload.ts
+++ b/packages/schemas/src/housing-update-payload.ts
@@ -1,0 +1,35 @@
+import { array, number, object, ObjectSchema, string } from 'yup';
+
+import {
+  HOUSING_STATUS_VALUES,
+  HousingUpdatePayloadDTO,
+  OCCUPANCY_VALUES
+} from '@zerologementvacant/models';
+
+export const housingUpdatePayload: ObjectSchema<HousingUpdatePayloadDTO> =
+  object({
+    // Required keys
+    status: number()
+      .required('Veuillez renseigner le statut de suivi')
+      .oneOf(HOUSING_STATUS_VALUES),
+    occupancy: string()
+      .required('Veuillez renseigner l’occupation actuelle')
+      .oneOf(OCCUPANCY_VALUES),
+    // Optional, nullable keys
+    subStatus: string().trim().nullable().optional().default(null),
+    precisions: array()
+      .of(string().trim().required())
+      .nullable()
+      .optional()
+      .default(null),
+    vacancyReasons: array()
+      .of(string().trim().required())
+      .nullable()
+      .optional()
+      .default(null),
+    occupancyIntended: string()
+      .oneOf(OCCUPANCY_VALUES)
+      .nullable()
+      .optional()
+      .default(null)
+  });

--- a/packages/schemas/src/id.ts
+++ b/packages/schemas/src/id.ts
@@ -1,0 +1,3 @@
+import { string } from 'yup';
+
+export const id = string().uuid().required();

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -5,6 +5,7 @@ import { establishmentFilters } from './establishment-filters';
 import { geoCode } from './geo-code';
 import { housingFilters } from './housing-filters';
 import { housingUpdatePayload } from './housing-update-payload';
+import { id } from './id';
 import { notePayload } from './note-payload';
 import { password, passwordConfirmation } from './password';
 import { siren } from './siren';
@@ -20,6 +21,7 @@ export const schemas = {
   geoCode,
   housingFilters,
   housingUpdatePayload,
+  id,
   notePayload,
   password,
   passwordConfirmation,

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -4,6 +4,8 @@ import { email } from './email';
 import { establishmentFilters } from './establishment-filters';
 import { geoCode } from './geo-code';
 import { housingFilters } from './housing-filters';
+import { housingUpdatePayload } from './housing-update-payload';
+import { notePayload } from './note-payload';
 import { password, passwordConfirmation } from './password';
 import { siren } from './siren';
 
@@ -17,6 +19,8 @@ export const schemas = {
   establishmentFilters,
   geoCode,
   housingFilters,
+  housingUpdatePayload,
+  notePayload,
   password,
   passwordConfirmation,
   siren

--- a/packages/schemas/src/note-payload.ts
+++ b/packages/schemas/src/note-payload.ts
@@ -1,0 +1,7 @@
+import { object, ObjectSchema, string } from 'yup';
+
+import { NotePayloadDTO } from '@zerologementvacant/models';
+
+export const notePayload: ObjectSchema<NotePayloadDTO> = object({
+  content: string().required('Veuillez renseigner le contenu de la note')
+});

--- a/packages/schemas/src/test/housing-update-payload.test.ts
+++ b/packages/schemas/src/test/housing-update-payload.test.ts
@@ -12,17 +12,17 @@ describe('Housing update payload', () => {
     status: fc.constantFrom(...HOUSING_STATUS_VALUES),
     occupancy: fc.constantFrom(...OCCUPANCY_VALUES),
     subStatus: fc.oneof(
-      fc.string({ minLength: 1 }),
+      fc.stringMatching(/\S/),
       fc.constant(null),
       fc.constant(undefined)
     ),
     precisions: fc.oneof(
-      fc.array(fc.string({ minLength: 1 })),
+      fc.array(fc.stringMatching(/\S/), { minLength: 1 }),
       fc.constant(null),
       fc.constant(undefined)
     ),
     vacancyReasons: fc.oneof(
-      fc.array(fc.string({ minLength: 1 })),
+      fc.array(fc.stringMatching(/\S/), { minLength: 1 }),
       fc.constant(null),
       fc.constant(undefined)
     ),

--- a/packages/schemas/src/test/housing-update-payload.test.ts
+++ b/packages/schemas/src/test/housing-update-payload.test.ts
@@ -1,0 +1,39 @@
+import { fc, test } from '@fast-check/jest';
+
+import {
+  HOUSING_STATUS_VALUES,
+  HousingUpdatePayloadDTO,
+  OCCUPANCY_VALUES
+} from '@zerologementvacant/models';
+import { housingUpdatePayload } from '../housing-update-payload';
+
+describe('Housing update payload', () => {
+  test.prop<HousingUpdatePayloadDTO>({
+    status: fc.constantFrom(...HOUSING_STATUS_VALUES),
+    occupancy: fc.constantFrom(...OCCUPANCY_VALUES),
+    subStatus: fc.oneof(
+      fc.string({ minLength: 1 }),
+      fc.constant(null),
+      fc.constant(undefined)
+    ),
+    precisions: fc.oneof(
+      fc.array(fc.string({ minLength: 1 })),
+      fc.constant(null),
+      fc.constant(undefined)
+    ),
+    vacancyReasons: fc.oneof(
+      fc.array(fc.string({ minLength: 1 })),
+      fc.constant(null),
+      fc.constant(undefined)
+    ),
+    occupancyIntended: fc.oneof(
+      fc.constantFrom(...OCCUPANCY_VALUES),
+      fc.constant(null),
+      fc.constant(undefined)
+    )
+  })('shoud validate inputs', (payload) => {
+    const validate = () => housingUpdatePayload.validateSync(payload);
+
+    expect(validate).not.toThrow();
+  });
+});

--- a/packages/schemas/src/test/id.test.ts
+++ b/packages/schemas/src/test/id.test.ts
@@ -1,0 +1,13 @@
+import { fc, test } from '@fast-check/jest';
+import { id } from '../id';
+
+describe('id', () => {
+  test.prop<[string]>([fc.uuid({ version: 4 })])(
+    'should validate inputs',
+    (input) => {
+      const validate = () => id.validateSync(input);
+
+      expect(validate).not.toThrow();
+    }
+  );
+});

--- a/packages/schemas/src/test/note-payload.test.ts
+++ b/packages/schemas/src/test/note-payload.test.ts
@@ -1,0 +1,14 @@
+import { fc, test } from '@fast-check/jest';
+
+import { NotePayloadDTO } from '@zerologementvacant/models';
+import { notePayload } from '../note-payload';
+
+describe('Note payload', () => {
+  test.prop<NotePayloadDTO>({
+    content: fc.string({ minLength: 1 })
+  })(`should validate inputs`, (payload) => {
+    const validate = () => notePayload.validateSync(payload);
+
+    expect(validate).not.toThrow();
+  });
+});

--- a/server/src/controllers/housingController.test.ts
+++ b/server/src/controllers/housingController.test.ts
@@ -62,8 +62,8 @@ import {
 import { faker } from '@faker-js/faker/locale/fr';
 import { OwnerApi } from '~/models/OwnerApi';
 import {
+  HOUSING_STATUS_VALUES,
   HousingDTO,
-  HousingStatus,
   HousingUpdatePayloadDTO,
   Occupancy,
   OCCUPANCY_VALUES
@@ -553,11 +553,19 @@ describe('Housing API', () => {
       housing = genHousingApi(oneOf(establishment.geoCodes));
       owner = genOwnerApi();
       payload = {
-        status: HousingStatus.BLOCKED,
+        status: faker.helpers.arrayElement(
+          HOUSING_STATUS_VALUES.filter(
+            (status) => status !== toHousingStatus(housing.status)
+          )
+        ),
         subStatus: null,
         precisions: null,
         vacancyReasons: null,
-        occupancy: Occupancy.DEPENDENCY,
+        occupancy: faker.helpers.arrayElement(
+          OCCUPANCY_VALUES.filter(
+            (occupancy) => occupancy !== housing.occupancy
+          )
+        ),
         occupancyIntended: null
       };
 

--- a/server/src/controllers/housingController.ts
+++ b/server/src/controllers/housingController.ts
@@ -530,7 +530,7 @@ async function createHousingUpdateNote(
   geoCode: string
 ) {
   if (housingUpdate.note) {
-    await noteRepository.insertHousingNote({
+    await noteRepository.createByHousing({
       id: uuidv4(),
       ...housingUpdate.note,
       createdBy: userId,

--- a/server/src/controllers/housingExportController.ts
+++ b/server/src/controllers/housingExportController.ts
@@ -214,8 +214,10 @@ function writeHousingWorksheet(
             vacancyStartYear: housing.vacancyStartYear,
             status: getHousingStatusApiLabel(housing.status),
             subStatus: housing.subStatus,
-            vacancyReasons: reduceStringArray(housing.vacancyReasons),
-            precisions: reduceStringArray(housing.precisions),
+            vacancyReasons: reduceStringArray(
+              housing.vacancyReasons ?? undefined
+            ),
+            precisions: reduceStringArray(housing.precisions ?? undefined),
             campaigns: reduceStringArray(
               housing.campaignIds?.map(
                 (campaignId) =>

--- a/server/src/controllers/noteController.test.ts
+++ b/server/src/controllers/noteController.test.ts
@@ -1,6 +1,8 @@
+import { fc, test } from '@fast-check/jest';
 import { constants } from 'http2';
 import request from 'supertest';
 
+import { NoteDTO, NotePayloadDTO } from '@zerologementvacant/models';
 import { createServer } from '~/infra/server';
 import { tokenProvider } from '~/test/testUtils';
 import {
@@ -8,35 +10,40 @@ import {
   genHousingApi,
   genHousingNoteApi,
   genUserApi,
-  oneOf,
+  oneOf
 } from '~/test/testFixtures';
 import {
   Establishments,
-  formatEstablishmentApi,
+  formatEstablishmentApi
 } from '~/repositories/establishmentRepository';
 import { formatUserApi, Users } from '~/repositories/userRepository';
 import {
   formatHousingRecordApi,
-  Housing,
+  Housing
 } from '~/repositories/housingRepository';
 import {
   formatHousingNoteApi,
   formatNoteApi,
   HousingNotes,
-  Notes,
+  Notes
 } from '~/repositories/noteRepository';
 import { NoteApi } from '~/models/NoteApi';
+import { UserApi, UserRoles } from '~/models/UserApi';
 
 describe('Note API', () => {
   const { app } = createServer();
 
   const establishment = genEstablishmentApi();
   const user = genUserApi(establishment.id);
+  const visitor: UserApi = {
+    ...genUserApi(establishment.id),
+    role: UserRoles.Visitor
+  };
   const housing = genHousingApi(oneOf(establishment.geoCodes));
 
   beforeAll(async () => {
     await Establishments().insert(formatEstablishmentApi(establishment));
-    await Users().insert(formatUserApi(user));
+    await Users().insert([user, visitor].map(formatUserApi));
     await Housing().insert(formatHousingRecordApi(housing));
   });
 
@@ -59,7 +66,7 @@ describe('Note API', () => {
 
     it('should list the housing notes', async () => {
       const notes = Array.from({ length: 3 }, () =>
-        genHousingNoteApi(user, housing),
+        genHousingNoteApi(user, housing)
       );
       await Notes().insert(notes.map(formatNoteApi));
       await HousingNotes().insert(notes.map(formatHousingNoteApi));
@@ -71,6 +78,57 @@ describe('Note API', () => {
       expect(status).toBe(constants.HTTP_STATUS_OK);
       expect(body).toSatisfyAll<NoteApi>((actual) => {
         return notes.map((note) => note.id).includes(actual.id);
+      });
+    });
+  });
+
+  describe('createByHousing', () => {
+    const testRoute = (id: string) => `/api/housing/${id}/notes`;
+
+    it('should be forbidden for a non-authenticated user', async () => {
+      const { status } = await request(app).post(testRoute(housing.id));
+
+      expect(status).toBe(constants.HTTP_STATUS_UNAUTHORIZED);
+    });
+
+    it('should be forbidden for a visitor', async () => {
+      const { status } = await request(app)
+        .post(testRoute(housing.id))
+        .use(tokenProvider(visitor));
+
+      expect(status).toBe(constants.HTTP_STATUS_UNAUTHORIZED);
+    });
+
+    test.prop<NotePayloadDTO>({
+      content: fc.string({ minLength: 1 })
+    })('should validate inputs', async (payload) => {
+      const { status } = await request(app)
+        .post(testRoute(housing.id))
+        .send(payload)
+        .type('json')
+        .use(tokenProvider(user));
+
+      expect(status).toBe(constants.HTTP_STATUS_CREATED);
+    });
+
+    it('should create a note', async () => {
+      const payload: NotePayloadDTO = {
+        content: 'This is a test note'
+      };
+
+      const { body, status } = await request(app)
+        .post(testRoute(housing.id))
+        .send(payload)
+        .type('json')
+        .use(tokenProvider(user));
+
+      expect(status).toBe(constants.HTTP_STATUS_CREATED);
+      expect(body).toStrictEqual<NoteDTO>({
+        id: expect.any(String),
+        content: payload.content,
+        noteKind: 'Note',
+        createdBy: user.id,
+        createdAt: expect.any(String)
       });
     });
   });

--- a/server/src/controllers/noteController.test.ts
+++ b/server/src/controllers/noteController.test.ts
@@ -141,7 +141,7 @@ describe('Note API', () => {
       expect(body).toStrictEqual<NoteDTO>({
         id: expect.any(String),
         content: payload.content,
-        noteKind: 'Note',
+        noteKind: 'Note courante',
         createdBy: user.id,
         createdAt: expect.any(String)
       });

--- a/server/src/controllers/noteController.test.ts
+++ b/server/src/controllers/noteController.test.ts
@@ -49,7 +49,7 @@ describe('Note API', () => {
   });
 
   describe('listByHousingId', () => {
-    const testRoute = (housingId: string) => `/api/notes/housing/${housingId}`;
+    const testRoute = (housingId: string) => `/api/housing/${housingId}/notes`;
 
     it('should be forbidden for a non-authenticated user', async () => {
       const { status } = await request(app).get(testRoute(housing.id));

--- a/server/src/controllers/noteController.ts
+++ b/server/src/controllers/noteController.ts
@@ -1,8 +1,12 @@
 import { Request, Response } from 'express';
 import { constants } from 'http2';
+import { v4 as uuidv4 } from 'uuid';
 
+import { NoteDTO, NotePayloadDTO } from '@zerologementvacant/models';
 import noteRepository from '~/repositories/noteRepository';
 import { logger } from '~/infra/logger';
+import { NoteApi, toNoteDTO } from '~/models/NoteApi';
+import { AuthenticatedRequest } from 'express-jwt';
 
 async function listByOwnerId(request: Request, response: Response) {
   const ownerId = request.params.ownerId;
@@ -22,9 +26,34 @@ async function listByHousingId(request: Request, response: Response) {
   response.status(constants.HTTP_STATUS_OK).json(notes);
 }
 
+interface PathParams extends Record<string, string> {
+  id: string;
+}
+
+async function createByHousing(
+  request: Request<PathParams, NoteDTO, NotePayloadDTO, never>,
+  response: Response<NoteDTO>
+) {
+  const { auth, body } = request as AuthenticatedRequest<
+    PathParams,
+    NoteDTO,
+    NotePayloadDTO,
+    never
+  >;
+  const note: NoteApi = {
+    id: uuidv4(),
+    content: body.content,
+    noteKind: 'Note',
+    createdBy: auth.userId,
+    createdAt: new Date()
+  };
+  response.status(constants.HTTP_STATUS_CREATED).json(toNoteDTO(note));
+}
+
 const noteController = {
+  createByHousing,
   listByOwnerId,
-  listByHousingId,
+  listByHousingId
 };
 
 export default noteController;

--- a/server/src/controllers/noteController.ts
+++ b/server/src/controllers/noteController.ts
@@ -53,7 +53,7 @@ async function createByHousing(
   const note: HousingNoteApi = {
     id: uuidv4(),
     content: body.content,
-    noteKind: 'Note',
+    noteKind: 'Note courante',
     createdBy: auth.userId,
     createdAt: new Date(),
     housingId: housing.id,

--- a/server/src/controllers/noteController.ts
+++ b/server/src/controllers/noteController.ts
@@ -1,35 +1,30 @@
 import { Request, Response } from 'express';
+import { AuthenticatedRequest } from 'express-jwt';
 import { constants } from 'http2';
 import { v4 as uuidv4 } from 'uuid';
 
 import { NoteDTO, NotePayloadDTO } from '@zerologementvacant/models';
 import noteRepository from '~/repositories/noteRepository';
-import { logger } from '~/infra/logger';
+import { createLogger } from '~/infra/logger';
 import { HousingNoteApi, toNoteDTO } from '~/models/NoteApi';
-import { AuthenticatedRequest } from 'express-jwt';
 import housingRepository from '~/repositories/housingRepository';
 import HousingMissingError from '~/errors/housingMissingError';
 
-async function listByOwnerId(request: Request, response: Response) {
-  const ownerId = request.params.ownerId;
-
-  logger.info('List notes for owner', ownerId);
-
-  const notes = await noteRepository.findOwnerNotes(ownerId);
-  response.status(constants.HTTP_STATUS_OK).json(notes);
-}
-
-async function listByHousingId(request: Request, response: Response) {
-  const housingId = request.params.housingId;
-
-  logger.info('List notes for housing', housingId);
-
-  const notes = await noteRepository.findHousingNotes(housingId);
-  response.status(constants.HTTP_STATUS_OK).json(notes);
-}
+const logger = createLogger('noteController');
 
 interface PathParams extends Record<string, string> {
   id: string;
+}
+
+async function findByHousing(
+  request: Request<PathParams>,
+  response: Response<NoteDTO[]>
+) {
+  const { params } = request;
+  logger.debug('Find notes by housing', { housing: params.id });
+
+  const notes = await noteRepository.findHousingNotes(params.id);
+  response.status(constants.HTTP_STATUS_OK).json(notes.map(toNoteDTO));
 }
 
 async function createByHousing(
@@ -42,6 +37,8 @@ async function createByHousing(
     NotePayloadDTO,
     never
   >;
+  logger.debug('Create a note by housing', { housing: params.id, note: body });
+
   const housing = await housingRepository.findOne({
     geoCode: establishment.geoCodes,
     id: params.id
@@ -65,8 +62,7 @@ async function createByHousing(
 
 const noteController = {
   createByHousing,
-  listByOwnerId,
-  listByHousingId
+  findByHousing
 };
 
 export default noteController;

--- a/server/src/infra/database/test/transaction.test.ts
+++ b/server/src/infra/database/test/transaction.test.ts
@@ -1,0 +1,91 @@
+import { faker } from '@faker-js/faker/locale/fr';
+import async from 'async';
+
+import db from '~/infra/database/index';
+import { getTransaction, startTransaction } from '~/infra/database/transaction';
+
+describe('Transaction', () => {
+  const tables = ['t1', 't2'];
+  const original = {
+    id: faker.string.uuid()
+  };
+
+  beforeAll(async () => {
+    await async.forEach(tables, async (name) => {
+      if (await db.schema.hasTable(name)) {
+        await db.schema.dropTable(name);
+      }
+
+      await db.schema.createTable(name, (table) => {
+        table.uuid('id').primary();
+      });
+
+      await db(name).insert(original);
+    });
+  });
+
+  afterAll(async () => {
+    await async.forEach(tables, async (name) => {
+      await db.schema.dropTable(name);
+    });
+  });
+
+  it('should correctly update a record', async () => {
+    const updated = { id: faker.string.uuid() };
+
+    await startTransaction(async () => {
+      const transaction = getTransaction();
+      if (!transaction) {
+        throw new Error('Transaction should be defined');
+      }
+
+      await async.forEach(tables, async (name) => {
+        await transaction(name).update(updated);
+      });
+    });
+
+    await async.forEach(tables, async (name) => {
+      const actual = await db(name).first();
+      expect(actual).toStrictEqual(updated);
+    });
+  });
+
+  it('should roll back if one of the queries fails', async () => {
+    try {
+      await startTransaction(async () => {
+        const transaction = getTransaction();
+        if (!transaction) {
+          throw new Error('Transaction should be defined');
+        }
+
+        await transaction('t1').update({ id: faker.string.uuid() });
+        await transaction('t2').update({ id: 'should-fail' });
+      });
+    } catch {
+      await async.forEach(tables, async (name) => {
+        const actual = await db(name).first();
+        expect(actual).toStrictEqual(original);
+      });
+    }
+  });
+
+  it('should handle multiple transactions', async () => {
+    const updateds = Array.from({ length: 3 }, () => ({
+      id: faker.string.uuid()
+    }));
+
+    await async.forEach(updateds, async (updated) => {
+      await startTransaction(async () => {
+        const transaction = getTransaction();
+        if (!transaction) {
+          throw new Error('Transaction should be defined');
+        }
+
+        await transaction('t1').update(updated);
+      });
+    });
+
+    const actual = await db('t1').first();
+    expect(updateds).toContainEqual(actual);
+  });
+});

--- a/server/src/infra/database/transaction.ts
+++ b/server/src/infra/database/transaction.ts
@@ -1,0 +1,31 @@
+import { AsyncLocalStorage } from 'async_hooks';
+import { Knex } from 'knex';
+import { AsyncOrSync } from 'ts-essentials';
+
+import db from '~/infra/database/index';
+
+interface TransactionStore {
+  transaction: Knex.Transaction;
+}
+
+const storage: AsyncLocalStorage<TransactionStore> =
+  new AsyncLocalStorage<TransactionStore>();
+
+export async function startTransaction(
+  cb: () => AsyncOrSync<void>,
+  options?: Knex.TransactionConfig
+) {
+  const transaction = await db.transaction(options);
+  try {
+    await storage.run({ transaction }, cb);
+    await transaction.commit();
+  } catch {
+    await transaction.rollback();
+  }
+}
+
+/**
+ * Get the active transaction, if any.
+ * {@link startTransaction} must be called before calling this function.
+ */
+export const getTransaction = () => storage.getStore()?.transaction;

--- a/server/src/middlewares/test/auth.test.ts
+++ b/server/src/middlewares/test/auth.test.ts
@@ -1,0 +1,76 @@
+import express, { NextFunction, Request, Response } from 'express';
+import { constants } from 'http2';
+import request from 'supertest';
+
+import { genEstablishmentApi, genUserApi } from '~/test/testFixtures';
+import { UserApi, UserRoles } from '~/models/UserApi';
+import { hasRole } from '~/middlewares/auth';
+
+describe('Auth', () => {
+  describe('hasRoles', () => {
+    const establishment = genEstablishmentApi();
+
+    function createUser(role: UserRoles): UserApi {
+      return { ...genUserApi(establishment.id), role };
+    }
+
+    function setUser(user: UserApi) {
+      return (request: Request, _: Response, next: NextFunction) => {
+        request.user = user;
+        next();
+      };
+    }
+
+    const visitor = createUser(UserRoles.Visitor);
+    const admin = createUser(UserRoles.Admin);
+    const user = createUser(UserRoles.Usual);
+
+    it('should succeed if the user has the given role', async () => {
+      const app = express();
+      app.get(
+        '/',
+        setUser(admin),
+        hasRole([UserRoles.Admin]),
+        (_, response) => {
+          response.status(constants.HTTP_STATUS_OK).send();
+        }
+      );
+
+      const { status } = await request(app).get('/');
+
+      expect(status).toBe(constants.HTTP_STATUS_OK);
+    });
+
+    it('should succeed if the user has one of the given roles', async () => {
+      const app = express();
+      app.get(
+        '/',
+        setUser(user),
+        hasRole([UserRoles.Admin, UserRoles.Usual]),
+        (_, response) => {
+          response.status(constants.HTTP_STATUS_OK).send();
+        }
+      );
+
+      const { status } = await request(app).get('/');
+
+      expect(status).toBe(constants.HTTP_STATUS_OK);
+    });
+
+    it('should fail if the user has none of the given roles', async () => {
+      const app = express();
+      app.get(
+        '/',
+        setUser(visitor),
+        hasRole([UserRoles.Admin, UserRoles.Usual]),
+        (_, response) => {
+          response.status(constants.HTTP_STATUS_OK).send();
+        }
+      );
+
+      const { status } = await request(app).get('/');
+
+      expect(status).toBe(constants.HTTP_STATUS_UNAUTHORIZED);
+    });
+  });
+});

--- a/server/src/models/HousingApi.ts
+++ b/server/src/models/HousingApi.ts
@@ -1,11 +1,17 @@
 import fp from 'lodash/fp';
 import { assert, MarkRequired } from 'ts-essentials';
 
-import { HousingSource, Occupancy } from '@zerologementvacant/models';
-import { OwnerApi } from './OwnerApi';
-import { HousingStatusApi } from './HousingStatusApi';
+import {
+  HousingDTO,
+  HousingKind,
+  HousingSource,
+  Occupancy
+} from '@zerologementvacant/models';
+import { OwnerApi, toOwnerDTO } from './OwnerApi';
+import { HousingStatusApi, toHousingStatus } from './HousingStatusApi';
 import { Sort } from './SortApi';
 import { HousingEventApi, isUserModified } from '~/models/EventApi';
+import OwnerMissingError from '~/errors/ownerMissingError';
 
 export type HousingId = Pick<HousingRecordApi, 'geoCode' | 'id'>;
 
@@ -36,7 +42,7 @@ export interface HousingRecordApi {
   buildingYear?: number;
   mutationDate: Date | null;
   taxed?: boolean;
-  vacancyReasons?: string[];
+  vacancyReasons?: string[] | null;
   /**
    * @deprecated See {@link dataFileYears}
    */
@@ -49,12 +55,12 @@ export interface HousingRecordApi {
   ownershipKind?: string;
   status: HousingStatusApi;
   subStatus?: string | null;
-  precisions?: string[];
+  precisions?: string[] | null;
   energyConsumption?: EnergyConsumptionGradesApi;
   energyConsumptionAt?: Date;
   occupancy: Occupancy;
   occupancyRegistered: Occupancy;
-  occupancyIntended?: Occupancy;
+  occupancyIntended?: Occupancy | null;
   source: HousingSource | null;
 }
 
@@ -67,6 +73,47 @@ export interface HousingApi extends HousingRecordApi {
   campaignIds?: string[];
   contactCount?: number;
   lastContact?: Date;
+}
+
+export function toHousingDTO(housing: HousingApi): HousingDTO {
+  if (!housing.owner) {
+    throw new OwnerMissingError();
+  }
+
+  return {
+    id: housing.id,
+    invariant: housing.invariant,
+    localId: housing.localId,
+    rawAddress: housing.rawAddress,
+    geoCode: housing.geoCode,
+    longitude: housing.longitude,
+    latitude: housing.latitude,
+    cadastralClassification: housing.cadastralClassification,
+    uncomfortable: housing.uncomfortable,
+    vacancyStartYear: housing.vacancyStartYear,
+    housingKind: housing.housingKind as HousingKind,
+    roomsCount: housing.roomsCount,
+    livingArea: housing.livingArea,
+    cadastralReference: housing.cadastralReference,
+    buildingYear: housing.buildingYear,
+    taxed: housing.taxed,
+    vacancyReasons: housing.vacancyReasons ?? null,
+    dataYears: housing.dataYears,
+    dataFileYears: housing.dataFileYears,
+    beneficiaryCount: housing.beneficiaryCount,
+    buildingLocation: housing.buildingLocation,
+    rentalValue: housing.rentalValue,
+    ownershipKind: housing.ownershipKind,
+    status: toHousingStatus(housing.status),
+    subStatus: housing.subStatus ?? null,
+    precisions: housing.precisions ?? null,
+    energyConsumption: housing.energyConsumption,
+    energyConsumptionAt: housing.energyConsumptionAt,
+    occupancy: housing.occupancy,
+    occupancyIntended: housing.occupancyIntended ?? null,
+    source: housing.source,
+    owner: toOwnerDTO(housing.owner)
+  };
 }
 
 export function assertOwner<T extends HousingApi>(

--- a/server/src/models/HousingStatusApi.ts
+++ b/server/src/models/HousingStatusApi.ts
@@ -1,3 +1,5 @@
+import { HousingStatus } from '@zerologementvacant/models';
+
 export enum HousingStatusApi {
   NeverContacted,
   Waiting,
@@ -5,6 +7,14 @@ export enum HousingStatusApi {
   InProgress,
   Completed,
   Blocked
+}
+
+export function fromHousingStatus(status: HousingStatus): HousingStatusApi {
+  return status as unknown as HousingStatusApi;
+}
+
+export function toHousingStatus(status: HousingStatusApi): HousingStatus {
+  return status as unknown as HousingStatus;
 }
 
 export const HOUSING_STATUS_VALUES = Object.values(HousingStatusApi).filter(

--- a/server/src/models/NoteApi.ts
+++ b/server/src/models/NoteApi.ts
@@ -1,11 +1,11 @@
 import { assert } from 'ts-essentials';
 
 import { NoteDTO } from '@zerologementvacant/models';
-import { UserApi } from '~/models/UserApi';
+import { toUserDTO, UserApi } from '~/models/UserApi';
 
-export interface NoteApi extends Omit<NoteDTO, 'createdAt'> {
-  creator?: UserApi;
+export interface NoteApi extends Omit<NoteDTO, 'creator' | 'createdAt'> {
   createdAt: Date;
+  creator?: UserApi;
 }
 
 export function toNoteDTO(note: NoteApi): NoteDTO {
@@ -14,7 +14,8 @@ export function toNoteDTO(note: NoteApi): NoteDTO {
     content: note.content,
     noteKind: note.noteKind,
     createdBy: note.createdBy,
-    createdAt: note.createdAt.toJSON()
+    createdAt: note.createdAt.toJSON(),
+    creator: note.creator ? toUserDTO(note.creator) : undefined
   };
 }
 

--- a/server/src/models/NoteApi.ts
+++ b/server/src/models/NoteApi.ts
@@ -1,14 +1,21 @@
 import { assert } from 'ts-essentials';
 
+import { NoteDTO } from '@zerologementvacant/models';
 import { UserApi } from '~/models/UserApi';
 
-export interface NoteApi {
-  id: string;
-  content: string;
-  noteKind: string;
-  createdBy: string;
+export interface NoteApi extends Omit<NoteDTO, 'createdAt'> {
   creator?: UserApi;
   createdAt: Date;
+}
+
+export function toNoteDTO(note: NoteApi): NoteDTO {
+  return {
+    id: note.id,
+    content: note.content,
+    noteKind: note.noteKind,
+    createdBy: note.createdBy,
+    createdAt: note.createdAt.toJSON()
+  };
 }
 
 export interface OwnerNoteApi extends NoteApi {

--- a/server/src/repositories/housingRepository.ts
+++ b/server/src/repositories/housingRepository.ts
@@ -38,6 +38,7 @@ import { groupsHousingTable } from './groupRepository';
 import { housingOwnersTable } from './housingOwnerRepository';
 import { campaignsHousingTable } from './campaignHousingRepository';
 import { campaignsTable } from './campaignRepository';
+import { getTransaction } from '~/infra/database/transaction';
 
 export const housingTable = 'fast_housing';
 export const buildingTable = 'buildings';
@@ -358,7 +359,8 @@ function include(includes: HousingInclude[], filters?: HousingFiltersApi) {
 async function update(housing: HousingApi): Promise<void> {
   logger.debug('Update housing', housing.id);
 
-  return db(housingTable)
+  const transaction = getTransaction();
+  return Housing(transaction)
     .where({
       // Use the index on the partitioned table
       geo_code: housing.geoCode,
@@ -897,7 +899,7 @@ export interface HousingRecordDBO {
   building_year?: number;
   mutation_date?: Date;
   taxed?: boolean;
-  vacancy_reasons?: string[];
+  vacancy_reasons: string[] | null;
   /**
    * @deprecated See {@link data_file_years}
    */
@@ -912,11 +914,11 @@ export interface HousingRecordDBO {
   rental_value?: number;
   condominium?: string;
   status: HousingStatusApi;
-  sub_status?: string | null;
-  precisions?: string[];
+  sub_status: string | null;
+  precisions: string[] | null;
   occupancy: Occupancy;
   occupancy_source: Occupancy;
-  occupancy_intended?: Occupancy;
+  occupancy_intended: Occupancy | null;
   energy_consumption_bdnb?: EnergyConsumptionGradesApi;
   energy_consumption_at_bdnb?: Date;
 }
@@ -971,8 +973,8 @@ export const parseHousingApi = (housing: HousingDBO): HousingApi => ({
   dataFileYears: housing.data_file_years ?? [],
   ownershipKind: housing.condominium,
   status: housing.status,
-  subStatus: housing.sub_status ?? undefined,
-  precisions: housing.precisions ?? undefined,
+  subStatus: housing.sub_status,
+  precisions: housing.precisions,
   energyConsumption: housing.energy_consumption_bdnb,
   energyConsumptionAt: housing.energy_consumption_at_bdnb,
   occupancy: housing.occupancy,
@@ -1022,19 +1024,23 @@ export const formatHousingRecordApi = (
   rooms_count: housingRecordApi.roomsCount,
   living_area: housingRecordApi.livingArea,
   cadastral_reference: housingRecordApi.cadastralReference,
-  vacancy_reasons: housingRecordApi.vacancyReasons,
+  vacancy_reasons: !housingRecordApi.vacancyReasons?.length
+    ? null
+    : housingRecordApi.vacancyReasons,
   taxed: housingRecordApi.taxed,
   condominium: housingRecordApi.ownershipKind,
   data_years: housingRecordApi.dataYears,
   data_file_years: housingRecordApi.dataFileYears,
   status: housingRecordApi.status,
-  sub_status: housingRecordApi.subStatus,
-  precisions: housingRecordApi.precisions,
+  sub_status: housingRecordApi.subStatus ?? null,
+  precisions: !housingRecordApi.precisions?.length
+    ? null
+    : housingRecordApi.precisions,
   energy_consumption_bdnb: housingRecordApi.energyConsumption,
   energy_consumption_at_bdnb: housingRecordApi.energyConsumptionAt,
   occupancy: housingRecordApi.occupancy,
   occupancy_source: housingRecordApi.occupancyRegistered,
-  occupancy_intended: housingRecordApi.occupancyIntended,
+  occupancy_intended: housingRecordApi.occupancyIntended ?? null,
   data_source: housingRecordApi.source
 });
 

--- a/server/src/repositories/noteRepository.ts
+++ b/server/src/repositories/noteRepository.ts
@@ -79,6 +79,14 @@ export interface NoteRecordDBO {
   note_kind: string;
   created_by: string;
   created_at: Date;
+  /**
+   * @deprecated
+   */
+  contact_kind_deprecated: string | null;
+  /**
+   * @deprecated
+   */
+  title_deprecated: string | null;
 }
 
 export interface NoteDBO extends NoteRecordDBO {
@@ -96,7 +104,9 @@ export const formatNoteApi = (noteApi: NoteApi): NoteRecordDBO => ({
   created_by: noteApi.createdBy,
   created_at: noteApi.createdAt,
   note_kind: noteApi.noteKind,
-  content: noteApi.content
+  content: noteApi.content,
+  contact_kind_deprecated: null,
+  title_deprecated: null
 });
 
 export const formatHousingNoteApi = (note: HousingNoteApi): HousingNoteDBO => ({

--- a/server/src/repositories/noteRepository.ts
+++ b/server/src/repositories/noteRepository.ts
@@ -26,11 +26,11 @@ async function insertOwnerNote(ownerNoteApi: OwnerNoteApi): Promise<void> {
   });
 }
 
-async function insertHousingNote(housingNote: HousingNoteApi): Promise<void> {
-  await insertManyHousingNotes([housingNote]);
+async function createByHousing(housingNote: HousingNoteApi): Promise<void> {
+  await createManyByHousing([housingNote]);
 }
 
-async function insertManyHousingNotes(
+async function createManyByHousing(
   housingNotes: HousingNoteApi[]
 ): Promise<void> {
   logger.info('Insert %d HousingNoteApi', housingNotes.length);
@@ -73,7 +73,7 @@ async function findHousingNotes(housingId: string): Promise<NoteApi[]> {
   return findNotes(housingNotesTable, 'housing_id', housingId);
 }
 
-interface NoteRecordDBO {
+export interface NoteRecordDBO {
   id: string;
   content: string;
   note_kind: string;
@@ -81,11 +81,11 @@ interface NoteRecordDBO {
   created_at: Date;
 }
 
-interface NoteDBO extends NoteRecordDBO {
+export interface NoteDBO extends NoteRecordDBO {
   creator?: UserDBO;
 }
 
-interface HousingNoteDBO {
+export interface HousingNoteDBO {
   note_id: string;
   housing_id: string;
   housing_geo_code: string;
@@ -116,9 +116,8 @@ export const parseNoteApi = (noteDbo: NoteDBO): NoteApi => ({
 
 export default {
   insertOwnerNote,
-  insertHousingNote,
-  insertManyHousingNotes,
+  createByHousing,
+  createManyByHousing,
   findHousingNotes,
-  findOwnerNotes,
-  formatNoteApi
+  findOwnerNotes
 };

--- a/server/src/repositories/test/noteRepository.test.ts
+++ b/server/src/repositories/test/noteRepository.test.ts
@@ -1,0 +1,63 @@
+import noteRepository, {
+  HousingNotes,
+  NoteRecordDBO,
+  Notes
+} from '~/repositories/noteRepository';
+import { HousingNoteApi } from '~/models/NoteApi';
+import {
+  genEstablishmentApi,
+  genHousingApi,
+  genHousingNoteApi,
+  genUserApi
+} from '~/test/testFixtures';
+import {
+  formatHousingRecordApi,
+  Housing
+} from '~/repositories/housingRepository';
+import {
+  Establishments,
+  formatEstablishmentApi
+} from '~/repositories/establishmentRepository';
+import { formatUserApi, Users } from '~/repositories/userRepository';
+
+describe('Note repository', () => {
+  describe('createByHousing', () => {
+    const establishment = genEstablishmentApi();
+    const creator = genUserApi(establishment.id);
+    const housing = genHousingApi();
+    const note: HousingNoteApi = genHousingNoteApi(creator, housing);
+
+    beforeAll(async () => {
+      await Establishments().insert(formatEstablishmentApi(establishment));
+      await Users().insert(formatUserApi(creator));
+      await Housing().insert(formatHousingRecordApi(housing));
+
+      await noteRepository.createByHousing(note);
+    });
+
+    it('should create the note', async () => {
+      const actual = await Notes().where({ id: note.id }).first();
+      expect(actual).toStrictEqual<NoteRecordDBO>({
+        id: note.id,
+        content: note.content,
+        note_kind: note.noteKind,
+        created_by: note.createdBy,
+        created_at: note.createdAt,
+        // Weird fields still present in the database
+        contact_kind_deprecated: null,
+        title_deprecated: null
+      });
+    });
+
+    it('should link the note to its housing', async () => {
+      const actual = await HousingNotes()
+        .where({
+          note_id: note.id,
+          housing_id: housing.id,
+          housing_geo_code: housing.geoCode
+        })
+        .first();
+      expect(actual).toBeDefined();
+    });
+  });
+});

--- a/server/src/routers/protected.ts
+++ b/server/src/routers/protected.ts
@@ -247,10 +247,10 @@ router.get(
 );
 
 router.get(
-  '/notes/housing/:housingId',
-  [isUUIDParam('housingId')],
+  '/housing/:id/notes',
+  [isUUIDParam('id')],
   validator.validate,
-  noteController.listByHousingId
+  noteController.findByHousing
 );
 router.post(
   '/housing/:id/notes',

--- a/server/src/routers/protected.ts
+++ b/server/src/routers/protected.ts
@@ -51,13 +51,15 @@ router.post(
   validator.validate,
   housingController.create
 );
-router.get('/housing/count',
+router.get(
+  '/housing/count',
   validatorNext.validate({
     query: schemas.housingFilters
       .concat(sortApi.sortSchema)
       .concat(paginationSchema)
   }),
-housingController.count);
+  housingController.count
+);
 router.get(
   '/housing/:id',
   housingController.getValidators,
@@ -70,7 +72,7 @@ router.post(
   validator.validate,
   housingController.updateList
 );
-// TODO: replace by PUT /housing/:id
+router.put('/housing/:id', housingController.updateNext);
 router.post(
   '/housing/:housingId',
   [param('housingId').isUUID(), ...housingController.updateValidators],

--- a/server/src/routers/protected.ts
+++ b/server/src/routers/protected.ts
@@ -1,6 +1,7 @@
 import fileUpload from 'express-fileupload';
 import Router from 'express-promise-router';
 import { param } from 'express-validator';
+import { object } from 'yup';
 
 import schemas from '@zerologementvacant/schemas';
 import accountController from '~/controllers/accountController';
@@ -20,7 +21,7 @@ import ownerController from '~/controllers/ownerController';
 import ownerProspectController from '~/controllers/ownerProspectController';
 import settingsController from '~/controllers/settingsController';
 import userController from '~/controllers/userController';
-import { jwtCheck, userCheck } from '~/middlewares/auth';
+import { hasRole, jwtCheck, userCheck } from '~/middlewares/auth';
 import { upload } from '~/middlewares/upload';
 import validator from '~/middlewares/validator';
 import { isUUIDParam } from '~/utils/validators';
@@ -28,6 +29,7 @@ import draftController from '~/controllers/draftController';
 import validatorNext from '~/middlewares/validator-next';
 import { paginationSchema } from '~/models/PaginationApi';
 import sortApi from '~/models/SortApi';
+import { UserRoles } from '~/models/UserApi';
 
 const router = Router();
 
@@ -249,6 +251,15 @@ router.get(
   [isUUIDParam('housingId')],
   validator.validate,
   noteController.listByHousingId
+);
+router.post(
+  '/housing/:id/notes',
+  hasRole([UserRoles.Usual, UserRoles.Admin]),
+  validatorNext.validate({
+    params: object({ id: schemas.id }),
+    body: schemas.notePayload
+  }),
+  noteController.createByHousing
 );
 
 // TODO: rework and merge this API with the User API

--- a/server/src/routers/protected.ts
+++ b/server/src/routers/protected.ts
@@ -74,7 +74,15 @@ router.post(
   validator.validate,
   housingController.updateList
 );
-router.put('/housing/:id', housingController.updateNext);
+router.put(
+  '/housing/:id',
+  hasRole([UserRoles.Usual, UserRoles.Admin]),
+  validatorNext.validate({
+    params: object({ id: schemas.id }),
+    body: schemas.housingUpdatePayload
+  }),
+  housingController.updateNext
+);
 router.post(
   '/housing/:housingId',
   [param('housingId').isUUID(), ...housingController.updateValidators],

--- a/yarn.lock
+++ b/yarn.lock
@@ -10854,6 +10854,7 @@ __metadata:
     lodash: "npm:^4.17.21"
     nodemon: "npm:^3.1.7"
     rimraf: "npm:^5.0.10"
+    ts-essentials: "npm:^10.0.2"
     ts-jest: "npm:^29.2.5"
     typescript: "npm:^5.6.2"
   languageName: unknown


### PR DESCRIPTION
- Create a new `AsideNext` based on MUI’s [Drawer](https://mui.com/material-ui/react-drawer/) to replace our custom `Aside`
- Split housing update and note creation
- Add `AppSelectNext` to replace our old `AppSelect`
- Add validation schemas for housing update, note creation and identity
- Add `hasRole` middleware
- Add a `transaction` module to start a transaction throughout several repositories