### PR TITLE
Fix: merge owner processing steps and handle BAN ID updates

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -1,8 +1,8 @@
 fileignoreconfig:
 - filename: analytics/dagster/src/assets/populate_edited_owners_ban_addresses.py
-  checksum: a8d5d783384c35462f4d2bb022976c9476cf23effc720ba3ecf46d08bae07387
+  checksum: 807543f1702293bc91e3d6c0646f74d1686b824cbbf87ae6bf007e3aa9b8d74a
 - filename: analytics/dagster/src/assets/populate_owners_ban_addresses.py
-  checksum: 98cbd0849c6325704a4105e764c79b622c228bbbcd010fb0a554948ab1832fa4
+  checksum: daf7e5430b47f26bc8b49c5cc2e23fbfd3dea4594d398c128bc77a5b963aa227
 version: ""
 167b15b2bde
 - filename: analytics/dagster/src/assets/dwh/ingest/ingest_postgres_asset.py

--- a/analytics/dagster/src/assets/populate_edited_owners_ban_addresses.py
+++ b/analytics/dagster/src/assets/populate_edited_owners_ban_addresses.py
@@ -1,139 +1,83 @@
-from dagster import asset, MetadataValue, AssetExecutionContext, Output, op
+from dagster import asset, MetadataValue, AssetExecutionContext, Output
 import requests
 import pandas as pd
-from io import StringIO
+from io import StringIO, BytesIO
+from datetime import datetime
+import time
 
 @asset(
-  description="Return edited owners (score = 1).",
-  required_resource_keys={"psycopg2_connection", "ban_config"}
+    description="Retrieve and process owners with edited BAN addresses, sending them directly to the API and updating valid responses into the database.",
+    required_resource_keys={"psycopg2_connection", "ban_config"}
 )
-def owners_with_edited_address(context: AssetExecutionContext):
+def process_and_update_edited_owners(context: AssetExecutionContext):
     config = context.resources.ban_config
-    chunk_size = config.chunk_size
-    max_files = config.max_files
-    disable_max_files = config.disable_max_files
-    query = f"""
-    SELECT
-        o.id as owner_id,
-        array_to_string(o.address_dgfip, ' ') as address_dgfip
+    total_updated = 0
+    total_failed = 0
+
+    query = """
+    SELECT o.id as owner_id, array_to_string(o.address_dgfip, ' ') as address_dgfip
     FROM owners o
     LEFT JOIN ban_addresses ba ON o.id = ba.ref_id
