### PR TITLE
Optimize BAN address processing (Parquet, logging, error handling) – tested locally with prod data, ready for deployment

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -8,7 +8,7 @@ fileignoreconfig:
 - filename: analytics/dagster/src/assets/populate_edited_owners_ban_addresses.py
   checksum: c3a27f2457d2c1cd5f01ef1940c78bc40f8dedb0aff7a5edbc0d1b1e5000f5d3
 - filename: analytics/dagster/src/assets/populate_housings_ban_addresses.py
-  checksum: 66b41821bccc209598ed3d082e5666102edf52ae854b41db3f0b3fe3640657b7
+  checksum: 395de97f41bbcfaa83d31c238f68d9d0f74b903de410dad1d6c0a673d3cb1efd
 - filename: analytics/dagster/src/assets/populate_owners_ban_addresses.py
   checksum: 6d33b062918f2957e659ddf9f63413fe273ab88b34ba31932d8b9cfda996a1f1
 - filename: analytics/dagster/src/resources/ban_config.py

--- a/.talismanrc
+++ b/.talismanrc
@@ -10,7 +10,7 @@ fileignoreconfig:
 - filename: analytics/dagster/src/assets/populate_housings_ban_addresses.py
   checksum: 395de97f41bbcfaa83d31c238f68d9d0f74b903de410dad1d6c0a673d3cb1efd
 - filename: analytics/dagster/src/assets/populate_owners_ban_addresses.py
-  checksum: 6d33b062918f2957e659ddf9f63413fe273ab88b34ba31932d8b9cfda996a1f1
+  checksum: 44ff3bd94c3f4abdd1a9b190eb107e6d2613b6597e9591905344e427412df389
 - filename: analytics/dagster/src/resources/ban_config.py
   checksum: 034c6924978983da0ca5897bb06b64598a5a813dc93d1d9e8f8a62da952d4d22
 - filename: analytics/dagster/src/resources/database_resources.py

--- a/analytics/.gitignore
+++ b/analytics/.gitignore
@@ -6,3 +6,4 @@
 .tmp
 .log
 dagster/logs/event.log
+*.parquet

--- a/analytics/dagster/src/assets/populate_edited_owners_ban_addresses.py
+++ b/analytics/dagster/src/assets/populate_edited_owners_ban_addresses.py
@@ -94,52 +94,44 @@ def send_csv_chunks_to_api(context: AssetExecutionContext, create_csv_chunks_fro
   description="Parse the aggregated CSV from the BAN address API, insert valid owners' addresses into `ban_addresses`, and return the count of processed records.",
   required_resource_keys={"psycopg2_connection"}
 )
-def parse_api_response_and_insert_owners_addresses(context: AssetExecutionContext, send_csv_chunks_to_api):
+def parse_api_response_and_insert_owners_addresses(context, send_csv_chunks_to_api):
     api_df = pd.read_csv(send_csv_chunks_to_api)
 
-    filtered_df = api_df[api_df['result_status'] == 'ok']
-    failed_rows = api_df[api_df['result_status'] != 'ok']
-    context.log.warning(f"Number of owners with failed API results: {len(failed_rows)}")
+    # Filtrage des résultats valides
+    filtered_df = api_df[api_df['result_status'] == 'ok'][['owner_id', 'result_id']].dropna()
 
-    filtered_df = filtered_df.applymap(lambda x: None if pd.isna(x) else x)
-    filtered_df['address_kind'] = "Owner"
+    failed_count = len(api_df) - len(filtered_df)
+    if failed_count > 0:
+        context.log.warning(f"Number of owners with failed API results: {failed_count}")
 
-    with context.resources.psycopg2_connection as conn:
-        with conn.cursor() as cursor:
-            cursor.execute("""
-            CREATE TEMP TABLE temp_ban_addresses (
+    # Utilisation d'une table temporaire pour la mise à jour
+    with context.resources.psycopg2_connection as conn, conn.cursor() as cursor:
+        cursor.execute("""
+            CREATE TEMP TABLE temp_update_ban (
                 ref_id TEXT,
-                house_number TEXT,
-                address TEXT,
-                street TEXT,
-                postal_code TEXT,
-                city TEXT,
-                latitude FLOAT,
-                longitude FLOAT,
-                score FLOAT,
-                ban_id TEXT,
-                address_kind TEXT
-            );
-            """)
+                ban_id TEXT
+            ) ON COMMIT DROP;
+        """)
 
