### PR TITLE
Added a space in the create a campaign from a group modal

### DIFF
--- a/frontend/src/components/modals/GroupCampaignCreationModal/GroupCampaignCreationModal.tsx
+++ b/frontend/src/components/modals/GroupCampaignCreationModal/GroupCampaignCreationModal.tsx
@@ -92,10 +92,7 @@ function GroupCampaignCreationModal(props: Props) {
           inputKey="description"
         />
         <Text>
-          La liste a été établie à partir du groupe 
-          <Text as="span" bold>
-            {props.group.title}
-          </Text>
+          La liste a été établie à partir du groupe &nbsp;<Text as="span" bold>{props.group.title}</Text>
           .
         </Text>
       </Container>


### PR DESCRIPTION
Problem is that today, there is no space btwn the sentence and the groupe name. here is my proposal.

<img width="391" height="58" alt="Capture d’écran 2025-09-12 à 15 50 31" src="https://github.com/user-attachments/assets/d060478f-1e5b-42d7-a702-0d577aa2a778" />
