### PR TITLE
Add last mutation filter for null type

### DIFF
--- a/frontend/src/models/Mutation.ts
+++ b/frontend/src/models/Mutation.ts
@@ -1,15 +1,25 @@
 import { Mutation } from '@zerologementvacant/models';
+import { match } from 'ts-pattern';
 
 import { birthdate } from '../utils/dateUtils';
 import { formatPrice } from '../utils/stringUtils';
 
 export function toString(mutation: Mutation): string {
-  const type = mutation.type === 'sale' ? 'Vente' : 'Donation';
+  const type = match(mutation.type)
+    .returnType<string | null>()
+    .with('sale', () => 'Vente')
+    .with('donation', () => 'Donation')
+    .with(null, () => null)
+    .exhaustive();
   const date = birthdate(new Date(mutation.date));
   const amount =
     mutation.type === 'sale' && mutation.amount !== null
       ? ` (Montant : ${formatPrice(mutation.amount)})`
       : '';
+
+  if (!type) {
+    return date;
+  }
 
   return `${type} le ${date}${amount}`;
 }

--- a/frontend/src/models/test/Mutation.test.ts
+++ b/frontend/src/models/test/Mutation.test.ts
@@ -2,7 +2,18 @@ import { toString } from '../Mutation';
 
 describe('Mutation', () => {
   describe('toString', () => {
-    it('should start by "Vente" if the mutation is a "sale"', () => {
+    it('should display the mutation date only if the mutation type is "null"', () => {
+      const actual = toString({
+        type: null,
+        date: new Date('2023-01-01')
+      });
+
+      expect(actual).toInclude('01/01/2023');
+      expect(actual).not.toInclude('Vente');
+      expect(actual).not.toInclude('Donation');
+    });
+
+    it('should start with "Vente" if the mutation is a "sale"', () => {
       const actual = toString({
         type: 'sale',
         date: new Date(),

--- a/packages/models/src/Mutation.ts
+++ b/packages/models/src/Mutation.ts
@@ -1,15 +1,19 @@
 import { HousingDTO } from './HousingDTO';
 
-export interface Sale {
+interface Unknown {
+  type: null;
+  date: Date;
+}
+interface Sale {
   type: 'sale';
   date: Date;
   amount: number | null;
 }
-export interface Donation {
+interface Donation {
   type: 'donation';
   date: Date;
 }
-export type Mutation = Sale | Donation;
+export type Mutation = Sale | Donation | Unknown;
 
 export function fromHousing(
   housing: Pick<
@@ -25,6 +29,13 @@ export function fromHousing(
     : null;
   const lastTransactionValue = housing.lastTransactionValue;
 
+  if (lastMutationDate && !lastTransactionDate) {
+    return {
+      type: null,
+      date: lastMutationDate
+    };
+  }
+
   if (lastMutationDate && lastTransactionDate) {
     return lastMutationDate > lastTransactionDate
       ? {
@@ -36,13 +47,6 @@ export function fromHousing(
           date: lastTransactionDate,
           amount: lastTransactionValue
         };
-  }
-
-  if (lastMutationDate && !lastTransactionDate) {
-    return {
-      type: 'donation',
-      date: lastMutationDate
-    };
   }
 
   if (lastTransactionDate) {

--- a/packages/models/src/test/Mutation.test.ts
+++ b/packages/models/src/test/Mutation.test.ts
@@ -2,23 +2,23 @@ import { fromHousing, Mutation } from '../Mutation';
 
 describe('Mutation', () => {
   describe('fromHousing', () => {
-    it('should be a "donation" if the last mutation is more recent than the last transaction', () => {
+    it('should have an empty type if the last mutation is specified but the last transaction is not', () => {
       const actual = fromHousing({
         lastMutationDate: '2023-01-01',
-        lastTransactionDate: '2022-12-31',
+        lastTransactionDate: null,
         lastTransactionValue: null
       });
 
       expect(actual).toStrictEqual<Mutation>({
-        type: 'donation',
+        type: null,
         date: new Date('2023-01-01')
       });
     });
 
-    it('should be a "donation" if the last transaction date is empty', () => {
+    it('should be a "donation" if the last mutation is more recent than the last transaction', () => {
       const actual = fromHousing({
         lastMutationDate: '2023-01-01',
-        lastTransactionDate: null,
+        lastTransactionDate: '2022-12-31',
         lastTransactionValue: null
       });
 


### PR DESCRIPTION
- Update `toString` function to handle null mutation type.
- Modify tests to reflect changes in mutation type handling.
- Extend `Mutation` type to include unknown mutation type.