-            buffer = StringIO()
-            filtered_df.to_csv(buffer, sep='\t', header=False, index=False)
-            buffer.seek(0)
-            cursor.copy_from(buffer, 'temp_ban_addresses', sep='\t')
+        buffer = StringIO()
+        filtered_df.to_csv(buffer, sep='\t', header=False, index=False)
+        buffer.seek(0)
 
-            cursor.execute("""
+
+
+        cursor.copy_from(buffer, 'temp_update_ban', sep='\t', columns=['ref_id', 'ban_id'])
+
+        cursor.execute("""
             UPDATE ban_addresses AS ba
             SET ban_id = tba.ban_id
-            FROM temp_ban_addresses AS tba
-            WHERE ba.ref_id = tba.ref_id
-            AND ba.address_kind = tba.address_kind;
-            """)
-            cursor.execute("DROP TABLE temp_ban_addresses;")
+            FROM pg_temp.temp_update_ban AS tba
+            WHERE ba.ref_id = tba.ref_id::uuid;
+        """)
 
         conn.commit()
 
-    context.log.info(f"{len(filtered_df)} valid records inserted successfully.")
+    updated_count = len(filtered_df)
+    context.log.info(f"{updated_count} records updated successfully.")
 
-    return {
-        "metadata": {"num_records": MetadataValue.text(f"{len(filtered_df)} records inserted")}
-    }
+    return {"metadata": {"num_records": MetadataValue.text(f"{updated_count} records updated")}}
+

--- a/analytics/dagster/src/assets/populate_edited_owners_ban_addresses.py
+++ b/analytics/dagster/src/assets/populate_edited_owners_ban_addresses.py
@@ -30,7 +30,7 @@ def owners_with_edited_address(context: AssetExecutionContext):
   description="Split the owners DataFrame into multiple CSV files (chunks), store them to disk, and return the file paths as metadata.",
   required_resource_keys={"ban_config"}
 )
-def create_csv_chunks_from_owners(context: AssetExecutionContext, owners_with_edited_address):
+def create_csv_chunks_from_edited_owners(context: AssetExecutionContext, owners_with_edited_address):
     config = context.resources.ban_config
 
     chunk_size = config.chunk_size
@@ -65,7 +65,7 @@ def create_csv_chunks_from_owners(context: AssetExecutionContext, owners_with_ed
   description="Send each CSV chunk to the BAN address API, aggregate valid responses into a single CSV, and return the path to the aggregated CSV file.",
   required_resource_keys={"ban_config"}
 )
-def send_csv_chunks_to_api(context: AssetExecutionContext, create_csv_chunks_from_owners):
+def send_csv_chunks_to_api(context: AssetExecutionContext, create_csv_chunks_from_edited_owners):
     config = context.resources.ban_config
 
     aggregated_file_path = f"{config.csv_file_path}_aggregated.csv"
