### PR TITLE
Fix event-related tables constraints

### DIFF
--- a/server/src/infra/database/migrations/20250716132309_precision-housing-events-fix-constraints.ts
+++ b/server/src/infra/database/migrations/20250716132309_precision-housing-events-fix-constraints.ts
@@ -2,6 +2,7 @@ import type { Knex } from 'knex';
 
 export async function up(knex: Knex): Promise<void> {
   await knex.schema.alterTable('precision_housing_events', (table) => {
+    table.dropIndex('event_id');
     table.dropForeign('event_id');
     table
       .foreign('event_id')
@@ -9,6 +10,7 @@ export async function up(knex: Knex): Promise<void> {
       .inTable('events')
       .onUpdate('CASCADE')
       .onDelete('CASCADE');
+    table.primary(['event_id']);
   });
 }
 
@@ -22,5 +24,6 @@ export async function down(knex: Knex): Promise<void> {
       .inTable('events')
       .onUpdate('CASCADE')
       .onDelete('RESTRICT');
+    table.index('event_id');
   });
 }

--- a/server/src/infra/database/migrations/20250716132309_precision-housing-events-fix-constraints.ts
+++ b/server/src/infra/database/migrations/20250716132309_precision-housing-events-fix-constraints.ts
@@ -1,0 +1,26 @@
+import type { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('precision_housing_events', (table) => {
+    table.dropForeign('event_id');
+    table
+      .foreign('event_id')
+      .references('id')
+      .inTable('events')
+      .onUpdate('CASCADE')
+      .onDelete('CASCADE');
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('precision_housing_events', (table) => {
+    table.dropPrimary();
+    table.dropForeign('event_id');
+    table
+      .foreign('event_id')
+      .references('id')
+      .inTable('events')
+      .onUpdate('CASCADE')
+      .onDelete('RESTRICT');
+  });
+}

--- a/server/src/infra/database/migrations/20250716132616_events-index-type.ts
+++ b/server/src/infra/database/migrations/20250716132616_events-index-type.ts
@@ -1,0 +1,16 @@
+import type { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('events', (table) => {
+    table.dropNullable('created_at');
+  });
+  await knex.schema.raw(
+    'CREATE INDEX IF NOT EXISTS events_type_created_at_idx ON events (type, created_at DESC)'
+  );
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('events', (table) => {
+    table.dropIndex(['type', 'created_at'], 'events_type_created_at_idx');
+  });
+}

--- a/server/src/infra/database/migrations/20250716132616_events-index-type.ts
+++ b/server/src/infra/database/migrations/20250716132616_events-index-type.ts
@@ -13,4 +13,7 @@ export async function down(knex: Knex): Promise<void> {
   await knex.schema.alterTable('events', (table) => {
     table.dropIndex(['type', 'created_at'], 'events_type_created_at_idx');
   });
+  await knex.schema.alterTable('events', (table) => {
+    table.setNullable('created_at');
+  });
 }

--- a/server/src/infra/database/migrations/20250716132835_owner-events-fix-foreign-key-constraints.ts
+++ b/server/src/infra/database/migrations/20250716132835_owner-events-fix-foreign-key-constraints.ts
@@ -10,8 +10,16 @@ export async function up(knex: Knex): Promise<void> {
       .onUpdate('CASCADE')
       .onDelete('CASCADE');
 
+    table.dropForeign('owner_id');
+    table
+      .foreign('owner_id')
+      .references('id')
+      .inTable('owners')
+      .onUpdate('CASCADE')
+      .onDelete('CASCADE');
+
     table.dropPrimary();
-    table.index('event_id');
+    table.primary(['event_id']);
   });
 }
 

