### PR TITLE
feat(api): add geo statistics endpoint for map aggregated housing counts

### DIFF
--- a/frontend/src/services/api.service.ts
+++ b/frontend/src/services/api.service.ts
@@ -30,6 +30,7 @@ export const zlvApi = createApi({
     'Establishment',
     'Event',
     'GeoPerimeter',
+    'GeoStatistics',
     'Group',
     'Housing',
     'HousingByStatus',

--- a/frontend/src/services/geo.service.ts
+++ b/frontend/src/services/geo.service.ts
@@ -1,9 +1,26 @@
+import type {
+  GeoLevel,
+  GeoStatisticsResponseDTO,
+} from '@zerologementvacant/models';
 import type { GeoPerimeter } from '../models/GeoPerimeter';
 import { zlvApi } from './api.service';
 import { getFileUploadErrorMessage } from '../utils/fileUploadErrors';
 
+interface GetGeoStatisticsParams {
+  level: GeoLevel;
+  code?: string;
+  establishmentId?: string;
+}
+
 export const geoPerimetersApi = zlvApi.injectEndpoints({
   endpoints: (builder) => ({
+    getGeoStatistics: builder.query<GeoStatisticsResponseDTO, GetGeoStatisticsParams>({
+      query: ({ level, code, establishmentId }) => ({
+        url: 'geo/statistics',
+        params: { level, code, establishmentId },
+      }),
+      providesTags: ['GeoStatistics'],
+    }),
     listGeoPerimeters: builder.query<GeoPerimeter[], void>({
       query: () => 'geo/perimeters',
       providesTags: (result) =>
@@ -62,6 +79,7 @@ const fileToFormData = (file: File) => {
 };
 
 export const {
+  useGetGeoStatisticsQuery,
   useListGeoPerimetersQuery,
   useUpdateGeoPerimeterMutation,
   useDeleteGeoPerimetersMutation,

--- a/packages/models/src/GeoStatisticsDTO.ts
+++ b/packages/models/src/GeoStatisticsDTO.ts
@@ -1,0 +1,65 @@
+/**
+ * Geographic level for statistics aggregation
+ */
+export type GeoLevel = 'region' | 'department' | 'epci';
+
+/**
+ * Statistics for a geographic area
+ */
+export interface GeoStatisticsDTO {
+  /**
+   * Geographic code (region code, department code, or EPCI SIREN)
+   */
+  code: string;
+  /**
+   * Name of the geographic area
+   */
+  name: string;
+  /**
+   * Number of housings in this area
+   */
+  housingCount: number;
+}
+
+/**
+ * Response for geographic statistics endpoint
+ */
+export interface GeoStatisticsResponseDTO {
+  /**
+   * Geographic level of aggregation
+   */
+  level: GeoLevel;
+  /**
+   * Establishment ID
+   */
+  establishmentId: string;
+  /**
+   * Statistics per geographic area
+   */
+  statistics: GeoStatisticsDTO[];
+}
+
+/**
+ * Region from geo.api.gouv.fr
+ */
+export interface GeoRegion {
+  code: string;
+  nom: string;
+}
+
+/**
+ * Department from geo.api.gouv.fr
+ */
+export interface GeoDepartment {
+  code: string;
+  nom: string;
+  codeRegion: string;
+}
+
+/**
+ * EPCI from geo.api.gouv.fr
+ */
+export interface GeoEPCI {
+  code: string;
+  nom: string;
+}

--- a/packages/models/src/index.ts
+++ b/packages/models/src/index.ts
@@ -25,6 +25,7 @@ export * from './EventType';
 export * from './Feature';
 export * from './FileUploadDTO';
 export * from './GeoPerimeterDTO';
+export * from './GeoStatisticsDTO';
 export * from './GroupDTO';
 export * from './HousingByBuilding';
 export * from './HousingDocumentDTO';

--- a/server/src/controllers/geoStatisticsController.ts
+++ b/server/src/controllers/geoStatisticsController.ts
@@ -1,0 +1,353 @@
+import { Request, Response } from 'express';
+import { AuthenticatedRequest } from 'express-jwt';
+import { query } from 'express-validator';
+import { constants } from 'http2';
+
+import {
+  GeoLevel,
+  GeoStatisticsDTO,
+  GeoStatisticsResponseDTO,
+  UserRole
+} from '@zerologementvacant/models';
+import ForbiddenError from '~/errors/forbiddenError';
+import { createLogger } from '~/infra/logger';
+import establishmentRepository from '~/repositories/establishmentRepository';
+import geoStatisticsRepository from '~/repositories/geoStatisticsRepository';
+import geoAPI from '~/services/geo/geo-api';
+
+const logger = createLogger('geoStatisticsController');
+
+/**
+ * Mapping of department codes to region codes
+ * This is cached after first fetch from geo.api.gouv.fr
+ */
+let departmentToRegionMap: Map<string, string> | null = null;
+let regionNamesMap: Map<string, string> | null = null;
+let departmentNamesMap: Map<string, string> | null = null;
+
+async function initializeMappings(): Promise<void> {
+  if (departmentToRegionMap && regionNamesMap && departmentNamesMap) {
+    return;
+  }
+
+  const [regions, departments] = await Promise.all([
+    geoAPI.getRegions(),
+    geoAPI.getDepartments()
+  ]);
+
+  regionNamesMap = new Map(regions.map((r) => [r.code, r.nom]));
+  departmentNamesMap = new Map(departments.map((d) => [d.code, d.nom]));
+  departmentToRegionMap = new Map(departments.map((d) => [d.code, d.codeRegion]));
+}
+
+const getStatisticsValidators = [
+  query('level')
+    .isIn(['region', 'department', 'epci'])
+    .withMessage('level must be one of: region, department, epci'),
+  query('code')
+    .optional()
+    .isString()
+    .withMessage('code must be a string'),
+  query('establishmentId')
+    .optional()
+    .isUUID()
+    .withMessage('establishmentId must be a valid UUID')
+];
+
+/**
+ * GET /api/geo/statistics
+ *
+ * Get housing count statistics aggregated by geographic level.
+ *
+ * Query parameters:
+ * - level: 'region' | 'department' | 'epci' (required)
+ * - code: geographic code to filter by parent level (optional)
+ *   - For level=department: region code to filter departments
+ *   - For level=epci: department code to filter EPCIs
+ * - establishmentId: establishment ID to query (optional, admin only)
+ *
+ * Security:
+ * - Regular users: can only query their own establishment
+ * - Admins: can query any establishment via establishmentId parameter
+ * - All filter codes must be within the user's establishment perimeter
+ */
+async function getStatistics(request: Request, response: Response) {
+  const { auth, user } = request as AuthenticatedRequest;
+  const level = request.query.level as GeoLevel;
+  const code = request.query.code as string | undefined;
+  const requestedEstablishmentId = request.query.establishmentId as string | undefined;
+
+  const isAdmin = user.role === UserRole.ADMIN;
+
+  // Determine which establishment to query
+  // undefined = France entière (no establishment filter)
+  let targetEstablishmentId: string | undefined;
+
+  if (requestedEstablishmentId) {
+    // Admin can query any establishment
+    if (!isAdmin && requestedEstablishmentId !== auth.establishmentId) {
+      throw new ForbiddenError();
+    }
+    targetEstablishmentId = requestedEstablishmentId;
+  } else {
+    // Default to current user's establishment (may be undefined for France entière)
+    targetEstablishmentId = auth.establishmentId;
+  }
+
+  logger.info('Get geo statistics', {
+    userId: user.id,
+    targetEstablishmentId,
+    level,
+    code
+  });
+
+  // Initialize geo mappings (cached after first call)
+  await initializeMappings();
+
+  let statistics: GeoStatisticsDTO[];
+
+  switch (level) {
+    case 'region':
+      statistics = await getRegionStatistics(targetEstablishmentId);
+      break;
+    case 'department':
+      statistics = await getDepartmentStatistics(targetEstablishmentId, code);
+      break;
+    case 'epci':
+      statistics = await getEPCIStatistics(targetEstablishmentId, code);
+      break;
+    default:
+      throw new Error(`Invalid level: ${level}`);
+  }
+
+  const result: GeoStatisticsResponseDTO = {
+    level,
+    establishmentId: targetEstablishmentId,
+    statistics
+  };
+
+  response.status(constants.HTTP_STATUS_OK).json(result);
+}
+
+/**
+ * Get housing counts aggregated by region
+ * If establishmentId is undefined, returns statistics for all housings (France entière)
+ */
+async function getRegionStatistics(
+  establishmentId: string | undefined
+): Promise<GeoStatisticsDTO[]> {
+  // Get counts by department
+  const departmentCounts = await geoStatisticsRepository.countByDepartment({
+    establishmentId
+  });
+
+  // Aggregate by region
+  const regionCounts = new Map<string, number>();
+
+  for (const dept of departmentCounts) {
+    const regionCode = departmentToRegionMap!.get(dept.code);
+    if (regionCode) {
+      const current = regionCounts.get(regionCode) || 0;
+      regionCounts.set(regionCode, current + dept.housingCount);
+    }
+  }
+
+  // Convert to DTO array
+  const statistics: GeoStatisticsDTO[] = [];
+  for (const [code, count] of regionCounts) {
+    statistics.push({
+      code,
+      name: regionNamesMap!.get(code) || code,
+      housingCount: count
+    });
+  }
+
+  // Sort by housing count descending
+  return statistics.sort((a, b) => b.housingCount - a.housingCount);
+}
+
+/**
+ * Get housing counts by department, optionally filtered by region
+ * If establishmentId is undefined, returns statistics for all housings (France entière)
+ *
+ * Security: If regionCode is provided and establishmentId is set, validates that
+ * the establishment covers ALL communes of ALL departments in the region.
+ */
+async function getDepartmentStatistics(
+  establishmentId: string | undefined,
+  regionCode?: string
+): Promise<GeoStatisticsDTO[]> {
+  // Security check for region filter (restrictive: must have ALL communes of ALL departments)
+  if (regionCode && establishmentId) {
+    const establishment = await establishmentRepository.get(establishmentId);
+    if (!establishment) {
+      logger.warn('Establishment not found for department statistics', { establishmentId });
+      return [];
+    }
+
+    // Get all departments in the requested region
+    const departmentsInRegion = Array.from(departmentToRegionMap!.entries())
+      .filter(([, region]) => region === regionCode)
+      .map(([dept]) => dept);
+
+    const establishmentGeoCodes = new Set(establishment.geoCodes);
+
+    // For each department in the region, check that ALL communes are in the establishment
+    for (const deptCode of departmentsInRegion) {
+      const communesInDept = await geoAPI.getCommunesByDepartment(deptCode);
+      const hasAllCommunes = communesInDept.every((commune) =>
+        establishmentGeoCodes.has(commune.code)
+      );
+
+      if (!hasAllCommunes) {
+        const missingCommunes = communesInDept
+          .filter((commune) => !establishmentGeoCodes.has(commune.code))
+          .map((c) => c.code);
+        logger.warn('Region access denied - establishment does not cover all communes of department', {
+          establishmentId,
+          regionCode,
+          deptCode,
+          totalCommunes: communesInDept.length,
+          missingCount: missingCommunes.length
+        });
+        throw new ForbiddenError();
+      }
+    }
+  }
+
+  const departmentCounts = await geoStatisticsRepository.countByDepartment({
+    establishmentId
+  });
+
+  let filtered = departmentCounts;
+
+  // Filter by region if specified
+  if (regionCode) {
+    filtered = departmentCounts.filter((dept) => {
+      const deptRegion = departmentToRegionMap!.get(dept.code);
+      return deptRegion === regionCode;
+    });
+  }
+
+  return filtered.map((dept) => ({
+    code: dept.code,
+    name: departmentNamesMap!.get(dept.code) || dept.code,
+    housingCount: dept.housingCount
+  }));
+}
+
+/**
+ * Get housing counts by EPCI for a department
+ *
+ * Security: If departmentCode is provided and establishmentId is set, validates that
+ * the department is within the establishment's geoCodes.
+ * If establishmentId is undefined (France entière), no security check is performed.
+ */
+async function getEPCIStatistics(
+  establishmentId: string | undefined,
+  departmentCode?: string
+): Promise<GeoStatisticsDTO[]> {
+  if (!departmentCode) {
+    // Return empty array if no department code provided
+    return [];
+  }
+
+  // Get all communes in the department with their EPCI codes
+  const communes = await geoAPI.getCommunesByDepartment(departmentCode);
+
+  // Get EPCIs for this department to get their names
+  const epcis = await geoAPI.getEPCIsByDepartment(departmentCode);
+  const epciNamesMap = new Map(epcis.map((e) => [e.code, e.nom]));
+
+  // Security check for department filter (restrictive: must have ALL communes of ALL EPCIs)
+  if (establishmentId) {
+    const establishment = await establishmentRepository.get(establishmentId);
+    if (!establishment) {
+      logger.warn('Establishment not found for EPCI statistics', { establishmentId });
+      return [];
+    }
+
+    // Build a map of EPCI code -> communes in that EPCI
+    const epciToCommunes = new Map<string, string[]>();
+    for (const commune of communes) {
+      if (commune.codeEpci) {
+        const existing = epciToCommunes.get(commune.codeEpci) || [];
+        existing.push(commune.code);
+        epciToCommunes.set(commune.codeEpci, existing);
+      }
+    }
+
+    // Get all EPCIs in this department
+    const epcisInDepartment = Array.from(epciToCommunes.keys());
+
+    // Check that establishment has ALL communes of EACH EPCI in the department
+    const establishmentGeoCodes = new Set(establishment.geoCodes);
+    const hasAllEpcis = epcisInDepartment.every((epciCode) => {
+      const communesInEpci = epciToCommunes.get(epciCode) || [];
+      // Must have ALL communes of this EPCI, not just some
+      return communesInEpci.every((communeCode) =>
+        establishmentGeoCodes.has(communeCode)
+      );
+    });
+
+    if (!hasAllEpcis) {
+      const missingEpcis = epcisInDepartment.filter((epciCode) => {
+        const communesInEpci = epciToCommunes.get(epciCode) || [];
+        return !communesInEpci.every((communeCode) =>
+          establishmentGeoCodes.has(communeCode)
+        );
+      });
+      logger.warn('Department access denied - establishment does not cover all communes of all EPCIs', {
+        establishmentId,
+        departmentCode,
+        epcisInDepartment: epcisInDepartment.length,
+        missingEpcisCount: missingEpcis.length
+      });
+      throw new ForbiddenError();
+    }
+  }
+
+  // Get all commune geo codes
+  const communeGeoCodes = communes.map((c) => c.code);
+
+  // Get housing counts for these communes
+  const communeCounts = await geoStatisticsRepository.countByCommuneInGeoCodes(
+    establishmentId,
+    communeGeoCodes
+  );
+
+  // Create a map of commune -> housing count
+  const communeCountMap = new Map(
+    communeCounts.map((c) => [c.code, c.housingCount])
+  );
+
+  // Aggregate by EPCI
+  const epciCounts = new Map<string, number>();
+  for (const commune of communes) {
+    if (commune.codeEpci) {
+      const housingCount = communeCountMap.get(commune.code) || 0;
+      const current = epciCounts.get(commune.codeEpci) || 0;
+      epciCounts.set(commune.codeEpci, current + housingCount);
+    }
+  }
+
+  // Convert to DTO array, filtering out EPCIs with 0 housings
+  const statistics: GeoStatisticsDTO[] = [];
+  for (const [code, count] of epciCounts) {
+    if (count > 0) {
+      statistics.push({
+        code,
+        name: epciNamesMap.get(code) || code,
+        housingCount: count
+      });
+    }
+  }
+
+  // Sort by housing count descending
+  return statistics.sort((a, b) => b.housingCount - a.housingCount);
+}
+
+export default {
+  getStatisticsValidators,
+  getStatistics
+};

--- a/server/src/controllers/test/geo-statistics-api.test.ts
+++ b/server/src/controllers/test/geo-statistics-api.test.ts
@@ -1,0 +1,245 @@
+import { GeoStatisticsResponseDTO, UserRole } from '@zerologementvacant/models';
+import { constants } from 'http2';
+import request from 'supertest';
+
+import { createServer } from '~/infra/server';
+import { UserApi } from '~/models/UserApi';
+import {
+  Establishments,
+  formatEstablishmentApi
+} from '~/repositories/establishmentRepository';
+import {
+  formatHousingRecordApi,
+  Housing
+} from '~/repositories/housingRepository';
+import { formatUserApi, Users } from '~/repositories/userRepository';
+import {
+  genEstablishmentApi,
+  genHousingApi,
+  genUserApi
+} from '~/test/testFixtures';
+import { tokenProvider } from '~/test/testUtils';
+
+describe('Geo Statistics API', () => {
+  let url: string;
+
+  beforeAll(async () => {
+    url = await createServer().testing();
+  });
+
+  // Create establishments with different geo codes
+  // Establishment with geoCodes in Grand Est (67, 68) and Pays de la Loire (44)
+  const establishment = genEstablishmentApi();
+  const establishmentWithGeoCodes = {
+    ...establishment,
+    geoCodes: ['67482', '67043', '68066', '44109', '44162']
+  };
+
+  const user: UserApi = {
+    ...genUserApi(establishmentWithGeoCodes.id),
+    role: UserRole.USUAL
+  };
+
+  const admin: UserApi = {
+    ...genUserApi(establishmentWithGeoCodes.id),
+    role: UserRole.ADMIN
+  };
+
+  const anotherEstablishment = genEstablishmentApi();
+  const anotherEstablishmentWithGeoCodes = {
+    ...anotherEstablishment,
+    geoCodes: ['75101', '75102', '75103'] // Paris
+  };
+  const anotherUser: UserApi = {
+    ...genUserApi(anotherEstablishmentWithGeoCodes.id),
+    role: UserRole.USUAL
+  };
+
+  beforeAll(async () => {
+    await Establishments().insert(
+      [establishmentWithGeoCodes, anotherEstablishmentWithGeoCodes].map(
+        formatEstablishmentApi
+      )
+    );
+    await Users().insert([user, admin, anotherUser].map(formatUserApi));
+
+    // Create housing in the establishment's geo codes
+    const housings = [
+      // Grand Est - Bas-Rhin (67)
+      genHousingApi('67482'),
+      genHousingApi('67482'),
+      genHousingApi('67043'),
+      // Grand Est - Haut-Rhin (68)
+      genHousingApi('68066'),
+      genHousingApi('68066'),
+      // Pays de la Loire - Loire-Atlantique (44)
+      genHousingApi('44109'),
+      // Another establishment - Paris (75)
+      genHousingApi('75101'),
+      genHousingApi('75102')
+    ];
+
+    await Housing().insert(housings.map(formatHousingRecordApi));
+  });
+
+  describe('GET /geo/statistics', () => {
+    const testRoute = '/api/geo/statistics';
+
+    it('should require authentication', async () => {
+      const { status } = await request(url).get(testRoute).query({
+        level: 'region'
+      });
+
+      expect(status).toBe(constants.HTTP_STATUS_UNAUTHORIZED);
+    });
+
+    it('should require level parameter', async () => {
+      const { status } = await request(url)
+        .get(testRoute)
+        .use(tokenProvider(user));
+
+      expect(status).toBe(constants.HTTP_STATUS_BAD_REQUEST);
+    });
+
+    it('should reject invalid level parameter', async () => {
+      const { status } = await request(url)
+        .get(testRoute)
+        .query({ level: 'invalid' })
+        .use(tokenProvider(user));
+
+      expect(status).toBe(constants.HTTP_STATUS_BAD_REQUEST);
+    });
+
+    describe('level=region', () => {
+      it('should return statistics by region', async () => {
+        const { body, status } = await request(url)
+          .get(testRoute)
+          .query({ level: 'region' })
+          .use(tokenProvider(user));
+
+        expect(status).toBe(constants.HTTP_STATUS_OK);
+        expect(body).toMatchObject<GeoStatisticsResponseDTO>({
+          level: 'region',
+          establishmentId: establishmentWithGeoCodes.id,
+          statistics: expect.any(Array)
+        });
+        expect(body.statistics.length).toBeGreaterThan(0);
+        // Each statistic should have code, name, and housingCount
+        body.statistics.forEach((stat: { code: string; name: string; housingCount: number }) => {
+          expect(stat).toHaveProperty('code');
+          expect(stat).toHaveProperty('name');
+          expect(stat).toHaveProperty('housingCount');
+          expect(stat.housingCount).toBeGreaterThan(0);
+        });
+      });
+    });
+
+    describe('level=department', () => {
+      it('should return statistics by department', async () => {
+        const { body, status } = await request(url)
+          .get(testRoute)
+          .query({ level: 'department' })
+          .use(tokenProvider(user));
+
+        expect(status).toBe(constants.HTTP_STATUS_OK);
+        expect(body.level).toBe('department');
+        expect(body.statistics.length).toBeGreaterThan(0);
+      });
+
+      it('should reject region code if establishment does not cover ALL departments (restrictive)', async () => {
+        // Establishment has geoCodes in 67, 68, 44 only
+        // Region 44 (Grand Est) has 10 departments: 67, 68, 57, 54, 55, 08, 10, 51, 52, 88
+        // Since establishment doesn't cover ALL departments, access should be denied
+        const { status } = await request(url)
+          .get(testRoute)
+          .query({ level: 'department', code: '44' }) // Grand Est
+          .use(tokenProvider(user));
+
+        expect(status).toBe(constants.HTTP_STATUS_FORBIDDEN);
+      });
+
+      it('should reject region code outside establishment perimeter', async () => {
+        const { status } = await request(url)
+          .get(testRoute)
+          .query({ level: 'department', code: '11' }) // Île-de-France - not in establishment geoCodes
+          .use(tokenProvider(user));
+
+        expect(status).toBe(constants.HTTP_STATUS_FORBIDDEN);
+      });
+    });
+
+    describe('level=epci', () => {
+      it('should return empty array if no department code provided', async () => {
+        const { body, status } = await request(url)
+          .get(testRoute)
+          .query({ level: 'epci' })
+          .use(tokenProvider(user));
+
+        expect(status).toBe(constants.HTTP_STATUS_OK);
+        expect(body.level).toBe('epci');
+        expect(body.statistics).toEqual([]);
+      });
+
+      it('should reject department code if establishment does not cover ALL EPCIs (restrictive)', async () => {
+        // Establishment has geoCodes ['67482', '67043'] which are both in Eurométropole de Strasbourg
+        // Department 67 (Bas-Rhin) has 25 EPCIs
+        // Since establishment only covers 1 EPCI out of 25, access should be denied
+        const { status } = await request(url)
+          .get(testRoute)
+          .query({ level: 'epci', code: '67' }) // Bas-Rhin
+          .use(tokenProvider(user));
+
+        expect(status).toBe(constants.HTTP_STATUS_FORBIDDEN);
+      });
+
+      it('should reject department code outside establishment perimeter', async () => {
+        const { status } = await request(url)
+          .get(testRoute)
+          .query({ level: 'epci', code: '75' }) // Paris - not in establishment geoCodes
+          .use(tokenProvider(user));
+
+        expect(status).toBe(constants.HTTP_STATUS_FORBIDDEN);
+      });
+    });
+
+    describe('security', () => {
+      it('should not allow regular users to query other establishments', async () => {
+        const { status } = await request(url)
+          .get(testRoute)
+          .query({
+            level: 'region',
+            establishmentId: anotherEstablishmentWithGeoCodes.id
+          })
+          .use(tokenProvider(user));
+
+        expect(status).toBe(constants.HTTP_STATUS_FORBIDDEN);
+      });
+
+      it('should allow admin to query any establishment', async () => {
+        const { body, status } = await request(url)
+          .get(testRoute)
+          .query({
+            level: 'region',
+            establishmentId: anotherEstablishmentWithGeoCodes.id
+          })
+          .use(tokenProvider(admin));
+
+        expect(status).toBe(constants.HTTP_STATUS_OK);
+        expect(body.establishmentId).toBe(anotherEstablishmentWithGeoCodes.id);
+      });
+
+      it('should allow users to query their own establishment explicitly', async () => {
+        const { body, status } = await request(url)
+          .get(testRoute)
+          .query({
+            level: 'region',
+            establishmentId: establishmentWithGeoCodes.id
+          })
+          .use(tokenProvider(user));
+
+        expect(status).toBe(constants.HTTP_STATUS_OK);
+        expect(body.establishmentId).toBe(establishmentWithGeoCodes.id);
+      });
+    });
+  });
+});

--- a/server/src/repositories/geoStatisticsRepository.ts
+++ b/server/src/repositories/geoStatisticsRepository.ts
@@ -1,0 +1,182 @@
+import db from '~/infra/database';
+import { createLogger } from '~/infra/logger';
+import { housingTable } from './housingRepository';
+import { establishmentsTable } from './establishmentRepository';
+
+const logger = createLogger('geoStatisticsRepository');
+
+export interface HousingCountByGeo {
+  code: string;
+  housingCount: number;
+}
+
+interface CountByDepartmentOptions {
+  /** If undefined, returns statistics for all housings (France entière) */
+  establishmentId?: string;
+  regionCode?: string;
+}
+
+interface CountByCommuneOptions {
+  /** If undefined, returns statistics for all housings (France entière) */
+  establishmentId?: string;
+  epciCode?: string;
+}
+
+/**
+ * Count housings by department for an establishment
+ * If no establishmentId provided, returns statistics for all housings (France entière)
+ */
+async function countByDepartment(
+  options: CountByDepartmentOptions
+): Promise<HousingCountByGeo[]> {
+  logger.debug('Count housings by department', options);
+
+  let query: string;
+  let params: string[];
+
+  if (options.establishmentId) {
+    // Filter by establishment's geoCodes
+    query = `
+      SELECT
+        SUBSTRING(fh.geo_code FROM 1 FOR 2) AS code,
+        COUNT(*)::text AS housing_count
+      FROM ${establishmentsTable} e
+      JOIN ${housingTable} fh
+        ON fh.geo_code = ANY(e.localities_geo_code)
+      WHERE e.id = ?
+      GROUP BY SUBSTRING(fh.geo_code FROM 1 FOR 2)
+      ORDER BY housing_count DESC
+    `;
+    params = [options.establishmentId];
+  } else {
+    // France entière: count all housings by department
+    query = `
+      SELECT
+        SUBSTRING(fh.geo_code FROM 1 FOR 2) AS code,
+        COUNT(*)::text AS housing_count
+      FROM ${housingTable} fh
+      GROUP BY SUBSTRING(fh.geo_code FROM 1 FOR 2)
+      ORDER BY housing_count DESC
+    `;
+    params = [];
+  }
+
+  const result = await db.raw<{ rows: { code: string; housing_count: string }[] }>(
+    query,
+    params
+  );
+
+  return result.rows.map((row) => ({
+    code: row.code,
+    housingCount: parseInt(row.housing_count, 10)
+  }));
+}
+
+/**
+ * Count housings by commune for an establishment, optionally filtered by EPCI
+ */
+async function countByCommune(
+  options: CountByCommuneOptions
+): Promise<HousingCountByGeo[]> {
+  logger.debug('Count housings by commune', options);
+
+  if (!options.establishmentId) {
+    logger.warn('countByCommune called without establishmentId');
+    return [];
+  }
+
+  let query = `
+    SELECT
+      fh.geo_code AS code,
+      COUNT(*)::text AS housing_count
+    FROM ${establishmentsTable} e
+    JOIN ${housingTable} fh
+      ON fh.geo_code = ANY(e.localities_geo_code)
+    WHERE e.id = ?
+  `;
+
+  const params: string[] = [options.establishmentId];
+
+  if (options.epciCode) {
+    // We'll filter by EPCI codes provided by the controller
+    // For now, we just return all communes
+  }
+
+  query += `
+    GROUP BY fh.geo_code
+    ORDER BY housing_count DESC
+  `;
+
+  const result = await db.raw<{ rows: { code: string; housing_count: string }[] }>(
+    query,
+    params
+  );
+
+  return result.rows.map((row) => ({
+    code: row.code,
+    housingCount: parseInt(row.housing_count, 10)
+  }));
+}
+
+/**
+ * Count housings by commune for specific geo codes
+ * If no establishmentId provided, counts all housings in those geoCodes (France entière)
+ */
+async function countByCommuneInGeoCodes(
+  establishmentId: string | undefined,
+  geoCodes: string[]
+): Promise<HousingCountByGeo[]> {
+  logger.debug('Count housings by commune in geoCodes', { establishmentId, geoCodesCount: geoCodes.length });
+
+  if (geoCodes.length === 0) {
+    return [];
+  }
+
+  let query: string;
+  let params: (string | string[])[];
+
+  if (establishmentId) {
+    // Filter by establishment's geoCodes AND the requested geoCodes
+    query = `
+      SELECT
+        fh.geo_code AS code,
+        COUNT(*)::text AS housing_count
+      FROM ${establishmentsTable} e
+      JOIN ${housingTable} fh
+        ON fh.geo_code = ANY(e.localities_geo_code)
+      WHERE e.id = ?
+        AND fh.geo_code = ANY(?)
+      GROUP BY fh.geo_code
+      ORDER BY housing_count DESC
+    `;
+    params = [establishmentId, geoCodes];
+  } else {
+    // France entière: count all housings in the requested geoCodes
+    query = `
+      SELECT
+        fh.geo_code AS code,
+        COUNT(*)::text AS housing_count
+      FROM ${housingTable} fh
+      WHERE fh.geo_code = ANY(?)
+      GROUP BY fh.geo_code
+      ORDER BY housing_count DESC
+    `;
+    params = [geoCodes];
+  }
+
+  const result = await db.raw<{ rows: { code: string; housing_count: string }[] }>(
+    query,
+    params
+  );
+
+  return result.rows.map((row) => ({
+    code: row.code,
+    housingCount: parseInt(row.housing_count, 10)
+  }));
+}
+
+export default {
+  countByDepartment,
+  countByCommune,
+  countByCommuneInGeoCodes
+};

--- a/server/src/routers/protected.ts
+++ b/server/src/routers/protected.ts
@@ -18,6 +18,7 @@ import draftController from '~/controllers/draftController';
 import eventController from '~/controllers/eventController';
 import fileController from '~/controllers/fileController';
 import geoController from '~/controllers/geoController';
+import geoStatisticsController from '~/controllers/geoStatisticsController';
 import groupController from '~/controllers/groupController';
 import housingController from '~/controllers/housingController';
 import housingExportController from '~/controllers/housingExportController';
@@ -455,6 +456,13 @@ router.delete(
   geoController.deleteGeoPerimeterListValidators,
   validator.validate,
   geoController.deleteGeoPerimeterList
+);
+
+router.get(
+  '/geo/statistics',
+  geoStatisticsController.getStatisticsValidators,
+  validator.validate,
+  geoStatisticsController.getStatistics
 );
 
 router.put(

--- a/server/src/services/geo/geo-api.ts
+++ b/server/src/services/geo/geo-api.ts
@@ -1,0 +1,363 @@
+import axios, { AxiosError, AxiosInstance } from 'axios';
+import {
+  GeoDepartment,
+  GeoEPCI,
+  GeoRegion
+} from '@zerologementvacant/models';
+import { createLogger } from '~/infra/logger';
+
+const logger = createLogger('geo-api');
+
+/**
+ * Commune with EPCI information from geo.api.gouv.fr
+ */
+export interface GeoCommune {
+  code: string;
+  nom: string;
+  codeDepartement: string;
+  codeRegion: string;
+  codeEpci?: string;
+}
+
+/**
+ * EPCI with department codes from geo.api.gouv.fr
+ */
+export interface GeoEPCIWithDepartments {
+  code: string;
+  nom: string;
+  codesDepartements: string[];
+  codesRegions: string[];
+  population: number;
+}
+
+export interface GeoAPI {
+  getRegions(): Promise<GeoRegion[]>;
+  getDepartments(): Promise<GeoDepartment[]>;
+  getEPCI(siren: string): Promise<GeoEPCI | null>;
+  getEPCIsByDepartment(departmentCode: string): Promise<GeoEPCIWithDepartments[]>;
+  getCommune(geoCode: string): Promise<GeoCommune | null>;
+  getCommunesByDepartment(departmentCode: string): Promise<GeoCommune[]>;
+  getCommunesByEPCI(epciSiren: string): Promise<GeoCommune[]>;
+}
+
+interface CacheEntry<T> {
+  data: T;
+  expiresAt: number;
+}
+
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours for static geo data
+const MAX_RETRIES = 3;
+const RETRY_DELAY_MS = 1000;
+
+/**
+ * Retry a function with exponential backoff
+ */
+async function withRetry<T>(
+  fn: () => Promise<T>,
+  context: string,
+  maxRetries = MAX_RETRIES
+): Promise<T> {
+  let lastError: Error | null = null;
+
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error as Error;
+
+      const isRetryable =
+        axios.isAxiosError(error) &&
+        (error.code === 'ECONNRESET' ||
+          error.code === 'ETIMEDOUT' ||
+          error.code === 'ENOTFOUND' ||
+          error.response?.status === 429 ||
+          error.response?.status === 503 ||
+          error.response?.status === 502 ||
+          error.response?.status === 504);
+
+      if (!isRetryable || attempt === maxRetries) {
+        logger.error(`${context} failed after ${attempt} attempt(s)`, {
+          error: axios.isAxiosError(error)
+            ? { code: error.code, status: error.response?.status, message: error.message }
+            : { message: (error as Error).message }
+        });
+        throw error;
+      }
+
+      const delay = RETRY_DELAY_MS * Math.pow(2, attempt - 1);
+      logger.warn(`${context} failed, retrying in ${delay}ms (attempt ${attempt}/${maxRetries})`, {
+        error: axios.isAxiosError(error)
+          ? { code: error.code, status: error.response?.status }
+          : { message: (error as Error).message }
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+  }
+
+  throw lastError;
+}
+
+class GeoAPIImpl implements GeoAPI {
+  private readonly http: AxiosInstance;
+  private regionsCache: CacheEntry<GeoRegion[]> | null = null;
+  private departmentsCache: CacheEntry<GeoDepartment[]> | null = null;
+  private communesByEPCICache: Map<string, CacheEntry<GeoCommune[]>> = new Map();
+
+  constructor() {
+    this.http = axios.create({
+      baseURL: 'https://geo.api.gouv.fr',
+      timeout: 10000
+    });
+
+    // Log all requests for debugging
+    this.http.interceptors.request.use((config) => {
+      logger.debug('geo.api.gouv.fr request', {
+        method: config.method?.toUpperCase(),
+        url: config.url
+      });
+      return config;
+    });
+
+    // Log response times
+    this.http.interceptors.response.use(
+      (response) => {
+        logger.debug('geo.api.gouv.fr response', {
+          url: response.config.url,
+          status: response.status,
+          duration: response.headers['x-response-time']
+        });
+        return response;
+      },
+      (error: AxiosError) => {
+        logger.warn('geo.api.gouv.fr error', {
+          url: error.config?.url,
+          status: error.response?.status,
+          code: error.code,
+          message: error.message
+        });
+        return Promise.reject(error);
+      }
+    );
+  }
+
+  private isCacheValid<T>(cache: CacheEntry<T> | null | undefined): cache is CacheEntry<T> {
+    return cache !== null && cache !== undefined && Date.now() < cache.expiresAt;
+  }
+
+  async getRegions(): Promise<GeoRegion[]> {
+    if (this.isCacheValid(this.regionsCache)) {
+      logger.debug('Using cached regions');
+      return this.regionsCache.data;
+    }
+
+    const data = await withRetry(
+      async () => {
+        const response = await this.http.get<GeoRegion[]>('/regions');
+        return response.data;
+      },
+      'Fetching regions'
+    );
+
+    this.regionsCache = {
+      data,
+      expiresAt: Date.now() + CACHE_TTL_MS
+    };
+
+    logger.info('Fetched and cached regions', { count: data.length });
+    return data;
+  }
+
+  async getDepartments(): Promise<GeoDepartment[]> {
+    if (this.isCacheValid(this.departmentsCache)) {
+      logger.debug('Using cached departments');
+      return this.departmentsCache.data;
+    }
+
+    const data = await withRetry(
+      async () => {
+        const response = await this.http.get<GeoDepartment[]>('/departements');
+        return response.data;
+      },
+      'Fetching departments'
+    );
+
+    this.departmentsCache = {
+      data,
+      expiresAt: Date.now() + CACHE_TTL_MS
+    };
+
+    logger.info('Fetched and cached departments', { count: data.length });
+    return data;
+  }
+
+  async getEPCI(siren: string): Promise<GeoEPCI | null> {
+    // Validate SIREN format (9 digits)
+    if (!/^\d{9}$/.test(siren)) {
+      logger.warn('Invalid EPCI SIREN format', { siren });
+      return null;
+    }
+
+    try {
+      const data = await withRetry(
+        async () => {
+          const response = await this.http.get<GeoEPCI>(`/epcis/${siren}`);
+          return response.data;
+        },
+        `Fetching EPCI ${siren}`
+      );
+      return data;
+    } catch (error) {
+      if (axios.isAxiosError(error) && error.response?.status === 404) {
+        logger.debug('EPCI not found', { siren });
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  async getEPCIsByDepartment(departmentCode: string): Promise<GeoEPCIWithDepartments[]> {
+    // Validate department code format (2 or 3 characters for DOM-TOM)
+    if (!/^[0-9]{2,3}[A-B]?$/.test(departmentCode)) {
+      logger.warn('Invalid department code format for EPCI lookup', { departmentCode });
+      return [];
+    }
+
+    try {
+      const data = await withRetry(
+        async () => {
+          const response = await this.http.get<GeoEPCIWithDepartments[]>(
+            '/epcis',
+            { params: { codeDepartement: departmentCode } }
+          );
+          return response.data;
+        },
+        `Fetching EPCIs for department ${departmentCode}`
+      );
+
+      logger.info('Fetched EPCIs for department', {
+        departmentCode,
+        count: data.length
+      });
+
+      return data;
+    } catch (error) {
+      if (axios.isAxiosError(error) && error.response?.status === 404) {
+        logger.debug('No EPCIs found for department', { departmentCode });
+        return [];
+      }
+      throw error;
+    }
+  }
+
+  async getCommunesByDepartment(departmentCode: string): Promise<GeoCommune[]> {
+    // Validate department code format (2 or 3 characters for DOM-TOM)
+    if (!/^[0-9]{2,3}[A-B]?$/.test(departmentCode)) {
+      logger.warn('Invalid department code format for communes lookup', { departmentCode });
+      return [];
+    }
+
+    try {
+      const data = await withRetry(
+        async () => {
+          const response = await this.http.get<GeoCommune[]>(
+            `/departements/${departmentCode}/communes`,
+            { params: { fields: 'code,nom,codeDepartement,codeRegion,codeEpci' } }
+          );
+          return response.data;
+        },
+        `Fetching communes for department ${departmentCode}`
+      );
+
+      logger.info('Fetched communes for department', {
+        departmentCode,
+        count: data.length
+      });
+
+      return data;
+    } catch (error) {
+      if (axios.isAxiosError(error) && error.response?.status === 404) {
+        logger.debug('No communes found for department', { departmentCode });
+        return [];
+      }
+      throw error;
+    }
+  }
+
+  async getCommune(geoCode: string): Promise<GeoCommune | null> {
+    // Validate geo code format (5 characters)
+    if (!/^[0-9A-Z]{5}$/.test(geoCode)) {
+      logger.warn('Invalid commune geo code format', { geoCode });
+      return null;
+    }
+
+    try {
+      const data = await withRetry(
+        async () => {
+          const response = await this.http.get<GeoCommune>(`/communes/${geoCode}`);
+          return response.data;
+        },
+        `Fetching commune ${geoCode}`
+      );
+      return data;
+    } catch (error) {
+      if (axios.isAxiosError(error) && error.response?.status === 404) {
+        logger.debug('Commune not found', { geoCode });
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  async getCommunesByEPCI(epciSiren: string): Promise<GeoCommune[]> {
+    // Validate SIREN format
+    if (!/^\d{9}$/.test(epciSiren)) {
+      logger.warn('Invalid EPCI SIREN format for communes lookup', { epciSiren });
+      return [];
+    }
+
+    // Check cache
+    const cached = this.communesByEPCICache.get(epciSiren);
+    if (this.isCacheValid(cached)) {
+      logger.debug('Using cached communes for EPCI', { epciSiren });
+      return cached.data;
+    }
+
+    try {
+      const data = await withRetry(
+        async () => {
+          const response = await this.http.get<GeoCommune[]>(
+            `/epcis/${epciSiren}/communes`
+          );
+          return response.data;
+        },
+        `Fetching communes for EPCI ${epciSiren}`
+      );
+
+      // Cache the result
+      this.communesByEPCICache.set(epciSiren, {
+        data,
+        expiresAt: Date.now() + CACHE_TTL_MS
+      });
+
+      logger.info('Fetched and cached communes for EPCI', {
+        epciSiren,
+        count: data.length
+      });
+
+      return data;
+    } catch (error) {
+      if (axios.isAxiosError(error) && error.response?.status === 404) {
+        logger.warn('EPCI not found for communes lookup', { epciSiren });
+        return [];
+      }
+      throw error;
+    }
+  }
+}
+
+export function createGeoAPI(): GeoAPI {
+  return new GeoAPIImpl();
+}
+
+export default createGeoAPI();

--- a/server/src/services/geo/geo-api.ts
+++ b/server/src/services/geo/geo-api.ts
@@ -199,9 +199,11 @@ class GeoAPIImpl implements GeoAPI {
     }
 
     try {
+      // Use encodeURIComponent for defense in depth
+      const safeSiren = encodeURIComponent(siren);
       const data = await withRetry(
         async () => {
-          const response = await this.http.get<GeoEPCI>(`/epcis/${siren}`);
+          const response = await this.http.get<GeoEPCI>(`/epcis/${safeSiren}`);
           return response.data;
         },
         `Fetching EPCI ${siren}`
@@ -264,10 +266,12 @@ class GeoAPIImpl implements GeoAPI {
     }
 
     try {
+      // Use encodeURIComponent for defense in depth (even though regex validation prevents injection)
+      const safeDepartmentCode = encodeURIComponent(departmentCode);
       const data = await withRetry(
         async () => {
           const response = await this.http.get<GeoCommune[]>(
-            `/departements/${departmentCode}/communes`,
+            `/departements/${safeDepartmentCode}/communes`,
             { params: { fields: 'code,nom,codeDepartement,codeRegion,codeEpci' } }
           );
           return response.data;
@@ -298,9 +302,11 @@ class GeoAPIImpl implements GeoAPI {
     }
 
     try {
+      // Use encodeURIComponent for defense in depth
+      const safeGeoCode = encodeURIComponent(geoCode);
       const data = await withRetry(
         async () => {
-          const response = await this.http.get<GeoCommune>(`/communes/${geoCode}`);
+          const response = await this.http.get<GeoCommune>(`/communes/${safeGeoCode}`);
           return response.data;
         },
         `Fetching commune ${geoCode}`
@@ -330,10 +336,12 @@ class GeoAPIImpl implements GeoAPI {
     }
 
     try {
+      // Use encodeURIComponent for defense in depth
+      const safeEpciSiren = encodeURIComponent(epciSiren);
       const data = await withRetry(
         async () => {
           const response = await this.http.get<GeoCommune[]>(
-            `/epcis/${epciSiren}/communes`
+            `/epcis/${safeEpciSiren}/communes`
           );
           return response.data;
         },

--- a/server/src/services/geo/geo-api.ts
+++ b/server/src/services/geo/geo-api.ts
@@ -217,8 +217,11 @@ class GeoAPIImpl implements GeoAPI {
   }
 
   async getEPCIsByDepartment(departmentCode: string): Promise<GeoEPCIWithDepartments[]> {
-    // Validate department code format (2 or 3 characters for DOM-TOM)
-    if (!/^[0-9]{2,3}[A-B]?$/.test(departmentCode)) {
+    // Validate department code format:
+    // - Metropolitan: 01-95 (2 digits)
+    // - Corsica: 2A, 2B
+    // - DOM-TOM: 971-976, 984-989 (3 digits)
+    if (!/^([0-9]{2,3}|2[AB])$/.test(departmentCode)) {
       logger.warn('Invalid department code format for EPCI lookup', { departmentCode });
       return [];
     }
@@ -251,8 +254,11 @@ class GeoAPIImpl implements GeoAPI {
   }
 
   async getCommunesByDepartment(departmentCode: string): Promise<GeoCommune[]> {
-    // Validate department code format (2 or 3 characters for DOM-TOM)
-    if (!/^[0-9]{2,3}[A-B]?$/.test(departmentCode)) {
+    // Validate department code format:
+    // - Metropolitan: 01-95 (2 digits)
+    // - Corsica: 2A, 2B
+    // - DOM-TOM: 971-976, 984-989 (3 digits)
+    if (!/^([0-9]{2,3}|2[AB])$/.test(departmentCode)) {
       logger.warn('Invalid department code format for communes lookup', { departmentCode });
       return [];
     }


### PR DESCRIPTION
## Summary

Add a new API endpoint `GET /api/geo/statistics` that returns housing counts aggregated by geographic level (region, department, EPCI) for map visualization.

### Key Features

- **Three aggregation levels**: region, department, EPCI
- **Hierarchical drill-down**: optional `code` filter parameter for parent-level filtering
- **Strict security**: users can only access data within their establishment perimeter
- **Restrictive perimeter validation**: establishment must cover ALL communes of ALL subdivisions to access filtered data

## API Documentation

### Endpoint

```
GET /api/geo/statistics
```

### Query Parameters

| Parameter | Type | Required | Description |
|-----------|------|----------|-------------|
| `level` | string | Yes | Aggregation level: `region`, `department`, or `epci` |
| `code` | string | No | Filter by parent geographic code (region code for departments, department code for EPCIs) |
| `establishmentId` | UUID | No | Admin only: query a specific establishment |

### Example Responses

#### Level: Region (no filter)

```http
GET /api/geo/statistics?level=region
```

```json
{
  "level": "region",
  "establishmentId": "abc123-...",
  "statistics": [
    { "code": "44", "name": "Grand Est", "housingCount": 1250 },
    { "code": "52", "name": "Pays de la Loire", "housingCount": 890 },
    { "code": "11", "name": "Île-de-France", "housingCount": 650 }
  ]
}
```

#### Level: Department (filtered by region)

```http
GET /api/geo/statistics?level=department&code=44
```

```json
{
  "level": "department",
  "establishmentId": "abc123-...",
  "statistics": [
    { "code": "67", "name": "Bas-Rhin", "housingCount": 450 },
    { "code": "68", "name": "Haut-Rhin", "housingCount": 380 },
    { "code": "57", "name": "Moselle", "housingCount": 220 }
  ]
}
```

#### Level: EPCI (filtered by department)

```http
GET /api/geo/statistics?level=epci&code=67
```

```json
{
  "level": "epci",
  "establishmentId": "abc123-...",
  "statistics": [
    { "code": "246700488", "name": "Eurométropole de Strasbourg", "housingCount": 320 },
    { "code": "200067924", "name": "CA de Haguenau", "housingCount": 85 }
  ]
}
```

## Security Model

### Restrictive Perimeter Validation

For an establishment to access filtered statistics:

1. **Region filter** (`level=department&code={regionCode}`):
   - Establishment must have **ALL communes** of **ALL departments** in the region

2. **Department filter** (`level=epci&code={departmentCode}`):
   - Establishment must have **ALL communes** of **ALL EPCIs** in the department

This ensures users can only see aggregated data for areas they fully cover.

### Access Rules

| User Role | Own Establishment | Other Establishments |
|-----------|-------------------|----------------------|
| Regular User | ✅ Full access | ❌ Forbidden |
| Admin | ✅ Full access | ✅ Full access via `establishmentId` param |

## Implementation Details

### New Files

- `packages/models/src/GeoStatisticsDTO.ts` - DTOs for the API response
- `server/src/controllers/geoStatisticsController.ts` - Main controller with security validation
- `server/src/repositories/geoStatisticsRepository.ts` - Database queries for housing counts
- `server/src/services/geo/geo-api.ts` - geo.api.gouv.fr client with caching and retry logic

### External Dependencies

Uses `geo.api.gouv.fr` for:
- Region and department reference data (cached 24h)
- EPCI and commune lookups for security validation

## Test Plan

- [x] Authentication required (401 for unauthenticated)
- [x] Level parameter required (400 if missing)
- [x] Level parameter validation (400 for invalid values)
- [x] Region level returns aggregated statistics
- [x] Department level returns statistics
- [x] Department level rejects unauthorized region codes (403)
- [x] EPCI level returns empty array without department code
- [x] EPCI level rejects unauthorized department codes (403)
- [x] Regular users cannot query other establishments (403)
- [x] Admins can query any establishment (200)
- [x] Users can query their own establishment explicitly (200)

All 13 tests passing.