-    WHERE ba.ref_id IS NOT NULL AND ba.score = 1  -- Propriétaires avec adresse éditée par Stéphanie
-    {"LIMIT " + str(max_files * chunk_size) if not disable_max_files else ""}
+    WHERE ba.ban_id IS NULL AND ba.score = 1;
     """
-    context.log.info(f"Limit applied: {'LIMIT ' + str(max_files * chunk_size) if not disable_max_files else 'No limit'}")
 
     try:
-        with context.resources.psycopg2_connection as conn:
-            df = pd.read_sql(query, conn)
-    except Exception as e:
-        context.log.error(f"Error executing query: {e}")
-        raise
+        with context.resources.psycopg2_connection as conn, conn.cursor() as cursor:
+            df = pd.read_sql_query(query, conn)
+            if df.empty:
+                context.log.info("No owners to process.")
+                return Output(value={"updated_records": 0, "failed_records": 0}, metadata={"num_records": MetadataValue.text("0 records updated, 0 failed")})
 
-    return df
+            csv_buffer = StringIO()
+            df.to_csv(csv_buffer, index=False)
+            csv_buffer.seek(0)
 
-@asset(
-  description="Split the owners DataFrame into multiple CSV files (chunks), store them to disk, and return the file paths as metadata.",
-  required_resource_keys={"ban_config"}
-)
-def create_csv_chunks_from_edited_owners(context: AssetExecutionContext, owners_with_edited_address):
-    config = context.resources.ban_config
-
-    chunk_size = config.chunk_size
-    max_files = config.max_files
-    disable_max_files = config.disable_max_files
-
-    num_chunks = len(owners_with_edited_address) // chunk_size + 1
-
-    if not disable_max_files:
-        num_chunks = min(num_chunks, max_files)
-
-    file_paths = []
-
-    for i in range(num_chunks):
-        start_idx = i * chunk_size
-        end_idx = (i + 1) * chunk_size
-        chunk = owners_with_edited_address.iloc[start_idx:end_idx]
-
-        chunk_file_path = f"{config.csv_file_path}_part_{i+1}.csv"
-        file_paths.append(chunk_file_path)
-
-        chunk.to_csv(chunk_file_path, index=False, columns=["owner_id", "address_dgfip"])
-
-        context.log.info(f"CSV file created: {chunk_file_path}")
-        context.log.info(f"Preview of the CSV file:\n{chunk.head()}")
-        context.log.info(f"Generated {i + 1} out of {num_chunks} files")
-
-    return Output(value=file_paths, metadata={"file_paths": MetadataValue.text(", ".join(file_paths))})
-
-
-@asset(
-  description="Send each CSV chunk to the BAN address API, aggregate valid responses into a single CSV, and return the path to the aggregated CSV file.",
-  required_resource_keys={"ban_config"}
-)
-def send_csv_chunks_to_api(context: AssetExecutionContext, create_csv_chunks_from_edited_owners):
-    config = context.resources.ban_config
-
-    aggregated_file_path = f"{config.csv_file_path}_aggregated.csv"
-
-    with open(aggregated_file_path, 'w') as aggregated_file:
-        first_file = True
-
-        for file_path in create_csv_chunks_from_edited_owners:
-            files = {'data': open(file_path, 'rb')}
+            files = {'data': ('owners.csv', csv_buffer, 'text/csv')}
             data = {'columns': 'address_dgfip', 'citycode': 'geo_code'}
-
             response = requests.post(config.api_url, files=files, data=data)
 
-            if response.status_code == 200:
-                api_data = pd.read_csv(StringIO(response.text))
-                api_data.to_csv(aggregated_file, mode='a', index=False, header=first_file)
-                first_file = False
+            if response.status_code != 200:
+                context.log.warning(f"API request failed with status code {response.status_code}")
+                return Output(value={"updated_records": 0, "failed_records": len(df)}, metadata={"num_records": MetadataValue.text(f"0 records updated, {len(df)} failed")})
 
-                context.log.info(f"Processed file: {file_path}")
-            else:
-                raise Exception(f"API request failed with status code {response.status_code}")
+            api_data = pd.read_csv(BytesIO(response.content))
+            valid_df = api_data[api_data['result_status'] == 'ok'][['owner_id', 'result_id']].dropna()
+            failed_count = len(api_data) - len(valid_df)
+            total_failed += failed_count
 
-    return aggregated_file_path
+            if failed_count > 0:
+                context.log.warning(f"Number of owners with failed API results: {failed_count}")
 
-@asset(
-  description="Parse the aggregated CSV from the BAN address API, insert valid owners' addresses into `ban_addresses`, and return the count of processed records.",
-  required_resource_keys={"psycopg2_connection"}
-)
-def parse_api_response_and_insert_edited_owners_addresses(context, send_csv_chunks_to_api):
-    api_df = pd.read_csv(send_csv_chunks_to_api)
+            if not valid_df.empty:
+                cursor.execute("""
+                    CREATE TEMP TABLE temp_update_ban (
+                        ref_id TEXT,
+                        ban_id TEXT
+                    ) ON COMMIT DROP;
+                """)
 
-    filtered_df = api_df[api_df['result_status'] == 'ok'][['owner_id', 'result_id']].dropna()
+                buffer = StringIO()
+                valid_df.to_csv(buffer, sep='\t', header=False, index=False)
+                buffer.seek(0)
+                cursor.copy_from(buffer, 'temp_update_ban', sep='\t', columns=['ref_id', 'ban_id'])
 
-    failed_count = len(api_df) - len(filtered_df)
-    if failed_count > 0:
-        context.log.warning(f"Number of owners with failed API results: {failed_count}")
+                cursor.execute("""
+                    UPDATE ban_addresses AS ba
+                    SET ban_id = tba.ban_id
+                    FROM pg_temp.temp_update_ban AS tba
+                    WHERE ba.ref_id = tba.ref_id::uuid;
+                """)
+                conn.commit()
+                total_updated += len(valid_df)
 
-    with context.resources.psycopg2_connection as conn, conn.cursor() as cursor:
-        cursor.execute("""
-            CREATE TEMP TABLE temp_update_ban (
-                ref_id TEXT,
-                ban_id TEXT
-            ) ON COMMIT DROP;
-        """)
+            context.log.info(f"Total records updated: {total_updated}")
+            context.log.info(f"Total failed records: {total_failed}")
 
-        buffer = StringIO()
-        filtered_df.to_csv(buffer, sep='\t', header=False, index=False)
-        buffer.seek(0)
+            return Output(
+                value={"updated_records": total_updated, "failed_records": total_failed},
+                metadata={"num_records": MetadataValue.text(f"{total_updated} records updated, {total_failed} failed")}
+            )
 
-        cursor.copy_from(buffer, 'temp_update_ban', sep='\t', columns=['ref_id', 'ban_id'])
-
-        cursor.execute("""
-            UPDATE ban_addresses AS ba
-            SET ban_id = tba.ban_id
-            FROM pg_temp.temp_update_ban AS tba
-            WHERE ba.ref_id = tba.ref_id::uuid;
-        """)
-
-        conn.commit()
-
-    updated_count = len(filtered_df)
-    context.log.info(f"{updated_count} records updated successfully.")
-
-    return {"metadata": {"num_records": MetadataValue.text(f"{updated_count} records updated")}}
-
+    except Exception as e:
+        context.log.error(f"Error processing API response and updating data: {e}")
+        raise

--- a/analytics/dagster/src/assets/populate_edited_owners_ban_addresses.py
+++ b/analytics/dagster/src/assets/populate_edited_owners_ban_addresses.py
@@ -18,7 +18,7 @@ def process_and_update_edited_owners(context: AssetExecutionContext):
     SELECT o.id as owner_id, array_to_string(o.address_dgfip, ' ') as address_dgfip
     FROM owners o
     LEFT JOIN ban_addresses ba ON o.id = ba.ref_id
-    WHERE ba.ban_id IS NULL AND ba.score = 1;
+    WHERE (ba.address_kind = 'Owner' AND ba.ban_id IS NULL AND ba.score = 1);
     """
 
     try:

