### PR TITLE
Correct tooltip wording for the searchbar

### DIFF
--- a/frontend/src/views/HousingList/HousingListView.tsx
+++ b/frontend/src/views/HousingList/HousingListView.tsx
@@ -171,7 +171,7 @@ const HousingListView = () => {
               <Tooltip
                 align="start"
                 place="bottom"
-                title="Copiez-collez vos invariants fiscaux facilement dans la barre de recherche pour gagner du temps !"
+                title="Pour retrouver une liste de logements, copiez-collez dans la barre de recherche la liste de leurs identifiants fiscaux séparés par un espace. Exemple : « 750123456789 750123456790 750123456791 »"
               />
             </Grid>
             <Grid size="auto">


### PR DESCRIPTION
Correction du wording du tooltip de la searchbar qui n'avait pas été pris en compte dans la MEP