### PR TITLE
feat: add housing creation from RNB buildings on map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,9 +36,10 @@ lerna-debug.log
 /talisman_report
 .clever.json
 
-# Data Stack
+# Data Stack / Python
 .pyc
 __pycache__
+venv/
 analytics/dagster/storage/
 .duckdb
 .jsonl

--- a/frontend/src/components/Map/RNBBuildings.tsx
+++ b/frontend/src/components/Map/RNBBuildings.tsx
@@ -1,0 +1,251 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useMap } from 'react-map-gl/maplibre';
+import type { FeatureCollection, MultiPolygon } from 'geojson';
+import type { MapMouseEvent } from 'maplibre-gl';
+
+import config from '../../utils/config';
+
+const SOURCE_ID = 'rnb-buildings';
+const FILL_LAYER_ID = 'rnb-buildings-fill';
+const OUTLINE_LAYER_ID = 'rnb-buildings-outline';
+
+// Minimum zoom level to start loading buildings
+const MIN_ZOOM_FOR_FETCH = 14;
+
+// Debounce delay in milliseconds
+const FETCH_DEBOUNCE_MS = 300;
+
+interface Props {
+  isVisible?: boolean;
+  onBuildingClick?: (rnbId: string) => void;
+}
+
+interface RNBBuildingProperties {
+  rnb_id: string;
+  status: string;
+}
+
+type RNBFeatureCollection = FeatureCollection<MultiPolygon, RNBBuildingProperties>;
+
+/**
+ * Display RNB (Référentiel National des Bâtiments) building outlines on the map.
+ * Dynamically fetches buildings based on the current viewport.
+ */
+function RNBBuildings(props: Props) {
+  const { housingMap: map } = useMap();
+  const isVisible = props.isVisible ?? true;
+  const addedRef = useRef(false);
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>();
+  const [, setIsLoading] = useState(false);
+
+  const fetchBuildings = useCallback(async () => {
+    if (!map) return;
+
+    const mapInstance = map.getMap();
+    const zoom = mapInstance.getZoom();
+
+    // Only fetch at sufficient zoom level
+    if (zoom < MIN_ZOOM_FOR_FETCH) {
+      // Clear existing data when zoomed out
+      const source = mapInstance.getSource(SOURCE_ID);
+      if (source && source.type === 'geojson') {
+        (source as maplibregl.GeoJSONSource).setData({
+          type: 'FeatureCollection',
+          features: []
+        });
+      }
+      return;
+    }
+
+    const bounds = mapInstance.getBounds();
+    const minLon = bounds.getWest();
+    const maxLon = bounds.getEast();
+    const minLat = bounds.getSouth();
+    const maxLat = bounds.getNorth();
+
+    setIsLoading(true);
+
+    try {
+      const url = new URL('/api/rnb/buildings', config.apiEndpoint);
+      url.searchParams.set('minLon', minLon.toString());
+      url.searchParams.set('maxLon', maxLon.toString());
+      url.searchParams.set('minLat', minLat.toString());
+      url.searchParams.set('maxLat', maxLat.toString());
+      url.searchParams.set('limit', '5000');
+
+      const response = await fetch(url.toString());
+      if (!response.ok) {
+        console.warn('Failed to fetch RNB buildings:', response.status);
+        return;
+      }
+
+      const geojson: RNBFeatureCollection = await response.json();
+
+      // Update source data
+      const source = mapInstance.getSource(SOURCE_ID);
+      if (source && source.type === 'geojson') {
+        (source as maplibregl.GeoJSONSource).setData(geojson);
+      }
+    } catch (error) {
+      console.warn('Error fetching RNB buildings:', error);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [map]);
+
+  const debouncedFetch = useCallback(() => {
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+    }
+    debounceRef.current = setTimeout(() => {
+      fetchBuildings();
+    }, FETCH_DEBOUNCE_MS);
+  }, [fetchBuildings]);
+
+  useEffect(() => {
+    if (!map) return;
+
+    const mapInstance = map.getMap();
+
+    const addSourceAndLayers = () => {
+      // Prevent duplicate additions
+      if (addedRef.current) return;
+      if (mapInstance.getSource(SOURCE_ID)) return;
+
+      try {
+        // Add empty source that will be populated dynamically
+        mapInstance.addSource(SOURCE_ID, {
+          type: 'geojson',
+          data: {
+            type: 'FeatureCollection',
+            features: []
+          }
+        });
+
+        mapInstance.addLayer({
+          id: FILL_LAYER_ID,
+          type: 'fill',
+          source: SOURCE_ID,
+          minzoom: 14,
+          paint: {
+            'fill-color': '#e63946',
+            'fill-opacity': 0.4
+          }
+        });
+
+        mapInstance.addLayer({
+          id: OUTLINE_LAYER_ID,
+          type: 'line',
+          source: SOURCE_ID,
+          minzoom: 14,
+          paint: {
+            'line-color': '#9d0208',
+            'line-width': 1,
+            'line-opacity': 0.8
+          }
+        });
+
+        addedRef.current = true;
+
+        // Initial fetch
+        fetchBuildings();
+      } catch (error) {
+        console.warn('Failed to add RNB layers:', error);
+      }
+    };
+
+    if (mapInstance.isStyleLoaded()) {
+      addSourceAndLayers();
+    } else {
+      mapInstance.once('style.load', addSourceAndLayers);
+    }
+
+    // Listen for map movement
+    mapInstance.on('moveend', debouncedFetch);
+
+    // Handle click on RNB buildings
+    const handleClick = (e: MapMouseEvent) => {
+      const features = mapInstance.queryRenderedFeatures(e.point, {
+        layers: [FILL_LAYER_ID]
+      });
+      if (features.length > 0) {
+        const feature = features[0];
+        const rnbId = feature.properties?.rnb_id;
+        if (rnbId && props.onBuildingClick) {
+          props.onBuildingClick(rnbId);
+        }
+      }
+    };
+
+    mapInstance.on('click', FILL_LAYER_ID, handleClick);
+
+    // Change cursor on hover
+    const handleMouseEnter = () => {
+      mapInstance.getCanvas().style.cursor = 'pointer';
+    };
+    const handleMouseLeave = () => {
+      mapInstance.getCanvas().style.cursor = '';
+    };
+    mapInstance.on('mouseenter', FILL_LAYER_ID, handleMouseEnter);
+    mapInstance.on('mouseleave', FILL_LAYER_ID, handleMouseLeave);
+
+    return () => {
+      // Cleanup debounce timer
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+      }
+
+      // Remove event listeners
+      mapInstance.off('moveend', debouncedFetch);
+      mapInstance.off('click', FILL_LAYER_ID, handleClick);
+      mapInstance.off('mouseenter', FILL_LAYER_ID, handleMouseEnter);
+      mapInstance.off('mouseleave', FILL_LAYER_ID, handleMouseLeave);
+
+      // Cleanup layers and source on unmount
+      try {
+        if (mapInstance.getLayer(OUTLINE_LAYER_ID)) {
+          mapInstance.removeLayer(OUTLINE_LAYER_ID);
+        }
+        if (mapInstance.getLayer(FILL_LAYER_ID)) {
+          mapInstance.removeLayer(FILL_LAYER_ID);
+        }
+        if (mapInstance.getSource(SOURCE_ID)) {
+          mapInstance.removeSource(SOURCE_ID);
+        }
+        addedRef.current = false;
+      } catch {
+        // Map might already be destroyed
+      }
+    };
+  }, [map, debouncedFetch, fetchBuildings, props.onBuildingClick]);
+
+  // Update visibility
+  useEffect(() => {
+    if (!map) return;
+
+    const mapInstance = map.getMap();
+
+    try {
+      if (mapInstance.getLayer(FILL_LAYER_ID)) {
+        mapInstance.setPaintProperty(
+          FILL_LAYER_ID,
+          'fill-opacity',
+          isVisible ? 0.4 : 0
+        );
+      }
+      if (mapInstance.getLayer(OUTLINE_LAYER_ID)) {
+        mapInstance.setPaintProperty(
+          OUTLINE_LAYER_ID,
+          'line-opacity',
+          isVisible ? 0.8 : 0
+        );
+      }
+    } catch {
+      // Layer might not exist yet
+    }
+  }, [map, isVisible]);
+
+  return null;
+}
+
+export default RNBBuildings;