--- a/analytics/dagster/src/assets/populate_owners_ban_addresses.py
+++ b/analytics/dagster/src/assets/populate_owners_ban_addresses.py
@@ -6,172 +6,140 @@ from datetime import datetime
 import time
 
 @asset(
-  description="Retrieve owners with no BAN address or a non-validated BAN address (score < 1) and process them in chunks.",
-  required_resource_keys={"psycopg2_connection", "ban_config"}
-)
-def process_owners_chunks(context: AssetExecutionContext):
-    config = context.resources.ban_config
-    chunk_size = config.chunk_size
-    max_files = config.max_files
-    disable_max_files = config.disable_max_files
-    query = f"""
-    SELECT
-        o.id as owner_id,
-        array_to_string(o.address_dgfip, ' ') as address_dgfip
-    FROM owners o
-    LEFT JOIN ban_addresses ba ON o.id = ba.ref_id
-    WHERE (ba.ref_id IS NULL)  -- Propriétaires sans adresse
-    {"LIMIT " + str(max_files * chunk_size) if not disable_max_files else ""}
-    """
-    context.log.info(f"Limit applied: {'LIMIT ' + str(max_files * chunk_size) if not disable_max_files else 'No limit'}")
-
-    try:
-      with context.resources.psycopg2_connection as conn:
-        chunksize = config.chunk_size
-        chunk_count = 0
-        max_files = config.max_files
-        disable_max_files = config.disable_max_files
-        file_paths = []
-
-        for chunk in pd.read_sql_query(query, conn, chunksize=chunksize):
-          if not disable_max_files and chunk_count >= max_files:
-            break
-
-          chunk_file_path = f"owners_without_address_part_{chunk_count+1}.csv"
-          chunk.to_csv(chunk_file_path, index=False)
-          file_paths.append(chunk_file_path)
-
-          context.log.info(f"CSV file created: {chunk_file_path}")
-          chunk_count += 1
-
-    except Exception as e:
-      context.log.error(f"Error executing query: {e}")
-      raise
-
-    return Output(value=file_paths, metadata={"file_paths": MetadataValue.text(", ".join(file_paths))})
-
-@asset(
-    description="Process CSV chunks with the BAN address API and insert valid responses into the database.",
+    description="Retrieve and process owners without a BAN address in chunks, sending them directly to the API and inserting valid responses into the database.",
     required_resource_keys={"psycopg2_connection", "ban_config"}
 )
