### PR TITLE
React router v7

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -59,7 +59,7 @@
     "react-pdf": "10.4.1",
     "react-redux": "8.1.3",
     "react-redux-loading-bar": "5.0.8",
-    "react-router-dom": "6.30.3",
+    "react-router": "^7.13.2",
     "react-toastify": "10.0.6",
     "react-use": "17.6.0",
     "redux": "5.0.1",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,7 +5,7 @@ import {
   Navigate,
   Route,
   RouterProvider
-} from 'react-router-dom';
+} from 'react-router';
 
 import { useAppDispatch, useAppSelector } from '~/hooks/useStore';
 import AuthenticatedLayout from '~/layouts/AuthenticatedLayout';
@@ -95,16 +95,7 @@ const router = sentry.createBrowserRouter(
 
       <Route path="*" element={<NotFoundView />} />
     </Route>
-  ),
-  {
-    future: {
-      v7_relativeSplatPath: true,
-      v7_fetcherPersist: true,
-      v7_normalizeFormMethod: true,
-      v7_partialHydration: true,
-      v7_skipActionErrorRevalidation: true
-    }
-  }
+  )
 );
 
 function App() {
@@ -123,7 +114,7 @@ function App() {
     }
   }, [dispatch, isSomeQueryPending]);
 
-  return <RouterProvider router={router} future={{ v7_startTransition: true }} />;
+  return <RouterProvider router={router} />;
 }
 
 export default App;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -95,7 +95,16 @@ const router = sentry.createBrowserRouter(
 
       <Route path="*" element={<NotFoundView />} />
     </Route>
-  )
+  ),
+  {
+    future: {
+      v7_relativeSplatPath: true,
+      v7_fetcherPersist: true,
+      v7_normalizeFormMethod: true,
+      v7_partialHydration: true,
+      v7_skipActionErrorRevalidation: true
+    }
+  }
 );
 
 function App() {
@@ -114,9 +123,7 @@ function App() {
     }
   }, [dispatch, isSomeQueryPending]);
 
-  return (
-    <RouterProvider router={router} future={{ v7_startTransition: true }} />
-  );
+  return <RouterProvider router={router} future={{ v7_startTransition: true }} />;
 }
 
 export default App;

--- a/frontend/src/components/Account/AccountDropdown.tsx
+++ b/frontend/src/components/Account/AccountDropdown.tsx
@@ -6,7 +6,7 @@ import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import { useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 import Dropdown from '~/components/Dropdown/Dropdown';
 import { useUser } from '~/hooks/useUser';

--- a/frontend/src/components/Auth/RequireAuth.tsx
+++ b/frontend/src/components/Auth/RequireAuth.tsx
@@ -1,6 +1,6 @@
 import { usePostHog } from 'posthog-js/react';
 import { type PropsWithChildren, useEffect } from 'react';
-import { Navigate, useLocation } from 'react-router-dom';
+import { Navigate, useLocation } from 'react-router';
 
 import { useUser } from '../../hooks/useUser';
 import { useFetchInterceptor } from '../../hooks/useFetchInterceptor';

--- a/frontend/src/components/Auth/RequireGuest.tsx
+++ b/frontend/src/components/Auth/RequireGuest.tsx
@@ -1,7 +1,7 @@
 import type { PropsWithChildren } from 'react';
 
 import { useUser } from '../../hooks/useUser';
-import { Navigate } from 'react-router-dom';
+import { Navigate } from 'react-router';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 interface RequireGuestProps {}

--- a/frontend/src/components/GroupCard/GroupCard.test.tsx
+++ b/frontend/src/components/GroupCard/GroupCard.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter as Router } from 'react-router-dom';
+import { MemoryRouter as Router } from 'react-router';
 import { genGroup } from '../../test/fixtures';
 import GroupCard from './GroupCard';
 

--- a/frontend/src/components/GroupCard/GroupCard.tsx
+++ b/frontend/src/components/GroupCard/GroupCard.tsx
@@ -2,7 +2,7 @@ import { fr } from '@codegouvfr/react-dsfr';
 import Stack, { type StackProps } from '@mui/material/Stack';
 import { styled } from '@mui/material/styles';
 import Typography from '@mui/material/Typography';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 
 import HousingCount from '~/components/HousingCount/HousingCount';
 import type { Group } from '~/models/Group';