--- a/frontend/src/components/modals/RNBHousingModal/RNBHousingModal.tsx
+++ b/frontend/src/components/modals/RNBHousingModal/RNBHousingModal.tsx
@@ -1,0 +1,241 @@
+import Alert from '@codegouvfr/react-dsfr/Alert';
+import { skipToken } from '@reduxjs/toolkit/query';
+import { toOccupancy, type DatafoncierHousing } from '@zerologementvacant/models';
+import Typography from '@mui/material/Typography';
+import { useEffect, useState } from 'react';
+
+import { createExtendedModal } from '~/components/modals/ConfirmationModal/ExtendedModal';
+import HousingResult from '~/components/HousingResult/HousingResult';
+import { type Housing } from '~/models/Housing';
+import { useFindHousingByRnbIdQuery } from '~/services/rnb.service';
+import { useCreateHousingMutation } from '~/services/housing.service';
+import { housingApi } from '~/services/housing.service';
+
+export interface RNBHousingModalProps {
+  rnbId: string | null;
+  onClose(): void;
+  onHousingCreated(housing: Housing): void;
+}
+
+function createRNBHousingModal() {
+  const modal = createExtendedModal({
+    id: 'rnb-housing-modal',
+    isOpenedByDefault: false
+  });
+
+  return {
+    ...modal,
+    Component(props: RNBHousingModalProps) {
+      // Use the non-lazy query with skipToken - it will automatically refetch when rnbId changes
+      const { data: housings, isLoading, error, isFetching } =
+        useFindHousingByRnbIdQuery(props.rnbId ?? skipToken);
+      const [createHousing, createHousingMutation] = useCreateHousingMutation();
+      const [getExistingHousing] = housingApi.useLazyGetHousingQuery();
+      const [selectedHousing, setSelectedHousing] =
+        useState<DatafoncierHousing | null>(null);
+      const [existingError, setExistingError] = useState<string | null>(null);
+      const [createError, setCreateError] = useState<string | null>(null);
+
+      // Reset selected housing when rnbId changes
+      useEffect(() => {
+        setSelectedHousing(null);
+        setExistingError(null);
+        setCreateError(null);
+      }, [props.rnbId]);
+
+      function handleClose() {
+        setSelectedHousing(null);
+        setExistingError(null);
+        setCreateError(null);
+        props.onClose();
+      }
+
+      async function handleSelect(housing: DatafoncierHousing) {
+        setExistingError(null);
+        // Check if housing already exists
+        try {
+          const existing = await getExistingHousing(housing.idlocal).unwrap();
+          if (existing) {
+            setExistingError(
+              `Ce logement existe déjà dans votre parc (${housing.idlocal})`
+            );
+            return;
+          }
+        } catch {
+          // Housing doesn't exist, we can proceed
+        }
+        setSelectedHousing(housing);
+      }
+
+      async function handleConfirm() {
+        if (selectedHousing) {
+          setCreateError(null);
+          try {
+            const housing = await createHousing({
+              localId: selectedHousing.idlocal
+            }).unwrap();
+            props.onHousingCreated(housing);
+            handleClose();
+          } catch (err: any) {
+            console.error('Failed to create housing:', err);
+            let errorMessage = 'Une erreur est survenue lors de la création du logement.';
+            if (err?.data?.name === 'HousingMissingError') {
+              errorMessage = `Ce logement (commune ${selectedHousing.idcom}) n'est pas dans le périmètre de votre établissement.`;
+            } else if (err?.data?.message) {
+              errorMessage = err.data.message;
+            }
+            setCreateError(errorMessage);
+          }
+        }
+      }
+
+      function toAddress(housing: DatafoncierHousing): string {
+        const streetNumber = housing.dnvoiri.replace(/^0+/, '');
+        const repetition = housing.dindic ?? '';
+        const street = housing.dvoilib;
+        const zipcode = housing.idcom;
+        const city = housing.idcomtxt;
+        return `${streetNumber}${repetition} ${street}, ${zipcode} ${city}`;
+      }
+
+      const hasHousings = housings && housings.length > 0;
+      const showList = hasHousings && !selectedHousing && !isFetching;
+      const showConfirm = selectedHousing !== null && !isFetching;
+
+      return (
+        <modal.Component
+          title={
+            showConfirm
+              ? 'Confirmer l\'ajout du logement'
+              : 'Logements trouvés dans ce bâtiment'
+          }
+          size="large"
+          buttons={
+            showConfirm
+              ? [
+                  {
+                    children: 'Retour',
+                    priority: 'secondary',
+                    doClosesModal: false,
+                    onClick: () => setSelectedHousing(null)
+                  },
+                  {
+                    children: 'Confirmer l\'ajout',
+                    doClosesModal: false,
+                    disabled: createHousingMutation.isLoading,
+                    onClick: handleConfirm
+                  }
+                ]
+              : [
+                  {
+                    children: 'Fermer',
+                    priority: 'secondary',
+                    doClosesModal: false,
+                    onClick: handleClose
+                  }
+                ]
+          }
+          onClose={handleClose}
+        >
+          {(isLoading || isFetching) && (
+            <Typography>Recherche des logements en cours...</Typography>
+          )}
+
+          {error && (
+            <Alert
+              severity="info"
+              title="Aucun logement"
+              description={`Aucun logement n'a été trouvé pour ce bâtiment RNB (${props.rnbId}) dans les Fichiers Fonciers.`}
+            />
+          )}
+
+          {existingError && (
+            <Alert
+              className="fr-mb-2w"
+              severity="warning"
+              title="Logement déjà existant"
+              description={existingError}
+            />
+          )}
+
+          {createError && (
+            <Alert
+              className="fr-mb-2w"
+              severity="error"
+              title="Erreur"
+              description={createError}
+            />
+          )}
+
+          {showList && (
+            <>
+              <Typography variant="subtitle2" sx={{ mb: '1rem' }}>
+                {housings.length} logement{housings.length > 1 ? 's' : ''}{' '}
+                trouvé{housings.length > 1 ? 's' : ''} dans ce bâtiment RNB.
+                Cliquez sur un logement pour l'ajouter à votre parc.
+              </Typography>
+              <div style={{ maxHeight: '400px', overflowY: 'auto' }}>
+                {housings.map((housing) => (
+                  <div
+                    key={housing.idlocal}
+                    style={{
+                      padding: '1rem',
+                      marginBottom: '0.5rem',
+                      border: '1px solid #ddd',
+                      borderRadius: '4px',
+                      cursor: 'pointer',
+                      transition: 'background-color 0.2s'
+                    }}
+                    onClick={() => handleSelect(housing)}
+                    onMouseEnter={(e) => {
+                      e.currentTarget.style.backgroundColor = '#f5f5f5';
+                    }}
+                    onMouseLeave={(e) => {
+                      e.currentTarget.style.backgroundColor = '';
+                    }}
+                  >
+                    <HousingResult
+                      address={toAddress(housing)}
+                      display="two-lines"
+                      localId={housing.idlocal}
+                      apartment={null}
+                      floor={null}
+                      occupancy={toOccupancy(housing.ccthp)}
+                    />
+                  </div>
+                ))}
+              </div>
+            </>
+          )}
+
+          {showConfirm && (
+            <>
+              <Typography variant="subtitle2" sx={{ mb: '1.5rem' }}>
+                Vous êtes sur le point d'ajouter ce logement à votre parc de
+                suivi.
+              </Typography>
+              <HousingResult
+                address={toAddress(selectedHousing)}
+                display="two-lines"
+                localId={selectedHousing.idlocal}
+                apartment={null}
+                floor={null}
+                occupancy={toOccupancy(selectedHousing.ccthp)}
+              />
+            </>
+          )}
+
+          {!isLoading && !isFetching && !error && !hasHousings && props.rnbId && (
+            <Alert
+              severity="info"
+              title="Aucun logement"
+              description="Aucun logement n'a été trouvé pour ce bâtiment dans les Fichiers Fonciers."
+            />
+          )}
+        </modal.Component>
+      );
+    }
+  };
+}
+
+export default createRNBHousingModal;

