### PR TITLE
Queue management

### DIFF
--- a/queue/.env.example
+++ b/queue/.env.example
@@ -14,3 +14,6 @@ S3_REGION=any
 S3_BUCKET=
 S3_ACCESS_KEY_ID=whatever
 S3_SECRET_ACCESS_KEY=whatever
+
+SENTRY_DSN=https://abcdefghijklmnopqrstuvwxyz123456.ingest.sentry.io/1234567
+SENTRY_ENABLED=true

--- a/queue/package.json
+++ b/queue/package.json
@@ -45,6 +45,7 @@
     "helmet": "^8.0.0",
     "htpasswd": "^2.4.6",
     "http-auth": "^4.2.0",
+    "ioredis": "^5.6.1",
     "parse-redis-url-simple": "^1.0.2"
   },
   "devDependencies": {
@@ -57,7 +58,7 @@
     "@types/express": "^4.17.21",
     "@types/http-auth": "^4.1.4",
     "@types/jest": "^29.5.13",
-    "@types/node": "^20.16.10",
+    "@types/node": "^24.0.10",
     "@types/supertest": "^6.0.2",
     "jest": "^29.7.0",
     "jest-extended": "^4.0.2",
@@ -68,7 +69,7 @@
     "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2",
     "tsx": "^4.19.4",
-    "typescript": "^5.6.2",
+    "typescript": "^5.8.3",
     "uuid": "^9.0.1"
   }
 }

--- a/queue/src/config.ts
+++ b/queue/src/config.ts
@@ -6,11 +6,14 @@ import { LOG_LEVELS, LogLevel } from '@zerologementvacant/utils';
 
 export const isProduction = process.env.NODE_ENV === 'production';
 