-def process_and_insert_owners(context: AssetExecutionContext, process_owners_chunks):
-  config = context.resources.ban_config
-  total_inserted = 0
-  total_failed = 0
-  batch_number = 1
+def process_and_insert_owners(context: AssetExecutionContext):
+    config = context.resources.ban_config
+    chunk_size = config.chunk_size
+    total_inserted = 0
+    total_failed = 0
 
-  try:
-    with context.resources.psycopg2_connection as conn, conn.cursor() as cursor:
-      cursor.execute("""
-        CREATE TEMP TABLE temp_ban_addresses (
-            ref_id UUID,
-            house_number TEXT,
-            address TEXT,
-            street TEXT,
-            postal_code TEXT,
-            city TEXT,
-            latitude FLOAT,
-            longitude FLOAT,
-            score FLOAT,
-            ban_id TEXT,
-            address_kind TEXT,
-            last_updated_at TIMESTAMP
-        ) ON COMMIT DROP;
-      """)
+    query_count = """
+    SELECT COUNT(*) FROM owners o
+    LEFT JOIN ban_addresses ba ON o.id = ba.ref_id
+    WHERE (ba.address_kind = 'Owner' AND ba.ban_id IS NULL);
+    """
 
-      for file_path in process_owners_chunks:
-        try:
-          df = pd.read_csv(file_path)
-          csv_buffer = StringIO()
-          df.to_csv(csv_buffer, index=False)
-          csv_buffer.seek(0)
-
-          files = {'data': ('chunk.csv', csv_buffer, 'text/csv')}
-          data = {'columns': 'address_dgfip', 'citycode': 'geo_code'}
-          response = requests.post(config.api_url, files=files, data=data)
-          time.sleep(1)
-
-          if response.status_code != 200:
-            context.log.warning(f"API request failed with status code {response.status_code}")
-            continue
-
-          api_data = pd.read_csv(BytesIO(response.content))
-          valid_df = api_data[api_data['result_status'] == 'ok'].copy()
-          failed_count = len(api_data) - len(valid_df)
-          total_failed += failed_count
-
-          if failed_count > 0:
-            context.log.warning(f"Batch {batch_number}: {failed_count} housings with failed API results")
-          else:
-            context.log.info(f"Batch {batch_number}: All housings processed successfully")
-
-          valid_df['address_kind'] = "Owner"
-          valid_df = valid_df.rename(columns={
-            'owner_id': 'ref_id',
-            'result_housenumber': 'house_number',
-            'result_label': 'address',
-            'result_street': 'street',
-            'result_postcode': 'postal_code',
-            'result_city': 'city',
-            'latitude': 'latitude',
-            'longitude': 'longitude',
-            'result_score': 'score',
-            'result_id': 'ban_id',
-            'address_kind': 'address_kind'
-          })
-          valid_df['last_updated_at'] = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
-
-          columns = [
-            'ref_id', 'house_number', 'address', 'street', 'postal_code', 'city',
-            'latitude', 'longitude', 'score', 'ban_id', 'address_kind', 'last_updated_at'
-          ]
-          valid_df = valid_df[columns]
-
-          if not valid_df.empty:
-            context.log.warning("Inserting valid records into the database")
-            buffer = StringIO()
-            valid_df.to_csv(buffer, sep='\t', header=False, index=False)
-            buffer.seek(0)
-            cursor.copy_from(buffer, 'temp_ban_addresses', sep='\t')
-
-            cursor.execute("SELECT COUNT(*) FROM temp_ban_addresses;")
-            row_count = cursor.fetchone()[0]
-            context.log.info(f"{row_count} rows inserted into temp_ban_addresses")
+    try:
+        with context.resources.psycopg2_connection as conn, conn.cursor() as cursor:
+            cursor.execute(query_count)
+            total_to_process = cursor.fetchone()[0]
+            context.log.info(f"Total records to process: {total_to_process}")
 
             cursor.execute("""
-              INSERT INTO ban_addresses (ref_id, house_number, address, street, postal_code, city, latitude, longitude, score, ban_id, address_kind, last_updated_at)
-              SELECT ref_id, house_number, address, street, postal_code, city, latitude, longitude, score, ban_id, address_kind, last_updated_at
-              FROM temp_ban_addresses
-              ON CONFLICT (ref_id, address_kind)
-              DO UPDATE SET
-                  house_number = EXCLUDED.house_number,
-                  address = EXCLUDED.address,
-                  street = EXCLUDED.street,
-                  postal_code = EXCLUDED.postal_code,
-                  city = EXCLUDED.city,
-                  latitude = EXCLUDED.latitude,
-                  longitude = EXCLUDED.longitude,
-                  score = EXCLUDED.score,
-                  ban_id = EXCLUDED.ban_id,
-                  last_updated_at = EXCLUDED.last_updated_at;
+                CREATE TEMP TABLE temp_ban_addresses (
+                    ref_id UUID,
+                    house_number TEXT,
+                    address TEXT,
+                    street TEXT,
+                    postal_code TEXT,
+                    city TEXT,
+                    latitude FLOAT,
+                    longitude FLOAT,
+                    score FLOAT,
+                    ban_id TEXT,
+                    address_kind TEXT,
+                    last_updated_at TIMESTAMP
+                ) ON COMMIT PRESERVE ROWS;
             """)
 