--- a/frontend/src/components/GroupHeader/GroupHeader.test.tsx
+++ b/frontend/src/components/GroupHeader/GroupHeader.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import { Provider } from 'react-redux';
-import { MemoryRouter as Router } from 'react-router-dom';
+import { MemoryRouter as Router } from 'react-router';
 
 import type { GroupDTO } from '@zerologementvacant/models';
 import { genGroupDTO, genUserDTO } from '@zerologementvacant/models/fixtures';

--- a/frontend/src/components/GroupHeader/GroupHeader.tsx
+++ b/frontend/src/components/GroupHeader/GroupHeader.tsx
@@ -5,7 +5,7 @@ import Stack from '@mui/material/Stack';
 import { styled } from '@mui/material/styles';
 import Typography from '@mui/material/Typography';
 import { useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { match, Pattern } from 'ts-pattern';
 
 import search from '~/assets/images/search.svg';

--- a/frontend/src/components/Header/SmallHeader.tsx
+++ b/frontend/src/components/Header/SmallHeader.tsx
@@ -12,7 +12,7 @@ import { styled } from '@mui/material/styles';
 import Typography from '@mui/material/Typography';
 import { useEffect, useState } from 'react';
 import { LoadingBar } from 'react-redux-loading-bar';
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation } from 'react-router';
 
 import AccountDropdown from '~/components/Account/AccountDropdown';
 import EstablishmentSearchableSelect from '~/components/establishment/EstablishmentSearchableSelect';

--- a/frontend/src/components/Map/Map.tsx
+++ b/frontend/src/components/Map/Map.tsx
@@ -8,9 +8,9 @@ import ReactiveMap, {
   type ViewState,
   type ViewStateChangeEvent
 } from 'react-map-gl/maplibre';
-import { useNavigate } from 'react-router-dom';
 import Box from '@mui/material/Box';
 import { styled } from '@mui/material/styles';
