### PR TITLE
modif_wording_GroupHeader

### DIFF
--- a/frontend/src/components/GroupHeader/GroupHeader.tsx
+++ b/frontend/src/components/GroupHeader/GroupHeader.tsx
@@ -88,7 +88,7 @@ function Empty() {
       </Typography>
       <Typography mb={1} variant="caption">
         Pour pouvoir exporter une liste de logements, sélectionnez les logements
-        que vous souhaitez cibler et cliquez sur “Ajouter dans un groupe”.
+        que vous souhaitez cibler et cliquez sur “Exporter ou contacter”.
       </Typography>
     </Stack>
   );


### PR DESCRIPTION
Modification du wording des instructions pour créer un premier groupe suite au changement du nom du CTA "Ajouter dans un groupe" devenu "Exporter ou contacter" dans le nouveau parcours de création de groupes/campagnes.