-            cursor.execute("""
-                DELETE FROM temp_ban_addresses;
-            """)
-            total_inserted += len(valid_df)
-        except Exception as e:
-          context.log.error(f"Error processing file {file_path}: {e}")
-        batch_number += 1
-      conn.commit()
-  except Exception as e:
-    context.log.error(f"Error processing API response and inserting data: {e}")
-    raise
+            processed = 0
+            while processed < total_to_process:
+                query_data = f"""
+                SELECT o.id as owner_id, array_to_string(o.address_dgfip, ' ') as address_dgfip
+                FROM owners o
+                LEFT JOIN ban_addresses ba ON o.id = ba.ref_id
+                WHERE (ba.address_kind = 'Owner' AND ba.ban_id IS NULL)
+                OFFSET {processed} LIMIT {chunk_size};
+                """
 
-  context.log.info(f"Total records inserted: {total_inserted}")
-  context.log.info(f"Total failed records: {total_failed}")
+                df = pd.read_sql_query(query_data, conn)
+                if df.empty:
+                    break
 
-  return Output(
-      value={"inserted_records": total_inserted, "failed_records": total_failed},
-      metadata={"num_records": MetadataValue.text(f"{total_inserted} records inserted, {total_failed} failed")}
-  )
+                csv_buffer = StringIO()
+                df.to_csv(csv_buffer, index=False)
+                csv_buffer.seek(0)
+
+                files = {'data': ('chunk.csv', csv_buffer, 'text/csv')}
+                data = {'columns': 'address_dgfip', 'citycode': 'geo_code'}
+                response = requests.post(config.api_url, files=files, data=data)
+                time.sleep(1)
+
+                if response.status_code != 200:
+                    context.log.warning(f"API request failed with status code {response.status_code}")
+                    continue
+
+                api_data = pd.read_csv(BytesIO(response.content))
+                valid_df = api_data[api_data['result_status'] == 'ok'].copy()
+                failed_count = len(api_data) - len(valid_df)
+                total_failed += failed_count
+
+                if failed_count > 0:
+                    context.log.warning(f"Batch {processed // chunk_size + 1}: {failed_count} failed API results")
+
+                valid_df['address_kind'] = "Owner"
+                valid_df = valid_df.rename(columns={
+                    'owner_id': 'ref_id',
+                    'result_housenumber': 'house_number',
+                    'result_label': 'address',
+                    'result_street': 'street',
+                    'result_postcode': 'postal_code',
+                    'result_city': 'city',
+                    'latitude': 'latitude',
+                    'longitude': 'longitude',
+                    'result_score': 'score',
+                    'result_id': 'ban_id',
+                    'address_kind': 'address_kind'
+                })
+                valid_df['last_updated_at'] = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+
+                expected_columns = [
+                    'ref_id', 'house_number', 'address', 'street', 'postal_code', 'city',
+                    'latitude', 'longitude', 'score', 'ban_id', 'address_kind', 'last_updated_at'
+                ]
+                valid_df = valid_df.reindex(columns=expected_columns, fill_value='NULL')
+
+                if not valid_df.empty:
+                    context.log.info(f"Valid DF size: {len(valid_df)}")
+                    buffer = StringIO()
+                    valid_df.to_csv(buffer, sep='\t', header=False, index=False, quoting=3)
+                    buffer.seek(0)
+                    cursor.copy_from(buffer, 'temp_ban_addresses', sep='\t', null='NULL', columns=expected_columns)
+
+                    cursor.execute("""
+                        INSERT INTO ban_addresses (ref_id, house_number, address, street, postal_code, city, latitude, longitude, score, ban_id, address_kind, last_updated_at)
+                        SELECT ref_id, house_number, address, street, postal_code, city, latitude, longitude, score, ban_id, address_kind, last_updated_at
+                        FROM temp_ban_addresses
+                        ON CONFLICT (ref_id, address_kind)
+                        DO UPDATE SET
+                            house_number = EXCLUDED.house_number,
+                            address = EXCLUDED.address,
+                            street = EXCLUDED.street,
+                            postal_code = EXCLUDED.postal_code,
+                            city = EXCLUDED.city,
+                            latitude = EXCLUDED.latitude,
+                            longitude = EXCLUDED.longitude,
+                            score = EXCLUDED.score,
+                            ban_id = EXCLUDED.ban_id,
+                            last_updated_at = EXCLUDED.last_updated_at;
+                    """)
+                    conn.commit()
+                    cursor.execute("DELETE FROM temp_ban_addresses;")
+                    total_inserted += len(valid_df)
+
+                processed += chunk_size
+                context.log.info(f"Processed {processed}/{total_to_process} records")
+
+    except Exception as e:
+        context.log.error(f"Error processing API response and inserting data: {e}")
+        raise
+
+    context.log.info(f"Total records inserted: {total_inserted}")
+    context.log.info(f"Total failed records: {total_failed}")
+
+    return Output(
+        value={"inserted_records": total_inserted, "failed_records": total_failed},
+        metadata={"num_records": MetadataValue.text(f"{total_inserted} records inserted, {total_failed} failed")}
+    )