+import { useNavigate } from 'react-router';
 
 import { useMapImage } from '../../hooks/useMapImage';
 import {

--- a/frontend/src/components/Owner/OwnerHousingCardGrid.tsx
+++ b/frontend/src/components/Owner/OwnerHousingCardGrid.tsx
@@ -3,7 +3,7 @@ import Skeleton from '@mui/material/Skeleton';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import { skipToken } from '@reduxjs/toolkit/query';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { match } from 'ts-pattern';
 
 import OwnerHousingCard from '~/components/Owner/OwnerHousingCard';

--- a/frontend/src/components/_app/AppLink/AppLink.tsx
+++ b/frontend/src/components/_app/AppLink/AppLink.tsx
@@ -1,7 +1,7 @@
 import type { FrIconClassName, RiIconClassName } from '@codegouvfr/react-dsfr';
 import classNames from 'classnames';
-import { Link } from 'react-router-dom';
-import type { LinkProps, Path, To } from 'react-router-dom';
+import { Link } from 'react-router';
+import type { LinkProps, Path, To } from 'react-router';
 
 export type AppLinkProps = LinkProps & {
   isSimple?: boolean;

--- a/frontend/src/components/modals/OnboardingModal/OnboardingModal.tsx
+++ b/frontend/src/components/modals/OnboardingModal/OnboardingModal.tsx
@@ -2,7 +2,7 @@ import { createModal } from '@codegouvfr/react-dsfr/Modal';
 import Typography from '@mui/material/Typography';
 import Grid from '@mui/material/Grid';
 import { useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import image from '../../../assets/images/community.svg';
 
 import { useIsDsfrReady } from '../../../hooks/useIsDsfrReady';

--- a/frontend/src/hooks/test/useSelection.test.tsx
+++ b/frontend/src/hooks/test/useSelection.test.tsx
@@ -2,7 +2,7 @@ import { faker } from '@faker-js/faker/locale/fr';
 import { act, renderHook } from '@testing-library/react';
 import type { PropsWithChildren } from 'react';
 import { Provider as StoreProvider } from 'react-redux';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 
 import configureTestStore from '../../utils/storeUtils';
 import { useSelection } from '../useSelection';

--- a/frontend/src/hooks/useEmailLink.tsx
+++ b/frontend/src/hooks/useEmailLink.tsx
@@ -1,4 +1,4 @@
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { useEffect, useMemo, useState } from 'react';
 import { hideLoading, showLoading } from 'react-redux-loading-bar';
 import { useAppDispatch } from './useStore';

--- a/frontend/src/hooks/useFetchInterceptor.ts
+++ b/frontend/src/hooks/useFetchInterceptor.ts
@@ -1,5 +1,5 @@
 import fetchIntercept from 'fetch-intercept';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { logOut } from '../store/actions/authenticationAction';
 import { useAppDispatch } from './useStore';

--- a/frontend/src/hooks/useProspect.tsx
+++ b/frontend/src/hooks/useProspect.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 import { useSaveProspectMutation } from '../services/prospect.service';
 

--- a/frontend/src/hooks/useScrollTop.ts
+++ b/frontend/src/hooks/useScrollTop.ts
@@ -1,5 +1,5 @@
 import { useLayoutEffect } from 'react';
-import { useLocation, useNavigationType } from 'react-router-dom';
+import { useLocation, useNavigationType } from 'react-router';
 
 /**
  * Scroll to the top of the page on route change.

--- a/frontend/src/hooks/useSelection.tsx
+++ b/frontend/src/hooks/useSelection.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import housingSlice from '../store/reducers/housingReducer';
 import { useAppDispatch, useAppSelector } from './useStore';
 

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -5,7 +5,7 @@ import { StrictMode } from 'react';
 import ReactDOM from 'react-dom/client';
 import { MapProvider } from 'react-map-gl/maplibre';
 import { Provider as StoreProvider } from 'react-redux';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import App from './App';
 
 import Notification from './components/Notification/Notification';

--- a/frontend/src/layouts/AuthenticatedLayout.tsx
+++ b/frontend/src/layouts/AuthenticatedLayout.tsx
@@ -1,5 +1,5 @@
 import SkipLinks from '@codegouvfr/react-dsfr/SkipLinks';
-import { Outlet } from 'react-router-dom';
+import { Outlet } from 'react-router';
 
 import RequireAuth from '~/components/Auth/RequireAuth';
 import Footer from '~/components/Footer/Footer';

--- a/frontend/src/layouts/GuestLayout.tsx
+++ b/frontend/src/layouts/GuestLayout.tsx
@@ -1,5 +1,5 @@
 import SkipLinks from '@codegouvfr/react-dsfr/SkipLinks';
-import { Outlet } from 'react-router-dom';
+import { Outlet } from 'react-router';
 
 import RequireGuest from '~/components/Auth/RequireGuest';
 import Header from '~/components/Header/Header';

--- a/frontend/src/utils/sentry.ts
+++ b/frontend/src/utils/sentry.ts
@@ -25,8 +25,8 @@ function init(): void {
       integrations: [
         // Browser performance and error tracking
         Sentry.browserTracingIntegration(),
-        // React Router v6 integration
-        Sentry.reactRouterV6BrowserTracingIntegration({
+        // React Router v7 integration
+        Sentry.reactRouterV7BrowserTracingIntegration({
           useEffect,
           useLocation,
           useNavigationType,
@@ -191,7 +191,7 @@ function initWebVitals() {
   });
 }
 
-const createSentryRouter: typeof createBrowserRouter = Sentry.wrapCreateBrowserRouterV6(createBrowserRouter);
+const createSentryRouter: typeof createBrowserRouter = Sentry.wrapCreateBrowserRouterV7(createBrowserRouter);
 
 // Export Sentry ErrorBoundary and utilities
 const ErrorBoundary = Sentry.ErrorBoundary;

--- a/frontend/src/utils/sentry.ts
+++ b/frontend/src/utils/sentry.ts
@@ -6,7 +6,7 @@ import {
   matchRoutes,
   useLocation,
   useNavigationType
-} from 'react-router-dom';
+} from 'react-router';
 
 import config from './config';
 

--- a/frontend/src/views/Account/AccountCreation/AccountEmailActivationView.tsx
+++ b/frontend/src/views/Account/AccountCreation/AccountEmailActivationView.tsx
@@ -5,7 +5,7 @@ import Stepper from '@codegouvfr/react-dsfr/Stepper';
 import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
 import classNames from 'classnames';
-import { Navigate, useLocation } from 'react-router-dom';
+import { Navigate, useLocation } from 'react-router';
 
 import styles from '../forgotten-password-view.module.scss';
 import { useActivationEmail } from '../../../hooks/useActivationEmail';

--- a/frontend/src/views/Account/AccountCreation/AccountEmailCreationView.tsx
+++ b/frontend/src/views/Account/AccountCreation/AccountEmailCreationView.tsx
@@ -4,7 +4,7 @@ import Grid from '@mui/material/Grid';
 import Stepper from '@codegouvfr/react-dsfr/Stepper';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { FormProvider, useForm } from 'react-hook-form';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { toast } from 'react-toastify';
 import { type InferType, object } from 'yup';
 

--- a/frontend/src/views/Account/AccountCreation/AccountPasswordCreationView.tsx
+++ b/frontend/src/views/Account/AccountCreation/AccountPasswordCreationView.tsx
@@ -4,7 +4,7 @@ import { yupResolver } from '@hookform/resolvers/yup';
 import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
 import { FormProvider, useForm } from 'react-hook-form';
-import { Navigate, useNavigate } from 'react-router-dom';
+import { Navigate, useNavigate } from 'react-router';
 import { type InferType, object } from 'yup';
 
 import {

--- a/frontend/src/views/Account/AccountCreation/test/AccountEmailActivationView.test.tsx
+++ b/frontend/src/views/Account/AccountCreation/test/AccountEmailActivationView.test.tsx
@@ -2,7 +2,7 @@ import { startReactDsfr } from '@codegouvfr/react-dsfr/spa';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Provider } from 'react-redux';
-import { createMemoryRouter, Link, RouterProvider } from 'react-router-dom';
+import { createMemoryRouter, Link, RouterProvider } from 'react-router';
 import { vi } from 'vitest';
 import Notification from '../../../../components/Notification/Notification';
 import { signupLinkApi } from '../../../../services/signup-link.service';

--- a/frontend/src/views/Account/AccountCreation/test/AccountEmailCreationView.test.tsx
+++ b/frontend/src/views/Account/AccountCreation/test/AccountEmailCreationView.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { createMemoryRouter, Outlet, RouterProvider } from 'react-router-dom';
+import { createMemoryRouter, Outlet, RouterProvider } from 'react-router';
 import AccountEmailCreationView from '../AccountEmailCreationView';
 import userEvent from '@testing-library/user-event';
 import { store } from '../../../../store/store';

--- a/frontend/src/views/Account/AccountCreation/test/AccountPasswordCreationView.test.tsx
+++ b/frontend/src/views/Account/AccountCreation/test/AccountPasswordCreationView.test.tsx
@@ -9,7 +9,7 @@ import {
   genSignupLinkDTO
 } from '@zerologementvacant/models/fixtures';
 import { Provider } from 'react-redux';
-import { createMemoryRouter, RouterProvider } from 'react-router-dom';
+import { createMemoryRouter, RouterProvider } from 'react-router';
 import OnboardingModal from '../../../../components/modals/OnboardingModal/OnboardingModal';
 import data from '../../../../mocks/handlers/data';
 import configureTestStore from '../../../../utils/storeUtils';

--- a/frontend/src/views/Account/AccountCreationView.tsx
+++ b/frontend/src/views/Account/AccountCreationView.tsx
@@ -1,6 +1,6 @@
 import { fr } from '@codegouvfr/react-dsfr';
 import Grid from '@mui/material/Grid';
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router';
 
 import AccountEmailCreationView from './AccountCreation/AccountEmailCreationView';
 import AccountEmailActivationView from './AccountCreation/AccountEmailActivationView';

--- a/frontend/src/views/Account/AccountSideMenu.tsx
+++ b/frontend/src/views/Account/AccountSideMenu.tsx
@@ -1,5 +1,5 @@
 import SideMenu, { type SideMenuProps } from '@codegouvfr/react-dsfr/SideMenu';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 import { useUser } from '~/hooks/useUser';
 

--- a/frontend/src/views/Account/Profile/ProfileLayout.tsx
+++ b/frontend/src/views/Account/Profile/ProfileLayout.tsx
@@ -1,5 +1,5 @@
 import { Container, Grid } from '@mui/material';
-import { Outlet } from 'react-router-dom';
+import { Outlet } from 'react-router';
 
 import AccountSideMenu from '~/views/Account/AccountSideMenu';
 

--- a/frontend/src/views/Account/Profile/test/UsersView.test.tsx
+++ b/frontend/src/views/Account/Profile/test/UsersView.test.tsx
@@ -11,7 +11,7 @@ import {
   genUserDTO
 } from '@zerologementvacant/models/fixtures';
 import { Provider } from 'react-redux';
-import { createMemoryRouter, RouterProvider } from 'react-router-dom';
+import { createMemoryRouter, RouterProvider } from 'react-router';
 
 import data from '~/mocks/handlers/data';
 import { fromUserDTO } from '~/models/User';

--- a/frontend/src/views/Campaign/CampaignView.tsx
+++ b/frontend/src/views/Campaign/CampaignView.tsx
@@ -6,7 +6,7 @@ import Container from '@mui/material/Container';
 
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 
 import CampaignCreatedFromGroup from '~/components/Campaign/CampaignCreatedFromGroup';
 import { createCampaignDeleteModal } from '~/components/Campaign/CampaignDeleteModal';

--- a/frontend/src/views/Campaign/test/CampaignListView.test.tsx
+++ b/frontend/src/views/Campaign/test/CampaignListView.test.tsx
@@ -16,7 +16,7 @@ import {
 } from '@zerologementvacant/models/fixtures';
 import { Order } from 'effect';
 import { Provider } from 'react-redux';
-import { createMemoryRouter, RouterProvider } from 'react-router-dom';
+import { createMemoryRouter, RouterProvider } from 'react-router';
 
 import data from '~/mocks/handlers/data';
 import { fromEstablishmentDTO } from '~/models/Establishment';

--- a/frontend/src/views/Campaign/test/CampaignView.test.tsx
+++ b/frontend/src/views/Campaign/test/CampaignView.test.tsx
@@ -1,18 +1,21 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import type { CampaignDTO } from '@zerologementvacant/models';
+import type { CampaignDTO, HousingDTO } from '@zerologementvacant/models';
 import {
   genCampaignDTO,
   genDraftDTO,
+  genHousingDTO,
   genSenderDTO
 } from '@zerologementvacant/models/fixtures';
 import { Provider } from 'react-redux';
-import { describe, expect, it } from 'vitest';
 import { createMemoryRouter, RouterProvider } from 'react-router';
+import { describe, expect, it } from 'vitest';
+import { faker } from '@faker-js/faker/locale/fr';
 
 import data from '~/mocks/handlers/data';
 import configureTestStore from '~/utils/storeUtils';
 import CampaignView from '../CampaignView';
+import HousingListView from '~/views/HousingList/HousingListView';
 
 vi.mock('@zerologementvacant/pdf', () => ({
   usePDF: vi.fn(() => [{ url: null, loading: false, error: undefined }, vi.fn()]),
@@ -20,25 +23,31 @@ vi.mock('@zerologementvacant/pdf', () => ({
   CampaignPage: vi.fn(() => null)
 }));
 
-vi.mock('posthog-js/react', async (importOriginal) => {
-  const mod = await importOriginal<typeof import('posthog-js/react')>();
-  return {
-    ...mod,
-    useFeatureFlagEnabled: vi.fn(),
-    usePostHog: () => ({ capture: vi.fn() })
-  };
-});
-
 describe('CampaignView', () => {
   const user = userEvent.setup();
 
-  function renderView(campaign: CampaignDTO) {
+  interface RenderViewOptions {
+    housings?: HousingDTO[];
+  }
+
+  function renderView(campaign: CampaignDTO, options?: RenderViewOptions) {
     data.campaigns.push(campaign);
+    if (options?.housings?.length) {
+      data.housings.push(...options.housings);
+      data.campaignHousings.set(
+        campaign.id,
+        options.housings.map((h) => ({ id: h.id }))
+      );
+      options.housings.forEach((housing) => {
+        data.housingCampaigns.set(housing.id, [{ id: campaign.id }]);
+      });
+    }
 
     const router = createMemoryRouter(
       [
         { path: '/campagnes', element: <div>Campagnes</div> },
-        { path: '/campagnes/:id', element: <CampaignView /> }
+        { path: '/campagnes/:id', element: <CampaignView /> },
+        { path: '/parc-de-logements', element: <HousingListView /> }
       ],
       { initialEntries: [`/campagnes/${campaign.id}`] }
     );
@@ -177,16 +186,21 @@ describe('CampaignView', () => {
       sentAt: null,
       returnCount: null
     };
+    const housings: HousingDTO[] = faker.helpers.multiple(() =>
+      genHousingDTO()
+    );
 
-    const { router } = renderView(campaign);
+    const { router } = renderView(campaign, {
+      housings
+    });
 
     await screen.findByRole('heading', { level: 1 });
     await user.click(
       screen.getByRole('button', { name: /voir les logements/i })
     );
-    await waitFor(() =>
-      expect(router.state.location.pathname).toBe('/parc-de-logements')
-    );
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe('/parc-de-logements');
+    });
   });
 
   it('displays the sentAt date in dd/MM/yyyy format when set', async () => {

--- a/frontend/src/views/Campaign/test/CampaignView.test.tsx
+++ b/frontend/src/views/Campaign/test/CampaignView.test.tsx
@@ -7,8 +7,8 @@ import {
   genSenderDTO
 } from '@zerologementvacant/models/fixtures';
 import { Provider } from 'react-redux';
-import { createMemoryRouter, RouterProvider } from 'react-router-dom';
 import { describe, expect, it } from 'vitest';
+import { createMemoryRouter, RouterProvider } from 'react-router';
 
 import data from '~/mocks/handlers/data';
 import configureTestStore from '~/utils/storeUtils';

--- a/frontend/src/views/Group/GroupView.tsx
+++ b/frontend/src/views/Group/GroupView.tsx
@@ -3,7 +3,7 @@ import { Breadcrumb } from '@codegouvfr/react-dsfr/Breadcrumb';
 import Grid from '@mui/material/Grid';
 import Stack from '@mui/material/Stack';
 import { useEffect } from 'react';
-import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router';
 
 import AppSearchBar from '~/components/_app/AppSearchBar/AppSearchBar';
 import GroupNext, { type GroupProps } from '~/components/Group/GroupNext';

--- a/frontend/src/views/Group/test/GroupView.test.tsx
+++ b/frontend/src/views/Group/test/GroupView.test.tsx
@@ -21,7 +21,7 @@ import {
   genUserDTO
 } from '@zerologementvacant/models/fixtures';
 import { Provider } from 'react-redux';
-import { createMemoryRouter, RouterProvider } from 'react-router-dom';
+import { createMemoryRouter, RouterProvider } from 'react-router';
 
 import data from '~/mocks/handlers/data';
 import { fromEstablishmentDTO } from '~/models/Establishment';

--- a/frontend/src/views/Housing/HousingOwnersView.tsx
+++ b/frontend/src/views/Housing/HousingOwnersView.tsx
@@ -6,7 +6,7 @@ import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import { skipToken } from '@reduxjs/toolkit/query';
 import { useEffect, useState } from 'react';
-import { useLocation, useParams } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router';
 
 import type {
   AwaitingOwnerRank,

--- a/frontend/src/views/Housing/HousingView.tsx
+++ b/frontend/src/views/Housing/HousingView.tsx
@@ -5,7 +5,7 @@ import Grid from '@mui/material/Grid';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import { skipToken } from '@reduxjs/toolkit/query';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 import { assert } from 'ts-essentials';
 
 import HousingHeader from '~/components/Housing/HousingHeader';

--- a/frontend/src/views/Housing/test/HousingOwnersView.test.tsx
+++ b/frontend/src/views/Housing/test/HousingOwnersView.test.tsx
@@ -20,7 +20,7 @@ import {
   genUserDTO
 } from '@zerologementvacant/models/fixtures';
 import { Provider } from 'react-redux';
-import { createMemoryRouter, RouterProvider } from 'react-router-dom';
+import { createMemoryRouter, RouterProvider } from 'react-router';
 
 import data from '~/mocks/handlers/data';
 import { fromEstablishmentDTO } from '~/models/Establishment';

--- a/frontend/src/views/Housing/test/HousingView.test.tsx
+++ b/frontend/src/views/Housing/test/HousingView.test.tsx
@@ -27,7 +27,7 @@ import async from 'async';
 import { format, subYears } from 'date-fns';
 import { pipe, Record } from 'effect';
 import { Provider } from 'react-redux';
-import { createMemoryRouter, RouterProvider } from 'react-router-dom';
+import { createMemoryRouter, RouterProvider } from 'react-router';
 
 import data from '~/mocks/handlers/data';
 import { fromEstablishmentDTO } from '~/models/Establishment';

--- a/frontend/src/views/HousingList/HousingListTab.tsx
+++ b/frontend/src/views/HousingList/HousingListTab.tsx
@@ -4,7 +4,7 @@ import Skeleton from '@mui/material/Skeleton';
 import Typography from '@mui/material/Typography';
 import { HousingStatus, type Occupancy } from '@zerologementvacant/models';
 import { useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { useNotification } from '~/hooks/useNotification';
 import GroupRemoveHousingModal from '../../components/GroupRemoveHousingModal/GroupRemoveHousingModal';

--- a/frontend/src/views/HousingList/HousingListView.tsx
+++ b/frontend/src/views/HousingList/HousingListView.tsx
@@ -3,7 +3,7 @@ import Button from '@codegouvfr/react-dsfr/Button';
 import Grid from '@mui/material/Grid';
 import Stack from '@mui/material/Stack';
 import { useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router';
 
 import Tooltip from '~/components/ui/Tooltip/Tooltip';
 import createGroupAddHousingModal from '~/components/Group/GroupAddHousingModal';

--- a/frontend/src/views/HousingList/test/HousingListView.test.tsx
+++ b/frontend/src/views/HousingList/test/HousingListView.test.tsx
@@ -36,7 +36,7 @@ import {
 import async from 'async';
 import { Array, pipe, Predicate } from 'effect';
 import { Provider } from 'react-redux';
-import { createMemoryRouter, RouterProvider } from 'react-router-dom';
+import { createMemoryRouter, RouterProvider } from 'react-router';
 
 import data from '~/mocks/handlers/data';
 import { fromEstablishmentDTO } from '~/models/Establishment';

--- a/frontend/src/views/Login/LoginView.test.tsx
+++ b/frontend/src/views/Login/LoginView.test.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 
 import { genUserDTO } from '@zerologementvacant/models/fixtures';
 import { Provider } from 'react-redux';
-import { createMemoryRouter, RouterProvider } from 'react-router-dom';
+import { createMemoryRouter, RouterProvider } from 'react-router';
 import data from '../../mocks/handlers/data';
 import configureTestStore from '../../utils/storeUtils';
 import LoginView from './LoginView';

--- a/frontend/src/views/Login/LoginView.tsx
+++ b/frontend/src/views/Login/LoginView.tsx
@@ -10,7 +10,7 @@ import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import { useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router';
 import * as yup from 'yup';
 
 import EstablishmentSearchableSelect from '~/components/establishment/EstablishmentSearchableSelect';

--- a/frontend/src/views/Login/TwoFactorView.tsx
+++ b/frontend/src/views/Login/TwoFactorView.tsx
@@ -8,7 +8,7 @@ import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { FormProvider, useForm } from 'react-hook-form';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router';
 import { useState } from 'react';
 import { object, string, type InferType }  from 'yup';
 

--- a/frontend/src/views/Owner/OwnerView.tsx
+++ b/frontend/src/views/Owner/OwnerView.tsx
@@ -5,7 +5,7 @@ import Container from '@mui/material/Container';
 import Grid from '@mui/material/Grid';
 import Stack from '@mui/material/Stack';
 import { skipToken } from '@reduxjs/toolkit/query';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import OwnerCard from '~/components/Owner/OwnerCard';
 import createOwnerEditionModal from '~/components/Owner/OwnerEditionModal';

--- a/frontend/src/views/SiteMapView.tsx
+++ b/frontend/src/views/SiteMapView.tsx
@@ -1,6 +1,6 @@
 import Container from '@mui/material/Container';
 import Typography from '@mui/material/Typography';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useDocumentTitle } from '~/hooks/useDocumentTitle';
 
 interface Route {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6298,13 +6298,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@remix-run/router@npm:1.23.2":
-  version: 1.23.2
-  resolution: "@remix-run/router@npm:1.23.2"
-  checksum: 10c0/7096b7f2086b2cd80c9e06873b71a8317e04858c01edc06a6fed187b660408a90f47c8e120e8af4c369cf1fa6b6a316a66b0917f42b6eb8a566e98b277c50449
-  languageName: node
-  linkType: hard
-
 "@rolldown/binding-android-arm64@npm:1.0.0":
   version: 1.0.0
   resolution: "@rolldown/binding-android-arm64@npm:1.0.0"
@@ -11321,7 +11314,7 @@ __metadata:
     react-pdf: "npm:10.4.1"
     react-redux: "npm:8.1.3"
     react-redux-loading-bar: "npm:5.0.8"
-    react-router-dom: "npm:6.30.3"
+    react-router: "npm:^7.13.2"
     react-toastify: "npm:10.0.6"
     react-use: "npm:17.6.0"
     redux: "npm:5.0.1"
@@ -13447,7 +13440,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cookie@npm:^1.1.1":
+"cookie@npm:^1.0.1, cookie@npm:^1.1.1":
   version: 1.1.1
   resolution: "cookie@npm:1.1.1"
   checksum: 10c0/79c4ddc0fcad9c4f045f826f42edf54bcc921a29586a4558b0898277fa89fb47be95bc384c2253f493af7b29500c830da28341274527328f18eba9f58afa112c
@@ -22050,27 +22043,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-router-dom@npm:6.30.3":
-  version: 6.30.3
-  resolution: "react-router-dom@npm:6.30.3"
+"react-router@npm:^7.13.2":
+  version: 7.13.2
+  resolution: "react-router@npm:7.13.2"
   dependencies:
-    "@remix-run/router": "npm:1.23.2"
-    react-router: "npm:6.30.3"
+    cookie: "npm:^1.0.1"
+    set-cookie-parser: "npm:^2.6.0"
   peerDependencies:
-    react: ">=16.8"
-    react-dom: ">=16.8"
-  checksum: 10c0/e8a1e13c662ed6ee71a785bd3418ba04b700bcd8aff6ea7b32524371e8abb1c85568cd4fe9b9e9d555b8101fd415f6f1796531f593da60be179ce75b37038657
-  languageName: node
-  linkType: hard
-
-"react-router@npm:6.30.3":
-  version: 6.30.3
-  resolution: "react-router@npm:6.30.3"
-  dependencies:
-    "@remix-run/router": "npm:1.23.2"
-  peerDependencies:
-    react: ">=16.8"
-  checksum: 10c0/a0a74bf5a933cf0abd47e0eac1d3a505cd66b866e3ee8f20d8016885d3b4361ba3ba72dee026248c6125e631b191ba6ad109184c892281cea6cb747c71bf5940
+    react: ">=18"
+    react-dom: ">=18"
+  peerDependenciesMeta:
+    react-dom:
+      optional: true
+  checksum: 10c0/c7620565df0b444507cfceb76733adbd26e28a72fc4d52d344190bcb2e6483427313a3b6076c53d362e2682ccdb1262731bcaa6c3577cbbeea130291a38715f1
   languageName: node
   linkType: hard
 
@@ -23106,6 +23091,13 @@ __metadata:
     parseurl: "npm:~1.3.3"
     send: "npm:~0.19.1"
   checksum: 10c0/36320397a073c71bedf58af48a4a100fe6d93f07459af4d6f08b9a7217c04ce2a4939e0effd842dc7bece93ffcd59eb52f58c4fff2a8e002dc29ae6b219cd42b
+  languageName: node
+  linkType: hard
+
+"set-cookie-parser@npm:^2.6.0":
+  version: 2.7.2
+  resolution: "set-cookie-parser@npm:2.7.2"
+  checksum: 10c0/4381a9eb7ee951dfe393fe7aacf76b9a3b4e93a684d2162ab35594fa4053cc82a4d7d7582bf397718012c9adcf839b8cd8f57c6c42901ea9effe33c752da4a45
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Enable all 5 remaining react-router v7 future flags in `createBrowserRouter` (these become default behavior in v7, so the flag step ensures zero behavioral surprises at package swap time)
- Replace `react-router-dom` with `react-router@7` — v7 ships as a single package; all imports updated across the frontend (`~57 files`)
- Update Sentry router integration: `reactRouterV6BrowserTracingIntegration` → `reactRouterV7BrowserTracingIntegration`, `wrapCreateBrowserRouterV6` → `wrapCreateBrowserRouterV7`

## Test plan

- [x] `yarn nx typecheck frontend` — passes
- [x] `yarn nx test frontend` — 403 tests passing, 36 test files, 0 failures
- [x] `yarn nx build frontend` — build succeeds
- [x] No `react-router-dom` references remain in `frontend/src/`

## Notes

- The app uses only the Data Router API (no loaders/actions/fetchers), so all v7 future flags were no-ops behaviorally — the migration is a drop-in
- 3 test files still use the legacy `<MemoryRouter>` component (`GroupCard`, `GroupHeader`, `useSelection`) — they work fine in v7 and are left as a follow-up cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)