--- a/server/src/infra/database/migrations/20250716132835_owner-events-fix-foreign-key-constraints.ts
+++ b/server/src/infra/database/migrations/20250716132835_owner-events-fix-foreign-key-constraints.ts
@@ -1,0 +1,26 @@
+import type { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('owner_events', (table) => {
+    table.dropForeign('event_id');
+    table
+      .foreign('event_id')
+      .references('id')
+      .inTable('events')
+      .onUpdate('CASCADE')
+      .onDelete('CASCADE');
+
+    table.dropPrimary();
+    table.index('event_id');
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('owner_events', (table) => {
+    table.dropIndex('event_id');
+    table.primary(['owner_id', 'event_id']);
+
+    table.dropForeign('event_id');
+    table.foreign('event_id').references('id').inTable('events');
+  });
+}

--- a/server/src/infra/database/migrations/20250716132835_owner-events-fix-foreign-key-constraints.ts
+++ b/server/src/infra/database/migrations/20250716132835_owner-events-fix-foreign-key-constraints.ts
@@ -25,8 +25,11 @@ export async function up(knex: Knex): Promise<void> {
 
 export async function down(knex: Knex): Promise<void> {
   await knex.schema.alterTable('owner_events', (table) => {
-    table.dropIndex('event_id');
+    table.dropPrimary();
     table.primary(['owner_id', 'event_id']);
+
+    table.dropForeign('owner_id');
+    table.foreign('owner_id').references('id').inTable('owners');
 
     table.dropForeign('event_id');
     table.foreign('event_id').references('id').inTable('events');

--- a/server/src/infra/database/migrations/20250716150612_housing-events-fix-index.ts
+++ b/server/src/infra/database/migrations/20250716150612_housing-events-fix-index.ts
@@ -1,0 +1,21 @@
+import type { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('housing_events', (table) => {
+    table.dropPrimary();
+    table.index('event_id');
+
+    table.dropIndex(['housing_id', 'event_id', 'housing_geo_code']);
+    table.index(['housing_geo_code', 'housing_id']);
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('housing_events', (table) => {
+    table.dropIndex(['housing_geo_code', 'housing_id']);
+    table.index(['housing_id', 'event_id', 'housing_geo_code']);
+
+    table.dropIndex('event_id');
+    table.primary(['event_id', 'housing_id', 'housing_geo_code']);
+  });
+}

--- a/server/src/infra/database/migrations/20250716150612_housing-events-fix-index.ts
+++ b/server/src/infra/database/migrations/20250716150612_housing-events-fix-index.ts
@@ -3,7 +3,7 @@ import type { Knex } from 'knex';
 export async function up(knex: Knex): Promise<void> {
   await knex.schema.alterTable('housing_events', (table) => {
     table.dropPrimary();
-    table.index('event_id');
+    table.primary(['event_id']);
 
     table.dropIndex(['housing_id', 'event_id', 'housing_geo_code']);
     table.index(['housing_geo_code', 'housing_id']);
@@ -15,7 +15,7 @@ export async function down(knex: Knex): Promise<void> {
     table.dropIndex(['housing_geo_code', 'housing_id']);
     table.index(['housing_id', 'event_id', 'housing_geo_code']);
 
-    table.dropIndex('event_id');
-    table.primary(['event_id', 'housing_id', 'housing_geo_code']);
+    table.dropPrimary();
+    table.primary(['housing_id', 'event_id']);
   });
 }

--- a/server/src/infra/database/migrations/20250716152359_campaign-events-remove-primary.ts
+++ b/server/src/infra/database/migrations/20250716152359_campaign-events-remove-primary.ts
@@ -1,0 +1,13 @@
+import type { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('campaign_events', (table) => {
+    table.dropPrimary();
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('campaign_events', (table) => {
+    table.primary(['campaign_id', 'event_id']);
+  });
+}

--- a/server/src/infra/database/migrations/20250716154722_campaign-housing-events-fix-constraints.ts
+++ b/server/src/infra/database/migrations/20250716154722_campaign-housing-events-fix-constraints.ts
@@ -1,17 +1,15 @@
 import type { Knex } from 'knex';
 
 export async function up(knex: Knex): Promise<void> {
-  await knex.schema.alterTable('campaign_events', (table) => {
+  await knex.schema.alterTable('campaign_housing_events', (table) => {
     table.dropIndex('event_id');
-    table.dropPrimary();
     table.primary(['event_id']);
   });
 }
 
 export async function down(knex: Knex): Promise<void> {
-  await knex.schema.alterTable('campaign_events', (table) => {
+  await knex.schema.alterTable('campaign_housing_events', (table) => {
     table.dropPrimary();
-    table.primary(['campaign_id', 'event_id']);
     table.index('event_id');
   });
 }

--- a/server/src/infra/database/migrations/20250716154907_group-housing-events-fix-constraints.ts
+++ b/server/src/infra/database/migrations/20250716154907_group-housing-events-fix-constraints.ts
@@ -1,17 +1,15 @@
 import type { Knex } from 'knex';
 
 export async function up(knex: Knex): Promise<void> {
-  await knex.schema.alterTable('campaign_events', (table) => {
+  await knex.schema.alterTable('group_housing_events', (table) => {
     table.dropIndex('event_id');
-    table.dropPrimary();
     table.primary(['event_id']);
   });
 }
 
 export async function down(knex: Knex): Promise<void> {
-  await knex.schema.alterTable('campaign_events', (table) => {
+  await knex.schema.alterTable('group_housing_events', (table) => {
     table.dropPrimary();
-    table.primary(['campaign_id', 'event_id']);
     table.index('event_id');
   });
 }

--- a/server/src/infra/database/migrations/20250716155117_housing-owner-events-fix-constraints.ts
+++ b/server/src/infra/database/migrations/20250716155117_housing-owner-events-fix-constraints.ts
@@ -1,17 +1,15 @@
 import type { Knex } from 'knex';
 
 export async function up(knex: Knex): Promise<void> {
-  await knex.schema.alterTable('campaign_events', (table) => {
+  await knex.schema.alterTable('housing_owner_events', (table) => {
     table.dropIndex('event_id');
-    table.dropPrimary();
     table.primary(['event_id']);
   });
 }
 
 export async function down(knex: Knex): Promise<void> {
-  await knex.schema.alterTable('campaign_events', (table) => {
+  await knex.schema.alterTable('housing_owner_events', (table) => {
     table.dropPrimary();
-    table.primary(['campaign_id', 'event_id']);
     table.index('event_id');
   });
 }


### PR DESCRIPTION
The main table `events` has an `id UUID PK`.
The event-related events should have an `event_id UUID FK PK`. There was no primary key constraint.