--- a/analytics/dagster/src/assets/populate_owners_ban_addresses.py
+++ b/analytics/dagster/src/assets/populate_owners_ban_addresses.py
@@ -18,7 +18,7 @@ def process_and_insert_owners(context: AssetExecutionContext):
     query_count = """
     SELECT COUNT(*) FROM owners o
     LEFT JOIN ban_addresses ba ON o.id = ba.ref_id
-    WHERE (ba.address_kind = 'Owner' AND ba.ban_id IS NULL);
+    WHERE (ba.address_kind = 'Owner' AND ba.ban_id IS NULL AND ba.score < 1);
     """
 
     try:

--- a/analytics/dagster/src/definitions.py
+++ b/analytics/dagster/src/definitions.py
@@ -24,8 +24,8 @@ import dagster
 from .project import dbt_project
 from .assets import production_dbt
 
-from .assets.populate_owners_ban_addresses import process_owners_chunks, process_and_insert_owners
-from .assets.populate_edited_owners_ban_addresses import owners_with_edited_address, create_csv_chunks_from_edited_owners, send_csv_chunks_to_api, parse_api_response_and_insert_edited_owners_addresses
+from .assets.populate_owners_ban_addresses import process_and_insert_owners
+from .assets.populate_edited_owners_ban_addresses import process_and_update_edited_owners
 from .assets.populate_housings_ban_addresses import housings_without_address_csv, process_housings_with_api
 from .resources.ban_config import ban_config_resource
 from .resources.database_resources import psycopg2_connection_resource