--- a/frontend/src/services/rnb.service.ts
+++ b/frontend/src/services/rnb.service.ts
@@ -1,0 +1,16 @@
+import type { DatafoncierHousing } from '@zerologementvacant/models';
+import { zlvApi } from './api.service';
+
+export const rnbApi = zlvApi.injectEndpoints({
+  endpoints: (builder) => ({
+    findHousingByRnbId: builder.query<DatafoncierHousing[], string>({
+      query: (rnbId: string) => `rnb/housing/${rnbId}`,
+      providesTags: (_housings, _error, rnbId) => [
+        { type: 'Datafoncier housing', id: rnbId }
+      ]
+    })
+  })
+});
+
+export const { useFindHousingByRnbIdQuery, useLazyFindHousingByRnbIdQuery } =
+  rnbApi;

--- a/server/src/controllers/rnbController.ts
+++ b/server/src/controllers/rnbController.ts
@@ -1,0 +1,416 @@
+import { Request, Response } from 'express';
+import { param, query, validationResult } from 'express-validator';
+import { constants } from 'http2';
+import fs from 'fs';
+import path from 'path';
+import readline from 'readline';
+import { fileURLToPath } from 'url';
+
+import { createLogger } from '~/infra/logger';
+import createDatafoncierHousingRepository from '~/repositories/datafoncierHousingRepository';
+
+const logger = createLogger('rnbController');
+
+// Path to RNB CSV file (ES module compatible)
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+// Navigate from controllers/ up to src/ and then to scripts/
+const RNB_CSV_PATH = path.resolve(__dirname, '../scripts/import-rnb/RNB_44.csv');
+
+// Lightweight building record (no shape stored - memory efficient)
+interface RNBBuildingIndex {
+  rnb_id: string;
+  lon: number;
+  lat: number;
+  status: string;
+  lineOffset: number; // Byte offset in file to read shape on demand
+}
+
+// Grid cell size (in degrees) for spatial indexing
+const GRID_CELL_SIZE = 0.01; // ~1km
+
+// Spatial index: Map<gridKey, RNBBuildingIndex[]>
+let spatialIndex: Map<string, RNBBuildingIndex[]> | null = null;
+let indexingInProgress = false;
+
+function getGridKey(lon: number, lat: number): string {
+  const gridX = Math.floor(lon / GRID_CELL_SIZE);
+  const gridY = Math.floor(lat / GRID_CELL_SIZE);
+  return `${gridX},${gridY}`;
+}
+
+function parsePointCoordinates(pointStr: string): [number, number] | null {
+  // Remove quotes and SRID prefix if present
+  const clean = pointStr.replace(/^"/, '').replace(/"$/, '').replace(/^SRID=\d+;/, '');
+  const match = clean.match(/POINT\(([-\d.]+)\s+([-\d.]+)\)/);
+  if (match) {
+    return [parseFloat(match[1]), parseFloat(match[2])];
+  }
+  return null;
+}
+
+// Parse CSV line with quoted fields containing semicolons
+function parseCSVLine(line: string): string[] {
+  const fields: string[] = [];
+  let current = '';
+  let inQuotes = false;
+
+  for (let i = 0; i < line.length; i++) {
+    const char = line[i];
+
+    if (char === '"') {
+      if (inQuotes && line[i + 1] === '"') {
+        // Escaped quote
+        current += '"';
+        i++;
+      } else {
+        inQuotes = !inQuotes;
+      }
+    } else if (char === ';' && !inQuotes) {
+      fields.push(current);
+      current = '';
+    } else {
+      current += char;
+    }
+  }
+  fields.push(current);
+  return fields;
+}
+
+function parseWktToGeoJson(shapeStr: string): object | null {
+  // Remove quotes and SRID prefix
+  const clean = shapeStr.replace(/^"/, '').replace(/"$/, '').replace(/^SRID=\d+;/, '');
+
+  // Match MULTIPOLYGON content
+  const match = clean.match(/MULTIPOLYGON\(\(\((.*)\)\)\)/s);
+  if (!match) return null;
+
+  // Split by ring separator "),(" to handle multiple rings
+  const ringsStr = match[1];
+  const rings: number[][][] = [];
+
+  // Parse each ring
+  const ringParts = ringsStr.split('),(');
+  for (const ringStr of ringParts) {
+    const coords: number[][] = [];
+
+    // Split coordinates by comma, but only valid coordinate pairs
+    for (const point of ringStr.split(',')) {
+      const trimmed = point.trim();
+      // Skip any residual parentheses
+      if (trimmed.startsWith('(') || trimmed.startsWith(')')) continue;
+
+      const parts = trimmed.split(/\s+/);
+      if (parts.length >= 2) {
+        const lon = parseFloat(parts[0]);
+        const lat = parseFloat(parts[1]);
+        if (!isNaN(lon) && !isNaN(lat)) {
+          coords.push([lon, lat]);
+        }
+      }
+    }
+
+    if (coords.length > 0) {
+      rings.push(coords);
+    }
+  }
+
+  if (rings.length > 0) {
+    // MultiPolygon structure: [polygon1, polygon2, ...]
+    // Each polygon: [outer_ring, inner_ring1, inner_ring2, ...]
+    // Each ring: [[lon, lat], [lon, lat], ...]
+    return {
+      type: 'MultiPolygon',
+      coordinates: [rings]  // Single polygon with multiple rings
+    };
+  }
+  return null;
+}
+
+// Read a specific line from the CSV file using byte offset
+async function readLineAtOffset(offset: number): Promise<string | null> {
+  return new Promise((resolve) => {
+    const stream = fs.createReadStream(RNB_CSV_PATH, {
+      start: offset,
+      encoding: 'utf8'
+    });
+
+    let data = '';
+    stream.on('data', (chunk) => {
+      data += chunk;
+      const newlineIdx = data.indexOf('\n');
+      if (newlineIdx !== -1) {
+        stream.destroy();
+        resolve(data.substring(0, newlineIdx));
+      }
+    });
+    stream.on('end', () => {
+      resolve(data || null);
+    });
+    stream.on('error', () => {
+      resolve(null);
+    });
+  });
+}
+
+async function buildSpatialIndex(): Promise<void> {
+  if (spatialIndex || indexingInProgress) return;
+
+  indexingInProgress = true;
+  logger.info('Building RNB spatial index (lightweight)...');
+
+  const startTime = Date.now();
+  spatialIndex = new Map();
+
+  try {
+    const fileStream = fs.createReadStream(RNB_CSV_PATH);
+    const rl = readline.createInterface({
+      input: fileStream,
+      crlfDelay: Infinity
+    });
+
+    let currentOffset = 0;
+    let lineNumber = 0;
+    let indexedCount = 0;
+
+    for await (const line of rl) {
+      const lineOffset = currentOffset;
+      currentOffset += Buffer.byteLength(line, 'utf8') + 1; // +1 for newline
+
+      lineNumber++;
+
+      // Skip header
+      if (lineNumber === 1) continue;
+
+      // Quick parse: only extract what we need for indexing
+      // rnb_id;point;shape;status;...
+      // We only need to parse up to status, not the full line
+      const firstSemi = line.indexOf(';');
+      if (firstSemi === -1) continue;
+
+      const rnb_id = line.substring(0, firstSemi);
+
+      // Find the point field (between first and second semicolon, respecting quotes)
+      let inQuotes = false;
+      let fieldStart = firstSemi + 1;
+      let semiCount = 0;
+      let pointEnd = -1;
+      let statusStart = -1;
+      let statusEnd = -1;
+
+      for (let i = fieldStart; i < line.length; i++) {
+        const char = line[i];
+        if (char === '"') {
+          inQuotes = !inQuotes;
+        } else if (char === ';' && !inQuotes) {
+          semiCount++;
+          if (semiCount === 1) {
+            pointEnd = i;
+          } else if (semiCount === 2) {
+            statusStart = i + 1;
+          } else if (semiCount === 3) {
+            statusEnd = i;
+            break;
+          }
+        }
+      }
+
+      if (pointEnd === -1 || statusStart === -1) continue;
+
+      const pointStr = line.substring(fieldStart, pointEnd);
+      const status = statusEnd > statusStart
+        ? line.substring(statusStart, statusEnd)
+        : line.substring(statusStart).split(';')[0];
+
+      const coords = parsePointCoordinates(pointStr);
+      if (!coords) continue;
+
+      const [lon, lat] = coords;
+      const gridKey = getGridKey(lon, lat);
+
+      const building: RNBBuildingIndex = {
+        rnb_id,
+        lon,
+        lat,
+        status,
+        lineOffset
+      };
+
+      if (!spatialIndex.has(gridKey)) {
+        spatialIndex.set(gridKey, []);
+      }
+      spatialIndex.get(gridKey)!.push(building);
+      indexedCount++;
+
+      // Log progress every 100k
+      if (indexedCount % 100000 === 0) {
+        logger.info(`Indexed ${indexedCount} buildings...`);
+      }
+    }
+
+    const duration = Date.now() - startTime;
+    logger.info(`RNB spatial index built: ${indexedCount} buildings in ${duration}ms`);
+    logger.info(`Grid cells: ${spatialIndex.size}`);
+
+  } catch (error) {
+    logger.error('Failed to build spatial index', { error });
+    spatialIndex = null;
+  } finally {
+    indexingInProgress = false;
+  }
+}
+
+// Start indexing on module load
+buildSpatialIndex();
+
+const getBuildingsValidators = [
+  query('minLon').isFloat().withMessage('minLon must be a number'),
+  query('maxLon').isFloat().withMessage('maxLon must be a number'),
+  query('minLat').isFloat().withMessage('minLat must be a number'),
+  query('maxLat').isFloat().withMessage('maxLat must be a number'),
+  query('limit').optional().isInt({ min: 1, max: 10000 }).withMessage('limit must be 1-10000')
+];
+
+async function getBuildings(request: Request, response: Response) {
+  const errors = validationResult(request);
+  if (!errors.isEmpty()) {
+    return response.status(constants.HTTP_STATUS_BAD_REQUEST).json({
+      errors: errors.array()
+    });
+  }
+
+  const minLon = parseFloat(request.query.minLon as string);
+  const maxLon = parseFloat(request.query.maxLon as string);
+  const minLat = parseFloat(request.query.minLat as string);
+  const maxLat = parseFloat(request.query.maxLat as string);
+  const limit = parseInt(request.query.limit as string) || 5000;
+
+  // Validate bounding box size (prevent too large requests)
+  const lonRange = maxLon - minLon;
+  const latRange = maxLat - minLat;
+
+  if (lonRange > 0.5 || latRange > 0.5) {
+    return response.status(constants.HTTP_STATUS_BAD_REQUEST).json({
+      error: 'Bounding box too large. Max 0.5 degrees (~50km)'
+    });
+  }
+
+  if (!spatialIndex) {
+    return response.status(constants.HTTP_STATUS_SERVICE_UNAVAILABLE).json({
+      error: 'Spatial index not ready. Please retry in a moment.'
+    });
+  }
+
+  logger.debug('Fetching RNB buildings', { minLon, maxLon, minLat, maxLat, limit });
+
+  // Find all grid cells that intersect the bounding box
+  const minGridX = Math.floor(minLon / GRID_CELL_SIZE);
+  const maxGridX = Math.floor(maxLon / GRID_CELL_SIZE);
+  const minGridY = Math.floor(minLat / GRID_CELL_SIZE);
+  const maxGridY = Math.floor(maxLat / GRID_CELL_SIZE);
+
+  // Collect matching buildings
+  const matchingBuildings: RNBBuildingIndex[] = [];
+
+  for (let gx = minGridX; gx <= maxGridX; gx++) {
+    for (let gy = minGridY; gy <= maxGridY; gy++) {
+      const gridKey = `${gx},${gy}`;
+      const buildings = spatialIndex.get(gridKey);
+
+      if (!buildings) continue;
+
+      for (const building of buildings) {
+        // Check if building is within bounding box
+        if (building.lon >= minLon && building.lon <= maxLon &&
+            building.lat >= minLat && building.lat <= maxLat) {
+          matchingBuildings.push(building);
+          if (matchingBuildings.length >= limit) break;
+        }
+      }
+      if (matchingBuildings.length >= limit) break;
+    }
+    if (matchingBuildings.length >= limit) break;
+  }
+
+  // Read shapes from file for matching buildings (in parallel batches)
+  const features: object[] = [];
+  const batchSize = 100;
+
+  for (let i = 0; i < matchingBuildings.length; i += batchSize) {
+    const batch = matchingBuildings.slice(i, i + batchSize);
+    const linePromises = batch.map(b => readLineAtOffset(b.lineOffset));
+    const lines = await Promise.all(linePromises);
+
+    for (let j = 0; j < batch.length; j++) {
+      const building = batch[j];
+      const line = lines[j];
+
+      if (!line) continue;
+
+      const parts = parseCSVLine(line);
+      if (parts.length < 3) continue;
+
+      const shapeStr = parts[2];
+      const geometry = parseWktToGeoJson(shapeStr);
+
+      if (geometry) {
+        features.push({
+          type: 'Feature',
+          properties: {
+            rnb_id: building.rnb_id,
+            status: building.status
+          },
+          geometry
+        });
+      }
+    }
+  }
+
+  const geojson = {
+    type: 'FeatureCollection',
+    features
+  };
+
+  logger.debug(`Returning ${features.length} RNB buildings`);
+
+  response.status(constants.HTTP_STATUS_OK).json(geojson);
+}
+
+const datafoncierHousingRepository = createDatafoncierHousingRepository();
+
+const getHousingByRnbIdValidators = [
+  param('rnbId').isString().notEmpty().withMessage('rnbId is required')
+];
+
+async function getHousingByRnbId(request: Request, response: Response) {
+  const errors = validationResult(request);
+  if (!errors.isEmpty()) {
+    return response.status(constants.HTTP_STATUS_BAD_REQUEST).json({
+      errors: errors.array()
+    });
+  }
+
+  const { rnbId } = request.params;
+
+  logger.debug('Looking up housing by rnb_id', { rnbId });
+
+  const housings = await datafoncierHousingRepository.find({ rnb_id: rnbId });
+
+  if (housings.length === 0) {
+    logger.debug('No housing found for rnb_id', { rnbId });
+    return response.status(constants.HTTP_STATUS_NOT_FOUND).json({
+      error: 'No housing found for this RNB building'
+    });
+  }
+
+  logger.debug(`Found ${housings.length} housing(s) for rnb_id`, { rnbId });
+
+  response.status(constants.HTTP_STATUS_OK).json(housings);
+}
+
+export default {
+  getBuildingsValidators,
+  getBuildings,
+  getHousingByRnbIdValidators,
+  getHousingByRnbId
+};