+export type Env = 'development' | 'test' | 'production';
+
 interface Config {
   api: {
     host: string;
   };
   app: {
+    env: Env;
     port: number;
   };
   auth: {
@@ -33,6 +36,10 @@ interface Config {
     accessKeyId: string;
     secretAccessKey: string;
   };
+  sentry: {
+    dsn: string | null;
+    enabled: boolean;
+  };
 }
 
 dotenv.config({
@@ -48,6 +55,11 @@ const config = convict<Config>({
     },
   },
   app: {
+    env: {
+      env: 'NODE_ENV',
+      format: ['development', 'test', 'production'],
+      default: 'development'
+    },
     port: {
       env: 'PORT',
       format: 'port',
@@ -120,6 +132,19 @@ const config = convict<Config>({
       sensitive: true,
     },
   },
+  sentry: {
+    dsn: {
+      env: 'SENTRY_DSN',
+      format: String,
+      default: null,
+      nullable: true
+    },
+    enabled: {
+      env: 'SENTRY_ENABLED',
+      format: Boolean,
+      default: isProduction
+    }
+  }
 })
   .validate({ allowed: 'strict' })
   .get();

--- a/queue/src/scripts/job-manager-cli.ts
+++ b/queue/src/scripts/job-manager-cli.ts
@@ -60,6 +60,7 @@ async function findJobsByCampaign(
 
       console.log(`Searching in status: ${status}`);
 
+      //ts-ignore-next-line
       while (true) {
         // Get jobs for ONE status at a time with proper pagination
         const jobs = await queue.getJobs([status], start, start + BATCH_SIZE - 1, true);

--- a/queue/src/scripts/job-manager-cli.ts
+++ b/queue/src/scripts/job-manager-cli.ts
@@ -1,0 +1,461 @@
+// job-manager-cli.ts
+import 'dotenv/config';
+import IORedis from 'ioredis';
+import { Queue, Job } from 'bullmq';
+
+interface JobError {
+  reason: string;
+  stack?: string[] | null;
+  note?: string;
+}
+
+interface DelayInfo {
+  delay?: number;
+  processedOn?: number;
+  finishedOn?: number;
+}
+
+interface JobResult {
+  id: string;
+  name: string;
+  status: string;
+  timestamp: number;
+  attemptsMade: number;
+  data: any;
+  error: JobError | null;
+  delayInfo: DelayInfo | null;
+}
+
+interface RetryResult {
+  success: number;
+  errors: string[];
+}
+
+type JobStatus = 'waiting' | 'delayed' | 'active' | 'completed' | 'failed';
+
+/**
+ * Validates if a string is a valid UUID
+ */
+function isValidUUID(str: string): boolean {
+  const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+  return uuidRegex.test(str);
+}
+
+/**
+ * Searches for all jobs with job.data.campaignId = campaignId
+ */
+async function findJobsByCampaign(
+  queue: Queue,
+  campaignId: string,
+  statuses: JobStatus[] = ['waiting', 'delayed', 'active', 'completed', 'failed']
+): Promise<JobResult[]> {
+  const results: JobResult[] = [];
+  const BATCH_SIZE = 100; // Process jobs in batches
+
+  for (const status of statuses) {
+    try {
+      let start = 0;
+      let totalJobsForStatus = 0;
+      let foundJobsForStatus = 0;
+
+      console.log(`Searching in status: ${status}`);
+
+      while (true) {
+        // Get jobs for ONE status at a time with proper pagination
+        const jobs = await queue.getJobs([status], start, start + BATCH_SIZE - 1, true);
+        
+        if (jobs.length === 0) {
+          break; // No more jobs to process
+        }
+
+        totalJobsForStatus += jobs.length;
+
+        for (const job of jobs) {
+          if (job && job.data && job.data.campaignId === campaignId) {
+            foundJobsForStatus++;
+            
+            // Get error information and additional details
+            let errorInfo: JobError | null = null;
+            let delayInfo: DelayInfo | null = null;
+            
+            if (status === 'failed' && job.failedReason) {
+              errorInfo = {
+                reason: job.failedReason,
+                stack: job.stacktrace ? job.stacktrace.slice(0, 3) : null
+              };
+            }
+            
+            // For delayed jobs, get delay information and last failure reason
+            if (status === 'delayed') {
+              delayInfo = {
+                delay: job.delay,
+                processedOn: job.processedOn,
+                finishedOn: job.finishedOn
+              };
+              
+              // If the job has attempts > 1, it likely failed before being delayed
+              if (job.attemptsMade > 0 && job.failedReason) {
+                errorInfo = {
+                  reason: job.failedReason,
+                  stack: job.stacktrace ? job.stacktrace.slice(0, 3) : null,
+                  note: "Last failure before being delayed"
+                };
+              }
+            }
+            
+            results.push({
+              id: job.id!,
+              name: job.name!,
+              status: status,
+              timestamp: job.timestamp,
+              attemptsMade: job.attemptsMade,
+              data: job.data,
+              error: errorInfo,
+              delayInfo: delayInfo,
+            });
+          }
+        }
+
+        start += BATCH_SIZE;
+
+        // If we got less than BATCH_SIZE jobs, we've reached the end
+        if (jobs.length < BATCH_SIZE) {
+          break;
+        }
+
+        // Safety check to avoid infinite loops
+        if (start > 50000) {
+          console.log(`Warning: Stopped at ${start} jobs for status ${status} to avoid processing too many jobs`);
+          break;
+        }
+      }
+
+      console.log(`Status ${status}: Found ${foundJobsForStatus} matching jobs out of ${totalJobsForStatus} total jobs`);
+
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      console.warn(`Warning: Could not fetch jobs for status ${status}:`, errorMessage);
+    }
+  }
+  return results;
+}
+
+/**
+ * Creates and launches a new job
+ */
+async function createJob(
+  queue: Queue,
+  jobName: string,
+  campaignId: string,
+  establishmentId: string,
+  additionalData: Record<string, any> = {}
+): Promise<Job> {
+  const jobData = {
+    campaignId,
+    establishmentId,
+    ...additionalData
+  };
+
+  const job = await queue.add(jobName, jobData);
+  return job;
+}
+
+/**
+ * Retries failed and delayed jobs for a specific campaign
+ */
+async function retryJobsByCampaign(queue: Queue, campaignId: string): Promise<RetryResult> {
+  console.log(`Looking for failed and delayed jobs with campaignId: ${campaignId}`);
+  
+  // Find failed and delayed jobs for this campaign
+  const jobsToRetry = await findJobsByCampaign(queue, campaignId, ['failed', 'delayed']);
+  
+  if (jobsToRetry.length === 0) {
+    console.log('No failed or delayed jobs found for this campaign.');
+    return { success: 0, errors: [] };
+  }
+
+  console.log(`Found ${jobsToRetry.length} job(s) to retry:`);
+  const failedCount = jobsToRetry.filter(j => j.status === 'failed').length;
+  const delayedCount = jobsToRetry.filter(j => j.status === 'delayed').length;
+  console.log(`  - ${failedCount} failed job(s)`);
+  console.log(`  - ${delayedCount} delayed job(s)`);
+  
+  let successCount = 0;
+  const errors: string[] = [];
+
+  for (const jobInfo of jobsToRetry) {
+    try {
+      // Get the actual job object
+      const job = await queue.getJob(jobInfo.id);
+      
+      if (!job) {
+        errors.push(`Job ${jobInfo.id} not found`);
+        continue;
+      }
+
+      // Handle different job states differently
+      if (jobInfo.status === 'failed') {
+        // For failed jobs, use retry()
+        await job.retry();
+        successCount++;
+        console.log(`✅ Retried failed job ${job.id} (${job.name})`);
+      } else if (jobInfo.status === 'delayed') {
+        // For delayed jobs, promote them to run immediately
+        await job.promote();
+        successCount++;
+        console.log(`✅ Promoted delayed job ${job.id} (${job.name}) to run immediately`);
+      }
+      
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      const errorMsg = `Failed to retry job ${jobInfo.id}: ${errorMessage}`;
+      errors.push(errorMsg);
+      console.error(`❌ ${errorMsg}`);
+    }
+  }
+
+  return { success: successCount, errors };
+}
+
+/**
+ * Retries a specific job by ID
+ */
+async function retryJobById(queue: Queue, jobId: string): Promise<boolean> {
+  try {
+    const job = await queue.getJob(jobId);
+    
+    if (!job) {
+      throw new Error(`Job with ID ${jobId} not found`);
+    }
+
+    // Check the current job state
+    const jobState = await job.getState();
+    
+    if (jobState === 'failed') {
+      // For failed jobs, use retry()
+      await job.retry();
+      console.log(`✅ Job ${jobId} (${job.name}) has been retried successfully`);
+      return true;
+    } else if (jobState === 'delayed') {
+      // For delayed jobs, promote them to run immediately
+      await job.promote();
+      console.log(`✅ Job ${jobId} (${job.name}) has been promoted to run immediately`);
+      return true;
+    } else {
+      console.log(`⚠️  Job ${jobId} is in '${jobState}' state. Can only retry 'failed' or promote 'delayed' jobs.`);
+      return false;
+    }
+    
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    console.error(`❌ Failed to retry job ${jobId}: ${errorMessage}`);
+    return false;
+  }
+}
+
+/**
+ * Displays help information
+ */
+function showHelp(): void {
+  console.log(`
+Job Manager CLI
+
+Usage:
+  npx ts-node job-manager-cli.ts search <queueName> <campaignId>
+  npx ts-node job-manager-cli.ts create <queueName> <jobName> <campaignId> <establishmentId>
+  npx ts-node job-manager-cli.ts retry <queueName> <campaignId>
+  npx ts-node job-manager-cli.ts retry <queueName> --job-id <jobId>
+
+Commands:
+  search    Search for jobs by campaignId
+  create    Create and launch a new job
+  retry     Retry failed and delayed jobs by campaignId or specific job by ID
+
+Arguments:
+  queueName        Name of the BullMQ queue
+  campaignId       UUID of the campaign
+  establishmentId  UUID of the establishment (for create command)
+  jobName          Name of the job to create
+  jobId            Specific job ID to retry
+
+Examples:
+  npx ts-node job-manager-cli.ts search email-queue 123e4567-e89b-12d3-a456-426614174000
+  npx ts-node job-manager-cli.ts create email-queue send-newsletter 123e4567-e89b-12d3-a456-426614174000 987fcdeb-51d3-4a2b-9876-543210987654
+  npx ts-node job-manager-cli.ts retry email-queue 123e4567-e89b-12d3-a456-426614174000
+  npx ts-node job-manager-cli.ts retry email-queue --job-id 12345
+`);
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  
+  if (args.length === 0 || args[0] === '--help' || args[0] === '-h') {
+    showHelp();
+    return;
+  }
+
+  const command = args[0];
+  
+  if (command === 'search') {
+    const [, queueName, campaignId] = args;
+    
+    if (!queueName || !campaignId) {
+      console.error('Error: Missing required arguments for search command');
+      console.error('Usage: npx ts-node job-manager-cli.ts search <queueName> <campaignId>');
+      process.exit(1);
+    }
+
+    if (!isValidUUID(campaignId)) {
+      console.error('Error: campaignId must be a valid UUID');
+      process.exit(1);
+    }
+
+    console.log(`Redis configuration: ${process.env.REDIS_URL}`);
+    const connection = new IORedis(process.env.REDIS_URL ?? 'redis://127.0.0.1:6379');
+    const queue = new Queue(queueName, { connection });
+
+    try {
+      const matches = await findJobsByCampaign(queue, campaignId);
+      console.log(`\n=== Results for campaignId="${campaignId}" in queue "${queueName}" ===\n`);
+      console.log(`➡️ ${matches.length} job(s) found\n`);
+      
+      if (matches.length === 0) {
+        console.log('No jobs found. This could mean:');
+        console.log('- The campaignId does not exist in any jobs');
+        console.log('- The jobs are in a different status than expected');
+        console.log('- The queue name is incorrect');
+        console.log('\nTry checking the BullMQ dashboard to verify the job status and data structure.');
+      } else {
+        matches.forEach(j => {
+          console.log(`[${j.status}] id=${j.id} name=${j.name} attempts=${j.attemptsMade}`);
+          console.log(`Data: ${JSON.stringify(j.data, null, 2)}`);
+          
+          // Display delay information for delayed jobs
+          if (j.delayInfo && j.status === 'delayed') {
+            if (j.delayInfo.delay) {
+              console.log(`⏰ Delayed for: ${j.delayInfo.delay}ms`);
+            }
+            if (j.delayInfo.processedOn) {
+              console.log(`📅 Last processed: ${new Date(j.delayInfo.processedOn).toISOString()}`);
+            }
+          }
+          
+          // Display error information for failed jobs or delayed jobs with previous failures
+          if (j.error) {
+            const prefix = j.error.note ? `❌ ${j.error.note}: ` : '❌ Error: ';
+            console.log(`${prefix}${j.error.reason}`);
+            if (j.error.stack) {
+              console.log(`Stack trace (first 3 lines):`);
+              j.error.stack.forEach(line => console.log(`   ${line}`));
+            }
+          }
+          
+          console.log('---');
+        });
+      }
+    } finally {
+      await queue.close();
+      await connection.quit();
+    }
+  } 
+  else if (command === 'create') {
+    const [, queueName, jobName, campaignId, establishmentId] = args;
+    
+    if (!queueName || !jobName || !campaignId || !establishmentId) {
+      console.error('Error: Missing required arguments for create command');
+      console.error('Usage: npx ts-node job-manager-cli.ts create <queueName> <jobName> <campaignId> <establishmentId>');
+      process.exit(1);
+    }
+
+    if (!isValidUUID(campaignId)) {
+      console.error('Error: campaignId must be a valid UUID');
+      process.exit(1);
+    }
+
+    if (!isValidUUID(establishmentId)) {
+      console.error('Error: establishmentId must be a valid UUID');
+      process.exit(1);
+    }
+
+    const connection = new IORedis(process.env.REDIS_URL ?? 'redis://127.0.0.1:6379');
+    const queue = new Queue(queueName, { connection });
+
+    try {
+      const job = await createJob(queue, jobName, campaignId, establishmentId);
+      console.log(`\n✅ Job created successfully!`);
+      console.log(`Job ID: ${job.id}`);
+      console.log(`Job Name: ${job.name}`);
+      console.log(`Queue: ${queueName}`);
+      console.log(`Data: ${JSON.stringify(job.data, null, 2)}`);
+    } finally {
+      await queue.close();
+      await connection.quit();
+    }
+  }
+  else if (command === 'retry') {
+    const [, queueName, campaignIdOrFlag, jobId] = args;
+    
+    if (!queueName) {
+      console.error('Error: Missing queue name for retry command');
+      console.error('Usage: npx ts-node job-manager-cli.ts retry <queueName> <campaignId>');
+      console.error('   or: npx ts-node job-manager-cli.ts retry <queueName> --job-id <jobId>');
+      process.exit(1);
+    }
+
+    const connection = new IORedis(process.env.REDIS_URL ?? 'redis://127.0.0.1:6379');
+    const queue = new Queue(queueName, { connection });
+
+    try {
+      // Check if it's a specific job ID retry
+      if (campaignIdOrFlag === '--job-id') {
+        if (!jobId) {
+          console.error('Error: Missing job ID');
+          console.error('Usage: npx ts-node job-manager-cli.ts retry <queueName> --job-id <jobId>');
+          process.exit(1);
+        }
+        
+        console.log(`\n=== Retrying job ${jobId} in queue "${queueName}" ===\n`);
+        await retryJobById(queue, jobId);
+      } 
+      // Otherwise, it's a campaign-based retry
+      else {
+        const campaignId = campaignIdOrFlag;
+        
+        if (!campaignId) {
+          console.error('Error: Missing campaignId');
+          console.error('Usage: npx ts-node job-manager-cli.ts retry <queueName> <campaignId>');
+          process.exit(1);
+        }
+
+        if (!isValidUUID(campaignId)) {
+          console.error('Error: campaignId must be a valid UUID');
+          process.exit(1);
+        }
+
+        console.log(`\n=== Retrying failed and delayed jobs for campaignId="${campaignId}" in queue "${queueName}" ===\n`);
+        const result = await retryJobsByCampaign(queue, campaignId);
+        
+        console.log(`\n📊 Summary:`);
+        console.log(`✅ Successfully retried: ${result.success} job(s)`);
+        if (result.errors.length > 0) {
+          console.log(`❌ Errors: ${result.errors.length}`);
+          result.errors.forEach(error => console.log(`   - ${error}`));
+        }
+      }
+    } finally {
+      await queue.close();
+      await connection.quit();
+    }
+  }
+  else {
+    console.error(`Error: Unknown command "${command}"`);
+    console.error('Use --help to see available commands');
+    process.exit(1);
+  }
+}
+
+main().catch(err => {
+  const errorMessage = err instanceof Error ? err.message : String(err);
+  console.error('Error:', errorMessage);
+  process.exit(1);
+});

--- a/queue/src/sentry.ts
+++ b/queue/src/sentry.ts
@@ -1,0 +1,38 @@
+import * as Sentry from '@sentry/node';
+import config from './config';
+import { createLogger } from './logger';
+
+function init(): void {
+  if (config.sentry.enabled && !config.sentry.dsn) {
+    throw new Error('Sentry must be initialized with a valid DSN');
+  }
+
+  const logger = createLogger('queue');
+
+  if (config.sentry.enabled && config.sentry.dsn) {
+    logger.info('Init sentry', {
+      level: 'error',
+      dsn: config.sentry.dsn,
+      service: 'queue'
+    });
+    Sentry.init({
+      dsn: config.sentry.dsn,
+      environment: config.app.env === 'production' ? 'production' : 'development',
+      tracesSampleRate: 0.2,
+      initialScope: {
+        tags: {
+          service: 'queue'
+        }
+      }
+    });
+  }
+}
+
+export default {
+  init,
+  addBreadcrumb: Sentry.addBreadcrumb,
+  captureException: Sentry.captureException,
+  captureMessage: Sentry.captureMessage,
+  setUser: Sentry.setUser,
+  setTag: Sentry.setTag
+};

--- a/server/src/infra/queue.ts
+++ b/server/src/infra/queue.ts
@@ -5,8 +5,6 @@ import config from '~/infra/config';
 
 const [redis] = parseRedisUrl(config.redis.url);
 
-console.log(config.redis.url)
-
 const queue = createQueue({
   connection: redis,
   defaultJobOptions: {

--- a/server/src/infra/queue.ts
+++ b/server/src/infra/queue.ts
@@ -5,9 +5,13 @@ import config from '~/infra/config';
 
 const [redis] = parseRedisUrl(config.redis.url);
 
+console.log(config.redis.url)
+
 const queue = createQueue({
   connection: redis,
   defaultJobOptions: {
+    // @ts-expect-error: timeout is valid at runtime
+    timeout: 10 * 60 * 1000,   // 5 min instead of 30 s
     attempts: 1_000,
     backoff: {
       type: 'exponential',

--- a/yarn.lock
+++ b/yarn.lock
@@ -10159,6 +10159,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/node@npm:^24.0.10":
+  version: 24.0.10
+  resolution: "@types/node@npm:24.0.10"
+  dependencies:
+    undici-types: "npm:~7.8.0"
+  checksum: 10c0/11dbd869d3e12ee7b7818113588950e538783e45d227122174c763cb05977defbd1e01b44b5ccd4b8997e42c3df7f7b83c6ee05cfa43d924c8882886bc5f6582
+  languageName: node
+  linkType: hard
+
 "@types/nodemailer@npm:^6.4.16":
   version: 6.4.17
   resolution: "@types/nodemailer@npm:6.4.17"
@@ -11274,7 +11283,7 @@ __metadata:
     "@types/express": "npm:^4.17.21"
     "@types/http-auth": "npm:^4.1.4"
     "@types/jest": "npm:^29.5.13"
-    "@types/node": "npm:^20.16.10"
+    "@types/node": "npm:^24.0.10"
     "@types/supertest": "npm:^6.0.2"
     "@zerologementvacant/api-sdk": "workspace:*"
     "@zerologementvacant/draft": "workspace:*"
@@ -11291,6 +11300,7 @@ __metadata:
     helmet: "npm:^8.0.0"
     htpasswd: "npm:^2.4.6"
     http-auth: "npm:^4.2.0"
+    ioredis: "npm:^5.6.1"
     jest: "npm:^29.7.0"
     jest-extended: "npm:^4.0.2"
     nodemon: "npm:^3.1.7"
@@ -11301,7 +11311,7 @@ __metadata:
     ts-jest: "npm:^29.2.5"
     ts-node: "npm:^10.9.2"
     tsx: "npm:^4.19.4"
-    typescript: "npm:^5.6.2"
+    typescript: "npm:^5.8.3"
     uuid: "npm:^9.0.1"
   bin:
     queue: dist/bin/index.js
@@ -19346,7 +19356,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ioredis@npm:^5.4.1":
+"ioredis@npm:^5.4.1, ioredis@npm:^5.6.1":
   version: 5.6.1
   resolution: "ioredis@npm:5.6.1"
   dependencies:
@@ -30823,7 +30833,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:>=3 < 6, typescript@npm:^5.6.2":
+"typescript@npm:>=3 < 6, typescript@npm:^5.6.2, typescript@npm:^5.8.3":
   version: 5.8.3
   resolution: "typescript@npm:5.8.3"
   bin:
@@ -30833,7 +30843,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A>=3 < 6#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.6.2#optional!builtin<compat/typescript>":
+"typescript@patch:typescript@npm%3A>=3 < 6#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.6.2#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.8.3#optional!builtin<compat/typescript>":
   version: 5.8.3
   resolution: "typescript@patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>::version=5.8.3&hash=5786d5"
   bin:
@@ -30922,6 +30932,13 @@ __metadata:
   version: 6.21.0
   resolution: "undici-types@npm:6.21.0"
   checksum: 10c0/c01ed51829b10aa72fc3ce64b747f8e74ae9b60eafa19a7b46ef624403508a54c526ffab06a14a26b3120d055e1104d7abe7c9017e83ced038ea5cf52f8d5e04
+  languageName: node
+  linkType: hard
+
+"undici-types@npm:~7.8.0":
+  version: 7.8.0
+  resolution: "undici-types@npm:7.8.0"
+  checksum: 10c0/9d9d246d1dc32f318d46116efe3cfca5a72d4f16828febc1918d94e58f6ffcf39c158aa28bf5b4fc52f410446bc7858f35151367bd7a49f21746cab6497b709b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR introduces a utility script to simplify campaign job management in the queue. The script allows:

- 🔍 Searching jobs by campaignId

- ❌ Viewing job errors (failed state)

- 🔁 Retrying existing jobs or 🔨 creating new ones from their data

In addition, to fix timeout-related failures on long-running jobs, the timeout has been increased from 30 seconds to 5 minutes.