@@ -91,7 +91,6 @@ yearly_ff_refresh_schedule = ScheduleDefinition(
 owners_asset_job = define_asset_job(
     name="populate_owners_addresses",
     selection=AssetSelection.assets(
-        "process_owners_chunks",
         "process_and_insert_owners",
     ),
 )
@@ -99,10 +98,7 @@ owners_asset_job = define_asset_job(
 edited_owners_asset_job = define_asset_job(
     name="populate_edited_owners_addresses",
     selection=AssetSelection.assets(
-        "owners_with_edited_address",
-        "create_csv_chunks_from_edited_owners",
-        "send_csv_chunks_to_api",
-        "parse_api_response_and_insert_edited_owners_addresses",
+        "process_and_update_edited_owners",
     ),
 )
 
@@ -120,8 +116,8 @@ defs = Definitions(
         # dagster_production_assets,
         # dagster_notion_assets,
         # dagster_notion_assets,
-        process_owners_chunks, process_and_insert_owners,
-        owners_with_edited_address, create_csv_chunks_from_edited_owners, send_csv_chunks_to_api, parse_api_response_and_insert_edited_owners_addresses,
+        process_and_insert_owners,
+        process_and_update_edited_owners,
         housings_without_address_csv, process_housings_with_api,
         *dwh_assets,
         *dbt_analytics_assets,


### PR DESCRIPTION
This pull request includes significant updates to the `analytics/dagster` assets, focusing on simplifying and improving the processing of owner and edited owner BAN addresses. The changes streamline the code by merging multiple steps into single functions and enhancing error handling.

Key changes include:

### Refactoring and Simplification:
* [`analytics/dagster/src/assets/populate_edited_owners_ban_addresses.py`](diffhunk://#diff-e29d90e83c642788f319657055c05227765a29d504629b8962f0df6e8fc3b590L1-R51): Combined multiple asset functions into `process_and_update_edited_owners`, which now handles retrieving, processing, and updating edited owners in one step. This change includes enhanced logging and error handling for better traceability. 
* [`analytics/dagster/src/assets/populate_owners_ban_addresses.py`](diffhunk://#diff-1d16d39581d6d035fb21183eb15f1b59bc2ce7a830b168cf63b16a1bff3ce64eL9-R29): Merged the chunk creation and processing steps into `process_and_insert_owners`, simplifying the workflow and improving efficiency.

### Updates to Definitions:
* [`analytics/dagster/src/definitions.py`](diffhunk://#diff-0db340bfd6c18bae6ebdb7f70879119398a4e27e106f13c369e23bbdd358dff2L27-R28): Updated asset job definitions to reflect the new simplified functions, removing references to deprecated functions. 

### Configuration Updates:
* [`.talismanrc`](diffhunk://#diff-efcd051724f24a743f7e1d572b337b61f6a1137ea138173c59346095eedd972aL3-R5): Updated checksums for the modified files to ensure they are properly tracked and ignored as needed.

These changes aim to improve the maintainability and performance of the codebase, making it easier to manage and extend in the future.