--- a/server/src/errors/httpError.ts
+++ b/server/src/errors/httpError.ts
@@ -33,7 +33,7 @@ export abstract class HttpError extends Error implements HttpError {
 }
 
 export function isHttpError(error: Error): error is HttpError {
-  return 'status' in error;
+  return 'status' in error && typeof (error as HttpError).toJSON === 'function';
 }
 
 export function isClientError(error: HttpError): boolean {

--- a/server/src/repositories/datafoncierHousingRepository.ts
+++ b/server/src/repositories/datafoncierHousingRepository.ts
@@ -10,6 +10,7 @@ export const DatafoncierHouses = (transaction = db) =>
 interface DatafoncierHousingFilters {
   idlocal?: string;
   idpropcte?: string;
+  rnb_id?: string;
 }
 
 class DatafoncierHousingRepository {

--- a/server/src/routers/unprotected.ts
+++ b/server/src/routers/unprotected.ts
@@ -6,6 +6,7 @@ import establishmentController from '~/controllers/establishmentController';
 import localityController from '~/controllers/localityController';
 import prospectController from '~/controllers/prospectController';
 import resetLinkController from '~/controllers/resetLinkController';
+import rnbController from '~/controllers/rnbController';
 import settingsController from '~/controllers/settingsController';
 import signupLinkController from '~/controllers/signupLinkController';
 import userController from '~/controllers/userController';
@@ -131,6 +132,22 @@ router.get(
   localityController.getLocalityValidators,
   validator.validate,
   localityController.getLocality
+);
+
+// RNB Buildings
+router.get(
+  '/rnb/buildings',
+  rnbController.getBuildingsValidators,
+  validator.validate,
+  rnbController.getBuildings
+);
+
+// RNB Housing lookup by rnb_id
+router.get(
+  '/rnb/housing/:rnbId',
+  rnbController.getHousingByRnbIdValidators,
+  validator.validate,
+  rnbController.getHousingByRnbId
 );
 
 export default router;

--- a/server/src/scripts/import-rnb/analyze_rnb.py
+++ b/server/src/scripts/import-rnb/analyze_rnb.py
@@ -1,0 +1,453 @@
+#!/usr/bin/env python3
+"""
+RNB (Référentiel National des Bâtiments) CSV Analysis Script
+
+Performs quantitative and qualitative analysis of RNB data with visualizations.
+"""
+
+import json
+import re
+from collections import Counter
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import pandas as pd
+import numpy as np
+
+# Configuration
+CSV_PATH = Path(__file__).parent / "RNB_44.csv"
+OUTPUT_DIR = Path(__file__).parent / "analysis_output"
+OUTPUT_DIR.mkdir(exist_ok=True)
+
+# Set matplotlib style
+plt.style.use('seaborn-v0_8-whitegrid')
+plt.rcParams['figure.figsize'] = (12, 8)
+plt.rcParams['font.size'] = 10
+
+
+def load_data(sample_size: int | None = None) -> pd.DataFrame:
+    """Load RNB CSV data."""
+    print(f"Loading data from {CSV_PATH}...")
+
+    df = pd.read_csv(
+        CSV_PATH,
+        sep=';',
+        nrows=sample_size,
+        dtype={
+            'rnb_id': str,
+            'point': str,
+            'shape': str,
+            'status': str,
+            'ext_ids': str,
+            'addresses': str,
+            'plots': str
+        }
+    )
+
+    print(f"Loaded {len(df):,} rows")
+    return df
+
+
+def extract_coordinates(point_str: str) -> tuple[float, float] | None:
+    """Extract longitude, latitude from SRID=4326;POINT(...) string."""
+    if pd.isna(point_str):
+        return None
+
+    match = re.search(r'POINT\(([-\d.]+)\s+([-\d.]+)\)', point_str)
+    if match:
+        lon, lat = float(match.group(1)), float(match.group(2))
+        return (lon, lat)
+    return None
+
+
+def parse_json_field(value: str) -> list | None:
+    """Parse JSON array field."""
+    if pd.isna(value) or value == '[]':
+        return []
+    try:
+        return json.loads(value)
+    except (json.JSONDecodeError, TypeError):
+        return None
+
+
+def analyze_quantitative(df: pd.DataFrame) -> dict:
+    """Perform quantitative analysis."""
+    print("\n" + "="*60)
+    print("QUANTITATIVE ANALYSIS")
+    print("="*60)
+
+    stats = {
+        'total_rows': len(df),
+        'unique_rnb_ids': df['rnb_id'].nunique(),
+        'status_counts': df['status'].value_counts().to_dict(),
+    }
+
+    # Missing values
+    missing = df.isnull().sum()
+    stats['missing_values'] = missing.to_dict()
+
+    print(f"\nTotal buildings: {stats['total_rows']:,}")
+    print(f"Unique RNB IDs: {stats['unique_rnb_ids']:,}")
+    print(f"Duplicates: {stats['total_rows'] - stats['unique_rnb_ids']:,}")
+
+    print("\nMissing values per column:")
+    for col, count in stats['missing_values'].items():
+        pct = (count / len(df)) * 100
+        print(f"  {col}: {count:,} ({pct:.2f}%)")
+
+    print("\nStatus distribution:")
+    for status, count in stats['status_counts'].items():
+        pct = (count / len(df)) * 100
+        print(f"  {status}: {count:,} ({pct:.2f}%)")
+
+    return stats
+
+
+def analyze_qualitative(df: pd.DataFrame) -> dict:
+    """Perform qualitative analysis on JSON fields."""
+    print("\n" + "="*60)
+    print("QUALITATIVE ANALYSIS")
+    print("="*60)
+
+    # Analyze ext_ids (external sources)
+    print("\nAnalyzing external IDs sources...")
+    source_counts = Counter()
+    ext_ids_count = []
+
+    for ext_ids_str in df['ext_ids'].dropna():
+        ext_ids = parse_json_field(ext_ids_str)
+        if ext_ids:
+            ext_ids_count.append(len(ext_ids))
+            for item in ext_ids:
+                if isinstance(item, dict) and 'source' in item:
+                    source_counts[item['source']] += 1
+
+    print(f"\nExternal ID sources:")
+    for source, count in source_counts.most_common():
+        print(f"  {source}: {count:,}")
+
+    # Analyze addresses
+    print("\nAnalyzing addresses...")
+    has_address = df['addresses'].apply(lambda x: x != '[]' and pd.notna(x)).sum()
+    no_address = len(df) - has_address
+    print(f"  With address: {has_address:,} ({has_address/len(df)*100:.2f}%)")
+    print(f"  Without address: {no_address:,} ({no_address/len(df)*100:.2f}%)")
+
+    # Extract city names from addresses
+    city_counts = Counter()
+    for addr_str in df['addresses'].dropna():
+        if addr_str == '[]':
+            continue
+        addresses = parse_json_field(addr_str)
+        if addresses:
+            for addr in addresses:
+                if isinstance(addr, dict) and 'city_name' in addr:
+                    city_name = addr['city_name']
+                    if city_name:
+                        city_counts[city_name] += 1
+
+    print(f"\nTop 15 cities by building count:")
+    for city, count in city_counts.most_common(15):
+        print(f"  {city}: {count:,}")
+
+    # Analyze plots (cadastral references)
+    print("\nAnalyzing cadastral plots...")
+    plots_count = []
+    for plots_str in df['plots'].dropna():
+        plots = parse_json_field(plots_str)
+        if plots:
+            plots_count.append(len(plots))
+
+    if plots_count:
+        print(f"  Average plots per building: {np.mean(plots_count):.2f}")
+        print(f"  Max plots per building: {max(plots_count)}")
+        print(f"  Buildings on single plot: {sum(1 for x in plots_count if x == 1):,}")
+        print(f"  Buildings on multiple plots: {sum(1 for x in plots_count if x > 1):,}")
+
+    return {
+        'source_counts': dict(source_counts),
+        'city_counts': dict(city_counts.most_common(50)),
+        'has_address': has_address,
+        'no_address': no_address,
+        'ext_ids_count': ext_ids_count,
+        'plots_count': plots_count
+    }
+
+
+def create_visualizations(df: pd.DataFrame, quant_stats: dict, qual_stats: dict):
+    """Create all visualizations."""
+    print("\n" + "="*60)
+    print("CREATING VISUALIZATIONS")
+    print("="*60)
+
+    # 1. Status distribution pie chart
+    print("\n1. Status distribution pie chart...")
+    fig, ax = plt.subplots(figsize=(10, 8))
+    status_data = quant_stats['status_counts']
+    colors = plt.cm.Set3(np.linspace(0, 1, len(status_data)))
+
+    wedges, texts, autotexts = ax.pie(
+        status_data.values(),
+        labels=status_data.keys(),
+        autopct='%1.1f%%',
+        colors=colors,
+        explode=[0.02] * len(status_data)
+    )
+    ax.set_title('Distribution des statuts de bâtiments RNB\n(Loire-Atlantique)', fontsize=14, fontweight='bold')
+    plt.tight_layout()
+    plt.savefig(OUTPUT_DIR / '01_status_pie_chart.png', dpi=150, bbox_inches='tight')
+    plt.close()
+
+    # 2. External sources bar chart
+    print("2. External sources bar chart...")
+    fig, ax = plt.subplots(figsize=(10, 6))
+    sources = qual_stats['source_counts']
+    ax.barh(list(sources.keys()), list(sources.values()), color='steelblue')
+    ax.set_xlabel('Nombre de bâtiments')
+    ax.set_title('Sources de données externes par bâtiment', fontsize=14, fontweight='bold')
+    for i, (source, count) in enumerate(sources.items()):
+        ax.text(count + max(sources.values()) * 0.01, i, f'{count:,}', va='center')
+    plt.tight_layout()
+    plt.savefig(OUTPUT_DIR / '02_sources_bar_chart.png', dpi=150, bbox_inches='tight')
+    plt.close()
+
+    # 3. Address coverage pie chart
+    print("3. Address coverage pie chart...")
+    fig, ax = plt.subplots(figsize=(8, 8))
+    address_data = {
+        'Avec adresse': qual_stats['has_address'],
+        'Sans adresse': qual_stats['no_address']
+    }
+    colors = ['#2ecc71', '#e74c3c']
+    ax.pie(
+        address_data.values(),
+        labels=address_data.keys(),
+        autopct='%1.1f%%',
+        colors=colors,
+        explode=[0.02, 0.02],
+        startangle=90
+    )
+    ax.set_title('Couverture des adresses\n(bâtiments avec/sans adresse)', fontsize=14, fontweight='bold')
+    plt.tight_layout()
+    plt.savefig(OUTPUT_DIR / '03_address_coverage.png', dpi=150, bbox_inches='tight')
+    plt.close()
+
+    # 4. Top cities bar chart
+    print("4. Top cities bar chart...")
+    fig, ax = plt.subplots(figsize=(12, 8))
+    city_data = dict(list(qual_stats['city_counts'].items())[:20])
+    y_pos = np.arange(len(city_data))
+    ax.barh(y_pos, list(city_data.values()), color='coral')
+    ax.set_yticks(y_pos)
+    ax.set_yticklabels(city_data.keys())
+    ax.invert_yaxis()
+    ax.set_xlabel('Nombre de bâtiments')
+    ax.set_title('Top 20 des communes par nombre de bâtiments', fontsize=14, fontweight='bold')
+    for i, count in enumerate(city_data.values()):
+        ax.text(count + max(city_data.values()) * 0.01, i, f'{count:,}', va='center')
+    plt.tight_layout()
+    plt.savefig(OUTPUT_DIR / '04_top_cities.png', dpi=150, bbox_inches='tight')
+    plt.close()
+
+    # 5. Plots per building histogram
+    print("5. Plots per building histogram...")
+    if qual_stats['plots_count']:
+        fig, ax = plt.subplots(figsize=(10, 6))
+        plots_data = qual_stats['plots_count']
+        ax.hist(plots_data, bins=range(1, min(max(plots_data) + 2, 12)),
+                edgecolor='black', color='mediumpurple', align='left')
+        ax.set_xlabel('Nombre de parcelles cadastrales')
+        ax.set_ylabel('Nombre de bâtiments')
+        ax.set_title('Distribution du nombre de parcelles par bâtiment', fontsize=14, fontweight='bold')
+        ax.set_xticks(range(1, min(max(plots_data) + 1, 11)))
+        plt.tight_layout()
+        plt.savefig(OUTPUT_DIR / '05_plots_histogram.png', dpi=150, bbox_inches='tight')
+        plt.close()
+
+    # 6. External IDs count histogram
+    print("6. External IDs count histogram...")
+    if qual_stats['ext_ids_count']:
+        fig, ax = plt.subplots(figsize=(10, 6))
+        ext_data = qual_stats['ext_ids_count']
+        ax.hist(ext_data, bins=range(1, min(max(ext_data) + 2, 8)),
+                edgecolor='black', color='teal', align='left')
+        ax.set_xlabel('Nombre de références externes')
+        ax.set_ylabel('Nombre de bâtiments')
+        ax.set_title('Distribution du nombre de références externes par bâtiment', fontsize=14, fontweight='bold')
+        ax.set_xticks(range(1, min(max(ext_data) + 1, 7)))
+        plt.tight_layout()
+        plt.savefig(OUTPUT_DIR / '06_ext_ids_histogram.png', dpi=150, bbox_inches='tight')
+        plt.close()
+
+    # 7. Data completeness summary
+    print("7. Data completeness summary...")
+    fig, ax = plt.subplots(figsize=(10, 6))
+    columns = ['rnb_id', 'point', 'shape', 'status', 'ext_ids', 'addresses', 'plots']
+    completeness = []
+    for col in columns:
+        if col == 'addresses':
+            # For addresses, consider '[]' as missing
+            complete = (df[col] != '[]') & df[col].notna()
+            completeness.append(complete.sum() / len(df) * 100)
+        else:
+            completeness.append((len(df) - quant_stats['missing_values'].get(col, 0)) / len(df) * 100)
+
+    colors = ['#27ae60' if c > 90 else '#f39c12' if c > 50 else '#e74c3c' for c in completeness]
+    bars = ax.bar(columns, completeness, color=colors, edgecolor='black')
+    ax.set_ylabel('Complétude (%)')
+    ax.set_title('Complétude des données par colonne', fontsize=14, fontweight='bold')
+    ax.set_ylim(0, 105)
+    ax.axhline(y=100, color='gray', linestyle='--', alpha=0.5)
+
+    for bar, val in zip(bars, completeness):
+        ax.text(bar.get_x() + bar.get_width()/2, bar.get_height() + 1,
+                f'{val:.1f}%', ha='center', va='bottom', fontsize=9)
+
+    plt.xticks(rotation=45, ha='right')
+    plt.tight_layout()
+    plt.savefig(OUTPUT_DIR / '07_data_completeness.png', dpi=150, bbox_inches='tight')
+    plt.close()
+
+    print(f"\nAll visualizations saved to: {OUTPUT_DIR}")
+
+
+def create_geographic_visualization(df: pd.DataFrame, sample_size: int = 50000):
+    """Create geographic scatter plot of buildings."""
+    print("\n8. Geographic distribution map...")
+
+    # Sample data for visualization (full dataset would be too heavy)
+    df_sample = df.sample(n=min(sample_size, len(df)), random_state=42)
+
+    # Extract coordinates
+    coords = df_sample['point'].apply(extract_coordinates)
+    valid_coords = coords.dropna()
+
+    if len(valid_coords) == 0:
+        print("  No valid coordinates found, skipping map.")
+        return
+
+    lons = [c[0] for c in valid_coords]
+    lats = [c[1] for c in valid_coords]
+
+    # Create scatter plot
+    fig, ax = plt.subplots(figsize=(12, 10))
+
+    # Get status for coloring
+    statuses = df_sample.loc[valid_coords.index, 'status']
+    unique_statuses = statuses.unique()
+    color_map = {s: plt.cm.tab10(i) for i, s in enumerate(unique_statuses)}
+    colors = [color_map[s] for s in statuses]
+
+    scatter = ax.scatter(lons, lats, c=colors, alpha=0.3, s=1)
+
+    # Add legend
+    legend_elements = [plt.Line2D([0], [0], marker='o', color='w',
+                                   markerfacecolor=color_map[s], markersize=8, label=s)
+                       for s in unique_statuses]
+    ax.legend(handles=legend_elements, loc='upper right', title='Statut')
+
+    ax.set_xlabel('Longitude')
+    ax.set_ylabel('Latitude')
+    ax.set_title(f'Distribution géographique des bâtiments RNB\n(échantillon de {len(valid_coords):,} bâtiments)',
+                 fontsize=14, fontweight='bold')
+    ax.set_aspect('equal')
+
+    plt.tight_layout()
+    plt.savefig(OUTPUT_DIR / '08_geographic_distribution.png', dpi=150, bbox_inches='tight')
+    plt.close()
+    print(f"  Map created with {len(valid_coords):,} points")
+
+
+def generate_report(quant_stats: dict, qual_stats: dict):
+    """Generate markdown report."""
+    report = f"""# Analyse RNB - Loire-Atlantique (44)
+
+## Résumé
+
+- **Total de bâtiments**: {quant_stats['total_rows']:,}
+- **IDs RNB uniques**: {quant_stats['unique_rnb_ids']:,}
+- **Doublons potentiels**: {quant_stats['total_rows'] - quant_stats['unique_rnb_ids']:,}
+
+## Distribution des statuts
+
+| Statut | Nombre | Pourcentage |
+|--------|--------|-------------|
+"""
+    for status, count in quant_stats['status_counts'].items():
+        pct = count / quant_stats['total_rows'] * 100
+        report += f"| {status} | {count:,} | {pct:.2f}% |\n"
+
+    report += f"""
+## Couverture des données
+
+### Adresses
+- Bâtiments avec adresse: {qual_stats['has_address']:,} ({qual_stats['has_address']/quant_stats['total_rows']*100:.2f}%)
+- Bâtiments sans adresse: {qual_stats['no_address']:,} ({qual_stats['no_address']/quant_stats['total_rows']*100:.2f}%)
+
+### Sources externes
+"""
+    for source, count in qual_stats['source_counts'].items():
+        report += f"- **{source}**: {count:,} références\n"
+
+    report += f"""
+## Top 10 communes
+
+| Commune | Nombre de bâtiments |
+|---------|---------------------|
+"""
+    for city, count in list(qual_stats['city_counts'].items())[:10]:
+        report += f"| {city} | {count:,} |\n"
+
+    report += """
+## Visualisations générées
+
+1. `01_status_pie_chart.png` - Distribution des statuts
+2. `02_sources_bar_chart.png` - Sources de données externes
+3. `03_address_coverage.png` - Couverture des adresses
+4. `04_top_cities.png` - Top 20 communes
+5. `05_plots_histogram.png` - Distribution des parcelles
+6. `06_ext_ids_histogram.png` - Distribution des références externes
+7. `07_data_completeness.png` - Complétude des données
+8. `08_geographic_distribution.png` - Carte de distribution
+
+---
+*Rapport généré automatiquement*
+"""
+
+    report_path = OUTPUT_DIR / 'ANALYSIS_REPORT.md'
+    report_path.write_text(report)
+    print(f"\nReport saved to: {report_path}")
+
+
+def main():
+    """Main analysis function."""
+    print("="*60)
+    print("RNB DATA ANALYSIS - Loire-Atlantique (44)")
+    print("="*60)
+
+    # Load data
+    df = load_data()
+
+    # Quantitative analysis
+    quant_stats = analyze_quantitative(df)
+
+    # Qualitative analysis
+    qual_stats = analyze_qualitative(df)
+
+    # Create visualizations
+    create_visualizations(df, quant_stats, qual_stats)
+
+    # Geographic visualization
+    create_geographic_visualization(df)
+
+    # Generate report
+    generate_report(quant_stats, qual_stats)
+
+    print("\n" + "="*60)
+    print("ANALYSIS COMPLETE")
+    print("="*60)
+    print(f"\nResults saved in: {OUTPUT_DIR}")
+
+
+if __name__ == "__main__":
+    main()

--- a/server/src/scripts/import-rnb/requirements.txt
+++ b/server/src/scripts/import-rnb/requirements.txt
@@ -1,0 +1,3 @@
+pandas>=2.0.0
+matplotlib>=3.7.0
+numpy>=1.24.0


### PR DESCRIPTION
## Summary

- Affiche les bâtiments RNB (Référentiel National des Bâtiments) sur la carte avec chargement dynamique selon le viewport
- Permet de cliquer sur un bâtiment RNB pour voir les logements associés dans les Fichiers Fonciers (`df_housing_nat_2024`)
- Ajoute une modal de sélection permettant d'ajouter un logement au parc de suivi

## Changements techniques

### Backend
- Ajout de l'endpoint `GET /api/rnb/housing/:rnbId` pour récupérer les logements par `rnb_id`
- Ajout du filtre `rnb_id` dans `datafoncierHousingRepository`
- Fix du type guard `isHttpError` pour éviter les erreurs avec les erreurs tierces sans méthode `toJSON`

### Frontend
- Nouveau composant `RNBBuildings.tsx` qui affiche les bâtiments RNB avec fetch dynamique
- Nouvelle modal `RNBHousingModal` pour sélectionner et créer un logement
- Nouveau service RTK Query `rnb.service.ts`
- Intégration dans `Map.tsx` avec gestion du clic sur les bâtiments

### Autres
- Ajout de `venv/` au `.gitignore`
- Script d'analyse RNB (`analyze_rnb.py`)

## Test plan

- [ ] Zoomer sur la carte jusqu'au niveau 14+ pour voir les bâtiments RNB (en rouge)
- [ ] Cliquer sur un bâtiment RNB pour ouvrir la modal
- [ ] Vérifier que les logements associés s'affichent
- [ ] Sélectionner un logement et confirmer l'ajout
- [ ] Vérifier la redirection vers la page du logement créé
- [ ] Vérifier le message d'erreur si le logement est hors périmètre