### PR TITLE
Modif du texte de l'alerte sur la BAN

### DIFF
--- a/frontend/src/components/OwnerAddressEdition/OwnerAddressEdition.tsx
+++ b/frontend/src/components/OwnerAddressEdition/OwnerAddressEdition.tsx
@@ -57,7 +57,6 @@ function OwnerAddressEdition(props: Props) {
           }}
         >
           L’adresse de la Base Adresse Nationale diffère de celle de la DGFIP.
-          Veuillez vérifier attentivement ces informations ou ignorez l’alerte.
         </CallOut>
       )}
     </>


### PR DESCRIPTION
Suppression d'une ligne du texte d'alerte sur la BAN dans la modale d'édition des informations propriétaires (texte inutile et réduction de la taille de l'alerte).