@@ -73,7 +73,7 @@ def send_csv_chunks_to_api(context: AssetExecutionContext, create_csv_chunks_fro
     with open(aggregated_file_path, 'w') as aggregated_file:
         first_file = True
 
-        for file_path in create_csv_chunks_from_owners:
+        for file_path in create_csv_chunks_from_edited_owners:
             files = {'data': open(file_path, 'rb')}
             data = {'columns': 'address_dgfip', 'citycode': 'geo_code'}
 
@@ -94,7 +94,7 @@ def send_csv_chunks_to_api(context: AssetExecutionContext, create_csv_chunks_fro
   description="Parse the aggregated CSV from the BAN address API, insert valid owners' addresses into `ban_addresses`, and return the count of processed records.",
   required_resource_keys={"psycopg2_connection"}
 )
-def parse_api_response_and_insert_owners_addresses(context, send_csv_chunks_to_api):
+def parse_api_response_and_insert_edited_owners_addresses(context, send_csv_chunks_to_api):
     api_df = pd.read_csv(send_csv_chunks_to_api)
 
     filtered_df = api_df[api_df['result_status'] == 'ok'][['owner_id', 'result_id']].dropna()

--- a/analytics/dagster/src/assets/populate_owners_ban_addresses.py
+++ b/analytics/dagster/src/assets/populate_owners_ban_addresses.py
@@ -6,6 +6,7 @@ import pyarrow.parquet as pq
 import pyarrow as pa
 import os
 from datetime import datetime
+import time
 
 @asset(
   description="Return owners with no BAN address or a non-validated BAN address (score < 1).",
@@ -98,7 +99,6 @@ def process_parquet_chunks_with_api(context: AssetExecutionContext, split_parque
     aggregated_file_path = "owners_without_address_aggregated.parquet"
     parquet_writer = None
 
-
     for file_path in split_parquet_owners_without_address:
         try:
             table = pq.read_table(file_path)
@@ -111,6 +111,7 @@ def process_parquet_chunks_with_api(context: AssetExecutionContext, split_parque
             files = {'data': ('chunk.csv', csv_buffer, 'text/csv')}
             data = {'columns': 'address_dgfip', 'citycode': 'geo_code'}
             response = requests.post(config.api_url, files=files, data=data)
+            time.sleep(5)
 
             if response.status_code == 200:
                 api_data = pd.read_csv(BytesIO(response.content))

--- a/analytics/dagster/src/assets/populate_owners_ban_addresses.py
+++ b/analytics/dagster/src/assets/populate_owners_ban_addresses.py
@@ -1,13 +1,18 @@
 from dagster import asset, MetadataValue, AssetExecutionContext, Output, op
 import requests
 import pandas as pd
-from io import StringIO
+from io import StringIO, BytesIO
+import pyarrow.parquet as pq
+import pyarrow as pa
+import os
+from datetime import datetime
 
 @asset(
   description="Return owners with no BAN address or a non-validated BAN address (score < 1).",
   required_resource_keys={"psycopg2_connection"}
 )
 def owners_without_address(context: AssetExecutionContext):
+    output_file="owners_without_address.parquet"
     query = """
     SELECT
         o.id as owner_id,
@@ -15,141 +20,226 @@ def owners_without_address(context: AssetExecutionContext):
     FROM owners o
     LEFT JOIN ban_addresses ba ON o.id = ba.ref_id
     WHERE (ba.ref_id IS NULL)  -- Propriétaires sans adresse
-       OR (ba.ref_id IS NOT NULL AND ba.address_kind = 'Owner' AND ba.score < 1);  -- Propriétaires avec adresse non validée par Stéphanie
+       OR (ba.ref_id IS NOT NULL AND ba.address_kind = 'Owner' AND ba.score < 1);  -- Propriétaires avec adresse non validée
     """
 
     try:
         with context.resources.psycopg2_connection as conn:
-            df = pd.read_sql(query, conn)
+            parquet_writer = None
+            chunksize = 1_000
+
+            for chunk in pd.read_sql_query(query, conn, chunksize=chunksize):
+                table = pa.Table.from_pandas(chunk)
+
+                if parquet_writer is None:
+                    parquet_writer = pq.ParquetWriter(output_file, table.schema)
+
+                parquet_writer.write_table(table)
+
+            if parquet_writer is not None:
+                parquet_writer.close()
+
     except Exception as e:
         context.log.error(f"Error executing query: {e}")
         raise
 
-    return df
+    context.log.info(f"Data saved to {output_file}")
+    return Output(value=output_file, metadata={"file_path": MetadataValue.text(output_file)})
 
 @asset(
-  description="Split the owners DataFrame into multiple CSV files (chunks), store them to disk, and return the file paths as metadata.",
-  required_resource_keys={"ban_config"}
+    description="Split the owners Parquet file into multiple smaller Parquet files and store them to disk.",
+    required_resource_keys={"ban_config"}
 )
-def create_csv_chunks_from_owners(context: AssetExecutionContext, owners_without_address):
+def split_parquet_owners_without_address(context: AssetExecutionContext, owners_without_address: str):
     config = context.resources.ban_config
 
     chunk_size = config.chunk_size
     max_files = config.max_files
     disable_max_files = config.disable_max_files
 
-    num_chunks = len(owners_without_address) // chunk_size + 1
-
-    if not disable_max_files:
-        num_chunks = min(num_chunks, max_files)
-
     file_paths = []
+    chunk_count = 0
 
-    for i in range(num_chunks):
-        start_idx = i * chunk_size
-        end_idx = (i + 1) * chunk_size
-        chunk = owners_without_address.iloc[start_idx:end_idx]
+    if not os.path.exists(owners_without_address):
+        context.log.error(f"File not found: {owners_without_address}")
+        raise FileNotFoundError(f"File not found: {owners_without_address}")
 
-        chunk_file_path = f"{config.csv_file_path}_part_{i+1}.csv"
-        file_paths.append(chunk_file_path)
+    try:
+        parquet_file = pq.ParquetFile(owners_without_address)
 
-        chunk.to_csv(chunk_file_path, index=False, columns=["owner_id", "address_dgfip"])
+        for batch in parquet_file.iter_batches(batch_size=chunk_size):
+            if not disable_max_files and chunk_count >= max_files:
+                break
 
-        context.log.info(f"CSV file created: {chunk_file_path}")
-        context.log.info(f"Preview of the CSV file:\n{chunk.head()}")
-        context.log.info(f"Generated {i + 1} out of {num_chunks} files")
+            chunk_table = pa.Table.from_batches([batch])
+            chunk_file_path = f"owners_without_address_part_{chunk_count+1}.parquet"
+            file_paths.append(chunk_file_path)
+
+            pq.write_table(chunk_table, chunk_file_path, compression='snappy')
+
+            context.log.info(f"Parquet file created: {chunk_file_path}")
+            context.log.info(f"Generated {chunk_count + 1} Parquet files")
+
+            chunk_count += 1
+
+    except Exception as e:
+        context.log.error(f"Error processing Parquet chunks: {e}")
+        raise
 
     return Output(value=file_paths, metadata={"file_paths": MetadataValue.text(", ".join(file_paths))})
 
-
 @asset(
-  description="Send each CSV chunk to the BAN address API, aggregate valid responses into a single CSV, and return the path to the aggregated CSV file.",
-  required_resource_keys={"ban_config"}
+    description="Send each Parquet chunk to the BAN address API, aggregate valid responses into a single Parquet file, and return the path to the aggregated file.",
+    required_resource_keys={"ban_config"}
 )
-def send_csv_chunks_to_api(context: AssetExecutionContext, create_csv_chunks_from_owners):
+def process_parquet_chunks_with_api(context: AssetExecutionContext, split_parquet_owners_without_address):
     config = context.resources.ban_config
 
-    aggregated_file_path = f"{config.csv_file_path}_aggregated.csv"
+    aggregated_file_path = "owners_without_address_aggregated.parquet"
+    parquet_writer = None
 
-    with open(aggregated_file_path, 'w') as aggregated_file:
-        first_file = True
 
-        for file_path in create_csv_chunks_from_owners:
-            files = {'data': open(file_path, 'rb')}
+    for file_path in split_parquet_owners_without_address:
+        try:
+            table = pq.read_table(file_path)
+            df = table.to_pandas()
+
+            csv_buffer = StringIO()
+            df.to_csv(csv_buffer, index=False)
+            csv_buffer.seek(0)
+
+            files = {'data': ('chunk.csv', csv_buffer, 'text/csv')}
             data = {'columns': 'address_dgfip', 'citycode': 'geo_code'}
-
             response = requests.post(config.api_url, files=files, data=data)
 
             if response.status_code == 200:
-                api_data = pd.read_csv(StringIO(response.text))
-                api_data.to_csv(aggregated_file, mode='a', index=False, header=first_file)
-                first_file = False
+                api_data = pd.read_csv(BytesIO(response.content))
+
+                table = pa.Table.from_pandas(api_data)
+
+                if parquet_writer is None:
+                    parquet_writer = pq.ParquetWriter(aggregated_file_path, table.schema)
+
+                parquet_writer.write_table(table)
 
                 context.log.info(f"Processed file: {file_path}")
-            else:
-                raise Exception(f"API request failed with status code {response.status_code}")
 
-    return aggregated_file_path
+            else:
+                context.log.warning(f"API request failed for {file_path} with status code {response.status_code}")
+
+        except Exception as e:
+            context.log.error(f"Error processing file {file_path}: {e}")
+
+    if parquet_writer is not None:
+        parquet_writer.close()
+
+    return Output(value=aggregated_file_path, metadata={"file_path": MetadataValue.path(aggregated_file_path)})
 
 @asset(
-  description="Parse the aggregated CSV from the BAN address API, insert valid owners' addresses into `ban_addresses`, and return the count of processed records.",
-  required_resource_keys={"psycopg2_connection"}
+    description="Parse the aggregated Parquet file from the BAN address API, insert valid owners' addresses into `ban_addresses`, and return the count of processed records.",
+    required_resource_keys={"psycopg2_connection"}
 )
-def parse_api_response_and_insert_owners_addresses(context: AssetExecutionContext, send_csv_chunks_to_api):
-    api_df = pd.read_csv(send_csv_chunks_to_api)
+def parse_api_response_and_insert_owners_addresses(context: AssetExecutionContext, process_parquet_chunks_with_api):
+    parquet_file = process_parquet_chunks_with_api
 
-    filtered_df = api_df[api_df['result_status'] == 'ok']
-    failed_rows = api_df[api_df['result_status'] != 'ok']
-    context.log.warning(f"Number of owners with failed API results: {len(failed_rows)}")
+    if not os.path.exists(parquet_file):
+        context.log.error(f"File not found: {parquet_file}")
+        raise FileNotFoundError(f"File not found: {parquet_file}")
 
-    filtered_df = filtered_df.applymap(lambda x: None if pd.isna(x) else x)
-    filtered_df['address_kind'] = "Owner"
+    total_inserted = 0
+    total_failed = 0
 
-    with context.resources.psycopg2_connection as conn:
-        with conn.cursor() as cursor:
+    try:
+        with context.resources.psycopg2_connection as conn, conn.cursor() as cursor:
             cursor.execute("""
-            CREATE TEMP TABLE temp_ban_addresses (
-                ref_id TEXT,
-                house_number TEXT,
-                address TEXT,
-                street TEXT,
-                postal_code TEXT,
-                city TEXT,
-                latitude FLOAT,
-                longitude FLOAT,
-                score FLOAT,
-                ban_id TEXT,
-                address_kind TEXT
-            );
+                CREATE TEMP TABLE temp_ban_addresses (
+                    ref_id UUID,
+                    house_number TEXT,
+                    address TEXT,
+                    street TEXT,
+                    postal_code TEXT,
+                    city TEXT,
+                    latitude FLOAT,
+                    longitude FLOAT,
+                    score FLOAT,
+                    ban_id TEXT,
+                    address_kind TEXT,
+                    last_updated_at TIMESTAMP
+                ) ON COMMIT DROP;
             """)
 
-            buffer = StringIO()
-            filtered_df.to_csv(buffer, sep='\t', header=False, index=False)
-            buffer.seek(0)
-            cursor.copy_from(buffer, 'temp_ban_addresses', sep='\t')
+            parquet_file = pq.ParquetFile(parquet_file)
+            for batch in parquet_file.iter_batches(batch_size=1000):
+                chunk_df = pa.Table.from_batches([batch]).to_pandas()
 
-            cursor.execute("""
-            INSERT INTO ban_addresses (ref_id, house_number, address, street, postal_code, city, latitude, longitude, score, ban_id, address_kind)
-            SELECT ref_id, house_number, address, street, postal_code, city, latitude, longitude, score, ban_id, address_kind
-            FROM temp_ban_addresses
-            ON CONFLICT (ref_id, address_kind)
-            DO UPDATE SET
-                house_number = EXCLUDED.house_number,
-                address = EXCLUDED.address,
-                street = EXCLUDED.street,
-                postal_code = EXCLUDED.postal_code,
-                city = EXCLUDED.city,
-                latitude = EXCLUDED.latitude,
-                longitude = EXCLUDED.longitude,
-                score = EXCLUDED.score,
-                ban_id = EXCLUDED.ban_id;
-            """)
-            cursor.execute("DROP TABLE temp_ban_addresses;")
+                valid_df = chunk_df[chunk_df['result_status'] == 'ok'].copy()
+                failed_count = len(chunk_df) - len(valid_df)
+                total_failed += failed_count
 
-        conn.commit()
+                if failed_count > 0:
+                    context.log.warning(f"Batch: {failed_count} owners with failed API results")
 
-    context.log.info(f"{len(filtered_df)} valid records inserted successfully.")
+                valid_df['address_kind'] = "Owner"
 
-    return {
-        "metadata": {"num_records": MetadataValue.text(f"{len(filtered_df)} records inserted")}
-    }
+                valid_df = valid_df.rename(columns={
+                    'owner_id': 'ref_id',
+                    'result_housenumber': 'house_number',
+                    'result_label': 'address',
+                    'result_street': 'street',
+                    'result_postcode': 'postal_code',
+                    'result_city': 'city',
+                    'latitude': 'latitude',
+                    'longitude': 'longitude',
+                    'result_score': 'score',
+                    'result_id': 'ban_id',
+                    'address_kind': 'address_kind'
+                })
+                valid_df['last_updated_at'] = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+
+                columns = [
+                    'ref_id', 'house_number', 'address', 'street', 'postal_code', 'city',
+                    'latitude', 'longitude', 'score', 'ban_id', 'address_kind', 'last_updated_at'
+                ]
+
+                valid_df = valid_df[columns]
+
+                if not valid_df.empty:
+                    buffer = StringIO()
+                    valid_df.to_csv(buffer, sep='\t', header=False, index=False)
+                    buffer.seek(0)
+
+                    cursor.copy_from(buffer, 'temp_ban_addresses', sep='\t')
+
+                    cursor.execute("""
+                        INSERT INTO ban_addresses (ref_id, house_number, address, street, postal_code, city, latitude, longitude, score, ban_id, address_kind, last_updated_at)
+                        SELECT ref_id, house_number, address, street, postal_code, city, latitude, longitude, score, ban_id, address_kind, last_updated_at
+                        FROM temp_ban_addresses
+                        ON CONFLICT (ref_id, address_kind)
+                        DO UPDATE SET
+                            house_number = EXCLUDED.house_number,
+                            address = EXCLUDED.address,
+                            street = EXCLUDED.street,
+                            postal_code = EXCLUDED.postal_code,
+                            city = EXCLUDED.city,
+                            latitude = EXCLUDED.latitude,
+                            longitude = EXCLUDED.longitude,
+                            score = EXCLUDED.score,
+                            ban_id = EXCLUDED.ban_id,
+                            last_updated_at = EXCLUDED.last_updated_at;
+                    """)
+
+                    total_inserted += len(valid_df)
+
+            conn.commit()
+
+    except Exception as e:
+        context.log.error(f"Error processing API response: {e}")
+        raise
+
+    context.log.info(f"Total records inserted: {total_inserted}")
+    context.log.info(f"Total failed records: {total_failed}")
+
+    return Output(
+        value={"inserted_records": total_inserted, "failed_records": total_failed},
+        metadata={"num_records": MetadataValue.text(f"{total_inserted} records inserted, {total_failed} failed")}
+    )

--- a/analytics/dagster/src/jobs/edited_owners_ban_addresses_job.py
+++ b/analytics/dagster/src/jobs/edited_owners_ban_addresses_job.py
@@ -1,12 +1,11 @@
 from dagster import job
 from dagster.src.assets.populate_edited_owners_ban_addresses import owners_with_edited_address
 from dagster.src.resources.ban_config import ban_config_resource
-from dagster.src.resources import sqlalchemy_engine_resource, psycopg2_connection_resource
+from dagster.src.resources import psycopg2_connection_resource
 
 @job(
     resource_defs={
         "ban_config": ban_config_resource,
-        "sqlalchemy_engine": sqlalchemy_engine_resource,
         "psycopg2_connection": psycopg2_connection_resource,
     }
 )

--- a/analytics/dagster/src/jobs/housings_ban_addresses_job.py
+++ b/analytics/dagster/src/jobs/housings_ban_addresses_job.py
@@ -1,12 +1,11 @@
 from dagster import job
 from dagster.src.assets.populate_owners_ban_addresses import owners_without_address
 from dagster.src.resources.ban_config import ban_config_resource
-from dagster.src.resources import sqlalchemy_engine_resource, psycopg2_connection_resource
+from dagster.src.resources import psycopg2_connection_resource
 
 @job(
     resource_defs={
         "ban_config": ban_config_resource,
-        "sqlalchemy_engine": sqlalchemy_engine_resource,
         "psycopg2_connection_resource": psycopg2_connection_resource,
     }
 )

--- a/analytics/dagster/src/jobs/owners_ban_addresses_job.py
+++ b/analytics/dagster/src/jobs/owners_ban_addresses_job.py
@@ -1,12 +1,11 @@
 from dagster import job
 from dagster.src.assets.populate_owners_ban_addresses import owners_without_address
 from dagster.src.resources.ban_config import ban_config_resource
-from dagster.src.resources import sqlalchemy_engine_resource, psycopg2_connection_resource
+from dagster.src.resources import psycopg2_connection_resource
 
 @job(
     resource_defs={
         "ban_config": ban_config_resource,
-        "sqlalchemy_engine": sqlalchemy_engine_resource,
         "psycopg2_connection": psycopg2_connection_resource,
     }
 )

--- a/analytics/dagster/src/requirements.txt
+++ b/analytics/dagster/src/requirements.txt
@@ -3,4 +3,4 @@ dlt[duckdb]>=0.4.11
 dlt[filesystem]
 dlt[parquet]
 s3fs
-
+pyarrow

--- a/analytics/dagster/src/resources/database_resources.py
+++ b/analytics/dagster/src/resources/database_resources.py
@@ -1,5 +1,4 @@
 from dagster import resource, Field, String
-from sqlalchemy import create_engine
 import psycopg2
 
 from ..config import Config
@@ -24,20 +23,3 @@ def psycopg2_connection_resource(init_context):
         yield conn
     finally:
         conn.close()
-
-@resource(config_schema={
-    "db_name": Field(String, default_value=Config.POSTGRES_PRODUCTION_DB_NAME),
-    "db_user": Field(String, default_value=Config.POSTGRES_PRODUCTION_USER),
-    "db_password": Field(String, default_value=Config.POSTGRES_PRODUCTION_PASSWORD),
-    "db_host": Field(String, default_value=Config.POSTGRES_PRODUCTION_DB),
-    "db_port": Field(String, default_value=Config.POSTGRES_PRODUCTION_PORT),
-})
-def sqlalchemy_engine_resource(init_context):
-    config = init_context.resource_config
-    engine = create_engine(
-        f'postgresql://{config["db_user"]}:{config["db_password"]}@{config["db_host"]}:{config["db_port"]}/{config["db_name"]}'
-    )
-    try:
-        yield engine
-    finally:
-        engine.dispose()


### PR DESCRIPTION
This pull request includes several changes to improve the handling of BAN address data. The changes focus on updating file handling, modifying function implementations, and enhancing logging and error handling.

### File Handling Improvements:
* Switched from CSV to Parquet format for better performance and efficiency in `populate_owners_ban_addresses.py`.
* Added `.parquet` to `.gitignore` to exclude Parquet files from version control.

### Function Implementations:
* Updated function names to better reflect their purpose.
* Modified the `parse_api_response_and_insert_owners_addresses` function to handle Parquet files and improved the database insertion logic.

### Logging and Error Handling:
* Enhanced logging to provide more detailed information about the process and errors.
* Improved error handling for file operations and API requests.

### Configuration Updates:
* Updated checksums in .talismanrc to reflect changes in the analytics/dagster/src/assets directory.

### Rate Limiting Mitigation:

* Added a 5-second delay after each API call in the owners job to prevent rate limiting issues and ensure stable processing.