### PR TITLE
feat(server): différencier l'export groupe de l'export campagne

### DIFF
--- a/frontend/src/models/HousingOwner.tsx
+++ b/frontend/src/models/HousingOwner.tsx
@@ -1,16 +1,7 @@
-import type { RelativeLocation } from '@zerologementvacant/models';
+import { RELATIVE_LOCATION_LABELS } from '@zerologementvacant/models';
 import { match } from 'ts-pattern';
 
-export const RELATIVE_LOCATION_LABELS: Record<RelativeLocation, string> = {
-  'same-address': 'Habite la même adresse',
-  'same-commune': 'Habite dans la même commune',
-  'same-department': 'Habite dans le même département',
-  'same-region': 'Habite dans la même région',
-  metropolitan: 'Habite dans une autre région',
-  overseas: 'Habite dans une autre région',
-  'foreign-country': 'Habite à l’étranger',
-  other: 'Pas d’information'
-};
+export { RELATIVE_LOCATION_LABELS };
 
 export function getHousingOwnerRankLabel(rank: number): string {
   return match(rank)

--- a/frontend/src/models/HousingOwner.tsx
+++ b/frontend/src/models/HousingOwner.tsx
@@ -1,7 +1,6 @@
-import { RELATIVE_LOCATION_LABELS } from '@zerologementvacant/models';
 import { match } from 'ts-pattern';
 
-export { RELATIVE_LOCATION_LABELS };
+export { RELATIVE_LOCATION_LABELS } from '@zerologementvacant/models';
 
 export function getHousingOwnerRankLabel(rank: number): string {
   return match(rank)

--- a/packages/models/src/RelativeLocation.ts
+++ b/packages/models/src/RelativeLocation.ts
@@ -26,3 +26,14 @@ export const RELATIVE_LOCATION_FILTER_VALUES = [
 ] as const;
 export type RelativeLocationFilter =
   (typeof RELATIVE_LOCATION_FILTER_VALUES)[number];
+
+export const RELATIVE_LOCATION_LABELS: Record<RelativeLocation, string> = {
+  'same-address': 'Habite la même adresse',
+  'same-commune': 'Habite dans la même commune',
+  'same-department': 'Habite dans le même département',
+  'same-region': 'Habite dans la même région',
+  metropolitan: 'Habite dans une autre région',
+  overseas: 'Habite dans une autre région',
+  'foreign-country': 'Habite à l\u2019étranger',
+  other: 'Pas d\u2019information'
+};

--- a/server/src/controllers/housingExportController.ts
+++ b/server/src/controllers/housingExportController.ts
@@ -5,7 +5,8 @@ import {
   isPrecisionBlockingPointCategory,
   isPrecisionEvolutionCategory,
   isPrecisionMechanismCategory,
-  OCCUPANCY_LABELS
+  OCCUPANCY_LABELS,
+  RELATIVE_LOCATION_LABELS
 } from '@zerologementvacant/models';
 import { slugify, timestamp } from '@zerologementvacant/utils';
 import { Predicate } from 'effect';
@@ -146,7 +147,7 @@ async function exportGroup(request: Request, response: Response) {
   });
 
   await Promise.all([
-    createHousingWorksheet({
+    createGroupHousingWorksheet({
       workbook,
       stream: housingStream,
       campaigns
@@ -349,6 +350,163 @@ export async function createHousingWorksheet(
           { header: 'Évolution(s)', key: 'evolutions' },
           { header: 'Campagne(s)', key: 'campaigns' },
           ...OWNER_WORKSHEET_COLUMNS
+        ]
+      })
+    );
+}
+
+/**
+ * Columns for the owner section in group exports.
+ * Compared to campaign exports:
+ * - "Propriétaire" renamed to "Propriétaire destinataire principal"
+ * - Address columns removed (LOVAC, BAN, Fiabilité, Numéro, Voie, Code postal, Commune, Complément)
+ * - New column: "Localisation du propriétaire destinataire principal"
+ */
+export const GROUP_OWNER_WORKSHEET_COLUMNS: Array<
+  Partial<Column> & { key: string }
+> = [
+  {
+    header: 'Propriétaire destinataire principal',
+    key: 'ownerName'
+  },
+  {
+    header: 'Localisation du propriétaire destinataire principal',
+    key: 'ownerRelativeLocation'
+  }
+];
+
+/**
+ * Housing worksheet for group exports with differentiated columns:
+ * - "Identifiant fiscal national" before "Identifiant fiscal départemental" (swapped)
+ * - "Point(s) de blocage", "Évolution(s)", "Dispositif(s)" (reordered)
+ * - Owner address columns removed
+ * - "Propriétaire" renamed
+ * - Alternating column colors (white/grey)
+ * - New: "Localisation du propriétaire destinataire principal"
+ */
+export async function createGroupHousingWorksheet(
+  options: CreateHousingWorksheetOptions
+): Promise<void> {
+  const { workbook, stream, campaigns } = options;
+  return stream
+    .pipeThrough(
+      new TransformStream<
+        HousingApi,
+        { housing: HousingApi; banAddress: AddressApi | null }
+      >({
+        async transform(housing, controller) {
+          const banAddress = await banAddressesRepository.getByRefId(
+            housing.id,
+            AddressKinds.Housing
+          );
+          controller.enqueue({
+            housing,
+            banAddress
+          });
+        }
+      })
+    )
+    .pipeThrough(
+      // @ts-expect-error - Type inference issue in @types/node (https://github.com/microsoft/TypeScript-DOM-lib-generator/pull/1676)
+      map(({ housing, banAddress }) => {
+        const building = getBuildingLocation(housing);
+        return {
+          localId: housing.localId,
+          invariant: housing.invariant,
+          plotId: housing.plotId,
+          geoCode: housing.geoCode,
+          housingRawAddress: housing.rawAddress
+            .filter(Predicate.isNotNullable)
+            .join('\n'),
+          housingAddress: banAddress
+            ? formatAddress(banAddress).join('\n')
+            : null,
+          housingAddressScore: banAddress?.score,
+          latitude: housing.latitude ?? banAddress?.latitude,
+          longitude: housing.longitude ?? banAddress?.longitude,
+          buildingLocation: building
+            ? [
+                building.building,
+                building.entrance,
+                building.level,
+                building.local
+              ].join('\n')
+            : null,
+          housingKind:
+            housing.housingKind === 'APPART' ? 'Appartement' : 'Maison',
+          energyConsumption: housing.energyConsumption,
+          energyConsumptionAt: housing.energyConsumptionAt,
+          livingArea: housing.livingArea,
+          roomsCount: housing.roomsCount,
+          buildingYear: housing.buildingYear,
+          occupancy: OCCUPANCY_LABELS[housing.occupancy],
+          vacancyStartYear: housing.vacancyStartYear,
+          status: HOUSING_STATUS_LABELS[housing.status],
+          subStatus: housing.subStatus,
+          blockingPoints: housing.precisions
+            ?.filter((precision) =>
+              isPrecisionBlockingPointCategory(precision.category)
+            )
+            ?.map((precision) => precision.label)
+            ?.join('\n'),
+          evolutions: housing.precisions
+            ?.filter((precision) =>
+              isPrecisionEvolutionCategory(precision.category)
+            )
+            ?.map((precision) => precision.label)
+            ?.join('\n'),
+          mechanisms: housing.precisions
+            ?.filter((precision) =>
+              isPrecisionMechanismCategory(precision.category)
+            )
+            ?.map((precision) => precision.label)
+            ?.join('\n'),
+          campaigns: housing.campaignIds
+            ?.filter(Predicate.isNotNullable)
+            ?.map((id) => campaigns.find((campaign) => campaign.id === id))
+            ?.map((campaign) => campaign?.title)
+            ?.join('\n'),
+          // Owner properties (only name, no address columns)
+          ownerName: housing.owner?.fullName,
+          ownerRelativeLocation: housing.ownerRelativeLocation
+            ? RELATIVE_LOCATION_LABELS[housing.ownerRelativeLocation]
+            : null
+        };
+      })
+    )
+    .pipeTo(
+      excelUtils.createWorksheet(workbook, {
+        name: 'Logements',
+        alternateColumnColors: true,
+        columns: [
+          { header: 'Identifiant fiscal national', key: 'localId' },
+          { header: 'Identifiant fiscal départemental', key: 'invariant' },
+          { header: 'Référence cadastrale', key: 'plotId' },
+          { header: 'Code INSEE commune du logement', key: 'geoCode' },
+          { header: 'Adresse LOVAC du logement', key: 'housingRawAddress' },
+          { header: 'Adresse BAN du logement', key: 'housingAddress' },
+          {
+            header: 'Adresse BAN du logement - Fiabilité',
+            key: 'housingAddressScore'
+          },
+          { header: 'Latitude', key: 'latitude' },
+          { header: 'Longitude', key: 'longitude' },
+          { header: 'Localisation', key: 'buildingLocation' },
+          { header: 'Type de logement', key: 'housingKind' },
+          { header: 'DPE représentatif', key: 'energyConsumption' },
+          { header: 'Date DPE', key: 'energyConsumptionAt' },
+          { header: 'Surface', key: 'livingArea' },
+          { header: 'Nombre de pièces', key: 'roomsCount' },
+          { header: 'Date de construction', key: 'buildingYear' },
+          { header: 'Occupation', key: 'occupancy' },
+          { header: 'Date de début de vacance', key: 'vacancyStartYear' },
+          { header: 'Statut', key: 'status' },
+          { header: 'Sous-statut', key: 'subStatus' },
+          { header: 'Point(s) de blocage', key: 'blockingPoints' },
+          { header: 'Évolution(s)', key: 'evolutions' },
+          { header: 'Dispositif(s)', key: 'mechanisms' },
+          { header: 'Campagne(s)', key: 'campaigns' },
+          ...GROUP_OWNER_WORKSHEET_COLUMNS
         ]
       })
     );

--- a/server/src/controllers/housingExportController.ts
+++ b/server/src/controllers/housingExportController.ts
@@ -180,6 +180,7 @@ export function toOwnerExcelRow(
 ) {
   return {
     ownerName: owner.fullName,
+    ownerBirthDate: owner.birthDate,
     ownerRawAddress: owner.rawAddress?.join('\n'),
     ownerBanAddress: owner.banAddress?.label,
     ownerBanAddressScore: owner.banAddress?.score
@@ -197,6 +198,10 @@ export const OWNER_WORKSHEET_COLUMNS: Array<
   Partial<Column> & { key: keyof ReturnType<typeof toOwnerExcelRow> }
 > = [
   { header: ‘Propriétaire destinataire principal’, key: ‘ownerName’ },
+  {
+    header: ‘Date de naissance du propriétaire’,
+    key: ‘ownerBirthDate’
+  },
   { header: ‘Adresse LOVAC du propriétaire’, key: ‘ownerRawAddress’ },
   { header: ‘Adresse BAN du propriétaire’, key: ‘ownerBanAddress’ },
   {
@@ -214,7 +219,7 @@ export const OWNER_WORKSHEET_COLUMNS: Array<
 ];
 
 export const OWNER_LOCATION_COLUMN = {
-  header: ‘Localisation du propriétaire destinataire principal’,
+  header: ‘Localisation du propriétaire’,
   key: ‘ownerRelativeLocation’ as const
 };
 
@@ -339,6 +344,7 @@ export async function createHousingWorksheet(
           { header: 'Référence cadastrale', key: 'plotId' },
           { header: 'Code INSEE commune du logement', key: 'geoCode' },
           { header: 'Adresse LOVAC du logement', key: 'housingRawAddress' },
+          { header: 'Précisions adresse du logement', key: 'buildingLocation' },
           { header: 'Adresse BAN du logement', key: 'housingAddress' },
           {
             header: 'Fiabilité Adresse BAN du logement (%)',
@@ -346,7 +352,6 @@ export async function createHousingWorksheet(
           },
           { header: 'Latitude', key: 'latitude' },
           { header: 'Longitude', key: 'longitude' },
-          { header: 'Précisions adresse du logement', key: 'buildingLocation' },
           { header: 'Type de logement', key: 'housingKind' },
           { header: 'DPE représentatif', key: 'energyConsumption' },
           { header: 'Date DPE', key: 'energyConsumptionAt' },
@@ -378,6 +383,10 @@ export const GROUP_OWNER_WORKSHEET_COLUMNS = [
   {
     header: 'Propriétaire destinataire principal',
     key: 'ownerName' as const
+  },
+  {
+    header: 'Date de naissance du propriétaire',
+    key: 'ownerBirthDate' as const
   },
   OWNER_LOCATION_COLUMN
 ];
@@ -475,6 +484,7 @@ export async function createGroupHousingWorksheet(
             ?.join('\n'),
           // Owner properties (only name, no address columns)
           ownerName: housing.owner?.fullName,
+          ownerBirthDate: housing.owner?.birthDate,
           ownerRelativeLocation: housing.ownerRelativeLocation
             ? RELATIVE_LOCATION_LABELS[housing.ownerRelativeLocation]
             : null
@@ -491,6 +501,7 @@ export async function createGroupHousingWorksheet(
           { header: 'Référence cadastrale', key: 'plotId' },
           { header: 'Code INSEE commune du logement', key: 'geoCode' },
           { header: 'Adresse LOVAC du logement', key: 'housingRawAddress' },
+          { header: 'Précisions adresse du logement', key: 'buildingLocation' },
           { header: 'Adresse BAN du logement', key: 'housingAddress' },
           {
             header: 'Adresse BAN du logement - Fiabilité',
@@ -498,7 +509,6 @@ export async function createGroupHousingWorksheet(
           },
           { header: 'Latitude', key: 'latitude' },
           { header: 'Longitude', key: 'longitude' },
-          { header: 'Précisions adresse du logement', key: 'buildingLocation' },
           { header: 'Type de logement', key: 'housingKind' },
           { header: 'DPE représentatif', key: 'energyConsumption' },
           { header: 'Date DPE', key: 'energyConsumptionAt' },

--- a/server/src/controllers/housingExportController.ts
+++ b/server/src/controllers/housingExportController.ts
@@ -197,30 +197,30 @@ export function toOwnerExcelRow(
 export const OWNER_WORKSHEET_COLUMNS: Array<
   Partial<Column> & { key: keyof ReturnType<typeof toOwnerExcelRow> }
 > = [
-  { header: ‘Propriétaire destinataire principal’, key: ‘ownerName’ },
+  { header: 'Propriétaire destinataire principal', key: 'ownerName' },
   {
-    header: ‘Date de naissance du propriétaire’,
-    key: ‘ownerBirthDate’
+    header: 'Date de naissance du propriétaire',
+    key: 'ownerBirthDate'
   },
-  { header: ‘Adresse LOVAC du propriétaire’, key: ‘ownerRawAddress’ },
-  { header: ‘Adresse BAN du propriétaire’, key: ‘ownerBanAddress’ },
+  { header: 'Adresse LOVAC du propriétaire', key: 'ownerRawAddress' },
+  { header: 'Adresse BAN du propriétaire', key: 'ownerBanAddress' },
   {
-    header: ‘Adresse BAN du propriétaire - Fiabilité’,
-    key: ‘ownerBanAddressScore’
+    header: 'Adresse BAN du propriétaire - Fiabilité',
+    key: 'ownerBanAddressScore'
   },
-  { header: ‘Numéro’, key: ‘ownerBanHouseNumber’ },
-  { header: ‘Voie’, key: ‘ownerBanStreet’ },
-  { header: ‘Code postal’, key: ‘ownerBanPostalCode’ },
-  { header: ‘Commune’, key: ‘ownerBanCity’ },
+  { header: 'Numéro', key: 'ownerBanHouseNumber' },
+  { header: 'Voie', key: 'ownerBanStreet' },
+  { header: 'Code postal', key: 'ownerBanPostalCode' },
+  { header: 'Commune', key: 'ownerBanCity' },
   {
-    header: ‘Complément d\u2019adresse du propriétaire’,
-    key: ‘ownerAdditionalAddress’
+    header: 'Complément d\u2019adresse du propriétaire',
+    key: 'ownerAdditionalAddress'
   }
 ];
 
 export const OWNER_LOCATION_COLUMN = {
-  header: ‘Localisation du propriétaire’,
-  key: ‘ownerRelativeLocation’ as const
+  header: 'Localisation du propriétaire',
+  key: 'ownerRelativeLocation' as const
 };
 
 export function createOwnerWorksheet(options: CreateOwnerWorksheetOptions) {

--- a/server/src/controllers/housingExportController.ts
+++ b/server/src/controllers/housingExportController.ts
@@ -279,7 +279,7 @@ export async function createHousingWorksheet(
             ? formatAddress(banAddress).join('\n')
             : null,
           housingAddressScore:
-            banAddress?.score != null
+            banAddress?.score !== null && banAddress?.score !== undefined
               ? `${banAddress.score * 100} %`
               : null,
           latitude: housing.latitude ?? banAddress?.latitude,

--- a/server/src/controllers/housingExportController.ts
+++ b/server/src/controllers/housingExportController.ts
@@ -196,22 +196,27 @@ export function toOwnerExcelRow(
 export const OWNER_WORKSHEET_COLUMNS: Array<
   Partial<Column> & { key: keyof ReturnType<typeof toOwnerExcelRow> }
 > = [
-  { header: 'Propriétaire', key: 'ownerName' },
-  { header: 'Adresse LOVAC du propriétaire', key: 'ownerRawAddress' },
-  { header: 'Adresse BAN du propriétaire', key: 'ownerBanAddress' },
+  { header: ‘Propriétaire destinataire principal’, key: ‘ownerName’ },
+  { header: ‘Adresse LOVAC du propriétaire’, key: ‘ownerRawAddress’ },
+  { header: ‘Adresse BAN du propriétaire’, key: ‘ownerBanAddress’ },
   {
-    header: 'Adresse BAN du propriétaire - Fiabilité',
-    key: 'ownerBanAddressScore'
+    header: ‘Adresse BAN du propriétaire - Fiabilité’,
+    key: ‘ownerBanAddressScore’
   },
-  { header: 'Numéro', key: 'ownerBanHouseNumber' },
-  { header: 'Voie', key: 'ownerBanStreet' },
-  { header: 'Code postal', key: 'ownerBanPostalCode' },
-  { header: 'Commune', key: 'ownerBanCity' },
+  { header: ‘Numéro’, key: ‘ownerBanHouseNumber’ },
+  { header: ‘Voie’, key: ‘ownerBanStreet’ },
+  { header: ‘Code postal’, key: ‘ownerBanPostalCode’ },
+  { header: ‘Commune’, key: ‘ownerBanCity’ },
   {
-    header: 'Complément d’adresse du propriétaire',
-    key: 'ownerAdditionalAddress'
+    header: ‘Complément d\u2019adresse du propriétaire’,
+    key: ‘ownerAdditionalAddress’
   }
 ];
+
+export const OWNER_LOCATION_COLUMN = {
+  header: ‘Localisation du propriétaire destinataire principal’,
+  key: ‘ownerRelativeLocation’ as const
+};
 
 export function createOwnerWorksheet(options: CreateOwnerWorksheetOptions) {
   const { workbook, stream } = options;
@@ -258,8 +263,8 @@ export async function createHousingWorksheet(
       map(({ housing, banAddress }) => {
         const building = getBuildingLocation(housing);
         return {
-          invariant: housing.invariant,
           localId: housing.localId,
+          invariant: housing.invariant,
           plotId: housing.plotId,
           geoCode: housing.geoCode,
           housingRawAddress: housing.rawAddress
@@ -268,7 +273,10 @@ export async function createHousingWorksheet(
           housingAddress: banAddress
             ? formatAddress(banAddress).join('\n')
             : null,
-          housingAddressScore: banAddress?.score,
+          housingAddressScore:
+            banAddress?.score != null
+              ? `${banAddress.score * 100} %`
+              : null,
           latitude: housing.latitude ?? banAddress?.latitude,
           longitude: housing.longitude ?? banAddress?.longitude,
           buildingLocation: building
@@ -290,12 +298,6 @@ export async function createHousingWorksheet(
           vacancyStartYear: housing.vacancyStartYear,
           status: HOUSING_STATUS_LABELS[housing.status],
           subStatus: housing.subStatus,
-          mechanisms: housing.precisions
-            ?.filter((precision) =>
-              isPrecisionMechanismCategory(precision.category)
-            )
-            ?.map((precision) => precision.label)
-            ?.join('\n'),
           blockingPoints: housing.precisions
             ?.filter((precision) =>
               isPrecisionBlockingPointCategory(precision.category)
@@ -308,48 +310,59 @@ export async function createHousingWorksheet(
             )
             ?.map((precision) => precision.label)
             ?.join('\n'),
+          mechanisms: housing.precisions
+            ?.filter((precision) =>
+              isPrecisionMechanismCategory(precision.category)
+            )
+            ?.map((precision) => precision.label)
+            ?.join('\n'),
           campaigns: housing.campaignIds
             ?.filter(Predicate.isNotNullable)
             ?.map((id) => campaigns.find((campaign) => campaign.id === id))
             ?.map((campaign) => campaign?.title)
             ?.join('\n'),
           // Owner properties
-          ...(housing.owner ? toOwnerExcelRow(housing.owner) : {})
+          ...(housing.owner ? toOwnerExcelRow(housing.owner) : {}),
+          ownerRelativeLocation: housing.ownerRelativeLocation
+            ? RELATIVE_LOCATION_LABELS[housing.ownerRelativeLocation]
+            : null
         };
       })
     )
     .pipeTo(
       excelUtils.createWorksheet(workbook, {
         name: 'Logements',
+        alternateColumnColors: true,
         columns: [
-          { header: 'Identifiant fiscal départemental', key: 'invariant' },
           { header: 'Identifiant fiscal national', key: 'localId' },
+          { header: 'Identifiant fiscal départemental', key: 'invariant' },
           { header: 'Référence cadastrale', key: 'plotId' },
           { header: 'Code INSEE commune du logement', key: 'geoCode' },
           { header: 'Adresse LOVAC du logement', key: 'housingRawAddress' },
           { header: 'Adresse BAN du logement', key: 'housingAddress' },
           {
-            header: 'Adresse BAN du logement - Fiabilité',
+            header: 'Fiabilité Adresse BAN du logement (%)',
             key: 'housingAddressScore'
           },
           { header: 'Latitude', key: 'latitude' },
           { header: 'Longitude', key: 'longitude' },
-          { header: 'Localisation', key: 'buildingLocation' },
+          { header: 'Précisions adresse du logement', key: 'buildingLocation' },
           { header: 'Type de logement', key: 'housingKind' },
           { header: 'DPE représentatif', key: 'energyConsumption' },
           { header: 'Date DPE', key: 'energyConsumptionAt' },
-          { header: 'Surface', key: 'livingArea' },
+          { header: 'Surface (m²)', key: 'livingArea' },
           { header: 'Nombre de pièces', key: 'roomsCount' },
-          { header: 'Date de construction', key: 'buildingYear' },
+          { header: 'Année de construction', key: 'buildingYear' },
           { header: 'Occupation', key: 'occupancy' },
-          { header: 'Date de début de vacance', key: 'vacancyStartYear' },
+          { header: 'Année de début de vacance', key: 'vacancyStartYear' },
           { header: 'Statut', key: 'status' },
           { header: 'Sous-statut', key: 'subStatus' },
-          { header: 'Dispositif(s)', key: 'mechanisms' },
-          { header: 'Point(s) de blocage', key: 'blockingPoints' },
-          { header: 'Évolution(s)', key: 'evolutions' },
-          { header: 'Campagne(s)', key: 'campaigns' },
-          ...OWNER_WORKSHEET_COLUMNS
+          { header: 'Points de blocage', key: 'blockingPoints' },
+          { header: 'Évolutions du logement', key: 'evolutions' },
+          { header: 'Dispositifs', key: 'mechanisms' },
+          { header: 'Campagnes', key: 'campaigns' },
+          ...OWNER_WORKSHEET_COLUMNS,
+          OWNER_LOCATION_COLUMN
         ]
       })
     );
@@ -358,21 +371,15 @@ export async function createHousingWorksheet(
 /**
  * Columns for the owner section in group exports.
  * Compared to campaign exports:
- * - "Propriétaire" renamed to "Propriétaire destinataire principal"
  * - Address columns removed (LOVAC, BAN, Fiabilité, Numéro, Voie, Code postal, Commune, Complément)
- * - New column: "Localisation du propriétaire destinataire principal"
+ * - Only keeps owner name + relative location
  */
-export const GROUP_OWNER_WORKSHEET_COLUMNS: Array<
-  Partial<Column> & { key: string }
-> = [
+export const GROUP_OWNER_WORKSHEET_COLUMNS = [
   {
     header: 'Propriétaire destinataire principal',
-    key: 'ownerName'
+    key: 'ownerName' as const
   },
-  {
-    header: 'Localisation du propriétaire destinataire principal',
-    key: 'ownerRelativeLocation'
-  }
+  OWNER_LOCATION_COLUMN
 ];
 
 /**
@@ -491,21 +498,21 @@ export async function createGroupHousingWorksheet(
           },
           { header: 'Latitude', key: 'latitude' },
           { header: 'Longitude', key: 'longitude' },
-          { header: 'Localisation', key: 'buildingLocation' },
+          { header: 'Précisions adresse du logement', key: 'buildingLocation' },
           { header: 'Type de logement', key: 'housingKind' },
           { header: 'DPE représentatif', key: 'energyConsumption' },
           { header: 'Date DPE', key: 'energyConsumptionAt' },
-          { header: 'Surface', key: 'livingArea' },
+          { header: 'Surface (m²)', key: 'livingArea' },
           { header: 'Nombre de pièces', key: 'roomsCount' },
-          { header: 'Date de construction', key: 'buildingYear' },
+          { header: 'Année de construction', key: 'buildingYear' },
           { header: 'Occupation', key: 'occupancy' },
-          { header: 'Date de début de vacance', key: 'vacancyStartYear' },
+          { header: 'Année de début de vacance', key: 'vacancyStartYear' },
           { header: 'Statut', key: 'status' },
           { header: 'Sous-statut', key: 'subStatus' },
-          { header: 'Point(s) de blocage', key: 'blockingPoints' },
-          { header: 'Évolution(s)', key: 'evolutions' },
-          { header: 'Dispositif(s)', key: 'mechanisms' },
-          { header: 'Campagne(s)', key: 'campaigns' },
+          { header: 'Points de blocage', key: 'blockingPoints' },
+          { header: 'Évolutions du logement', key: 'evolutions' },
+          { header: 'Dispositifs', key: 'mechanisms' },
+          { header: 'Campagnes', key: 'campaigns' },
           ...GROUP_OWNER_WORKSHEET_COLUMNS
         ]
       })

--- a/server/src/controllers/housingExportController.ts
+++ b/server/src/controllers/housingExportController.ts
@@ -410,6 +410,10 @@ export const GROUP_OWNER_WORKSHEET_COLUMNS = [
     header: 'Date de naissance du propriétaire',
     key: 'ownerBirthDate' as const
   },
+  {
+    header: 'Commune de résidence',
+    key: 'ownerBanCity' as const
+  },
   OWNER_LOCATION_COLUMN
 ];
 
@@ -423,6 +427,7 @@ export async function createGroupHousingWorksheet(
     toOwnerRow: (housing) => ({
       ownerName: housing.owner?.fullName,
       ownerBirthDate: housing.owner?.birthDate,
+      ownerBanCity: housing.owner?.banAddress?.city,
       ownerRelativeLocation: housing.ownerRelativeLocation
         ? RELATIVE_LOCATION_LABELS[housing.ownerRelativeLocation]
         : null

--- a/server/src/controllers/housingExportController.ts
+++ b/server/src/controllers/housingExportController.ts
@@ -248,14 +248,19 @@ interface HousingWorksheetConfig {
   toOwnerRow: (housing: HousingApi) => Record<string, unknown>;
 }
 
-const HOUSING_COLUMNS = [
+// Columns before the address score column (inserted per-variant via config)
+const HOUSING_COLUMNS_BEFORE_SCORE = [
   { header: 'Identifiant fiscal national', key: 'localId' },
   { header: 'Identifiant fiscal départemental', key: 'invariant' },
   { header: 'Référence cadastrale', key: 'plotId' },
   { header: 'Code INSEE commune du logement', key: 'geoCode' },
   { header: 'Adresse LOVAC du logement', key: 'housingRawAddress' },
   { header: 'Précisions adresse du logement', key: 'buildingLocation' },
-  { header: 'Adresse BAN du logement', key: 'housingAddress' },
+  { header: 'Adresse BAN du logement', key: 'housingAddress' }
+] as const;
+
+// Columns after the address score column
+const HOUSING_COLUMNS_AFTER_SCORE = [
   { header: 'Latitude', key: 'latitude' },
   { header: 'Longitude', key: 'longitude' },
   { header: 'Type de logement', key: 'housingKind' },
@@ -370,9 +375,9 @@ async function createHousingWorksheetBase(
         alternateColumnColors: true,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         columns: [
-          ...HOUSING_COLUMNS.slice(0, 7),
+          ...HOUSING_COLUMNS_BEFORE_SCORE,
           { header: addressScoreHeader, key: 'housingAddressScore' },
-          ...HOUSING_COLUMNS.slice(7),
+          ...HOUSING_COLUMNS_AFTER_SCORE,
           ...ownerColumns
         ] as any[]
       })

--- a/server/src/controllers/housingExportController.ts
+++ b/server/src/controllers/housingExportController.ts
@@ -368,12 +368,13 @@ async function createHousingWorksheetBase(
       excelUtils.createWorksheet(workbook, {
         name: 'Logements',
         alternateColumnColors: true,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         columns: [
           ...HOUSING_COLUMNS.slice(0, 7),
           { header: addressScoreHeader, key: 'housingAddressScore' },
           ...HOUSING_COLUMNS.slice(7),
           ...ownerColumns
-        ]
+        ] as any[]
       })
     );
 }

--- a/server/src/controllers/housingExportController.ts
+++ b/server/src/controllers/housingExportController.ts
@@ -139,24 +139,12 @@ async function exportGroup(request: Request, response: Response) {
     },
     includes: ['owner', 'campaigns', 'precisions']
   });
-  const ownerStream = ownerRepository.stream({
-    filters: {
-      groupId: group.id
-    },
-    includes: ['banAddress', 'housings']
-  });
 
-  await Promise.all([
-    createGroupHousingWorksheet({
-      workbook,
-      stream: housingStream,
-      campaigns
-    }),
-    createOwnerWorksheet({
-      workbook,
-      stream: ownerStream
-    })
-  ]);
+  await createGroupHousingWorksheet({
+    workbook,
+    stream: housingStream,
+    campaigns
+  });
 
   await workbook.commit();
   await groupRepository.save({

--- a/server/src/controllers/housingExportController.ts
+++ b/server/src/controllers/housingExportController.ts
@@ -241,10 +241,47 @@ export interface CreateHousingWorksheetOptions {
   campaigns: ReadonlyArray<CampaignApi>;
 }
 
-export async function createHousingWorksheet(
-  options: CreateHousingWorksheetOptions
+interface HousingWorksheetConfig {
+  addressScoreHeader: string;
+  formatAddressScore: (score: number) => string | number;
+  ownerColumns: ReadonlyArray<Partial<Column> & { key: string }>;
+  toOwnerRow: (housing: HousingApi) => Record<string, unknown>;
+}
+
+const HOUSING_COLUMNS = [
+  { header: 'Identifiant fiscal national', key: 'localId' },
+  { header: 'Identifiant fiscal départemental', key: 'invariant' },
+  { header: 'Référence cadastrale', key: 'plotId' },
+  { header: 'Code INSEE commune du logement', key: 'geoCode' },
+  { header: 'Adresse LOVAC du logement', key: 'housingRawAddress' },
+  { header: 'Précisions adresse du logement', key: 'buildingLocation' },
+  { header: 'Adresse BAN du logement', key: 'housingAddress' },
+  { header: 'Latitude', key: 'latitude' },
+  { header: 'Longitude', key: 'longitude' },
+  { header: 'Type de logement', key: 'housingKind' },
+  { header: 'DPE représentatif', key: 'energyConsumption' },
+  { header: 'Date DPE', key: 'energyConsumptionAt' },
+  { header: 'Surface (m²)', key: 'livingArea' },
+  { header: 'Nombre de pièces', key: 'roomsCount' },
+  { header: 'Année de construction', key: 'buildingYear' },
+  { header: 'Occupation', key: 'occupancy' },
+  { header: 'Année de début de vacance', key: 'vacancyStartYear' },
+  { header: 'Statut', key: 'status' },
+  { header: 'Sous-statut', key: 'subStatus' },
+  { header: 'Points de blocage', key: 'blockingPoints' },
+  { header: 'Évolutions du logement', key: 'evolutions' },
+  { header: 'Dispositifs', key: 'mechanisms' },
+  { header: 'Campagnes', key: 'campaigns' }
+] as const;
+
+async function createHousingWorksheetBase(
+  options: CreateHousingWorksheetOptions,
+  config: HousingWorksheetConfig
 ): Promise<void> {
   const { workbook, stream, campaigns } = options;
+  const { addressScoreHeader, formatAddressScore, ownerColumns, toOwnerRow } =
+    config;
+
   return stream
     .pipeThrough(
       new TransformStream<
@@ -256,10 +293,7 @@ export async function createHousingWorksheet(
             housing.id,
             AddressKinds.Housing
           );
-          controller.enqueue({
-            housing,
-            banAddress
-          });
+          controller.enqueue({ housing, banAddress });
         }
       })
     )
@@ -280,7 +314,7 @@ export async function createHousingWorksheet(
             : null,
           housingAddressScore:
             banAddress?.score !== null && banAddress?.score !== undefined
-              ? `${banAddress.score * 100} %`
+              ? formatAddressScore(banAddress.score)
               : null,
           latitude: housing.latitude ?? banAddress?.latitude,
           longitude: housing.longitude ?? banAddress?.longitude,
@@ -326,11 +360,7 @@ export async function createHousingWorksheet(
             ?.map((id) => campaigns.find((campaign) => campaign.id === id))
             ?.map((campaign) => campaign?.title)
             ?.join('\n'),
-          // Owner properties
-          ...(housing.owner ? toOwnerExcelRow(housing.owner) : {}),
-          ownerRelativeLocation: housing.ownerRelativeLocation
-            ? RELATIVE_LOCATION_LABELS[housing.ownerRelativeLocation]
-            : null
+          ...toOwnerRow(housing)
         };
       })
     )
@@ -339,45 +369,36 @@ export async function createHousingWorksheet(
         name: 'Logements',
         alternateColumnColors: true,
         columns: [
-          { header: 'Identifiant fiscal national', key: 'localId' },
-          { header: 'Identifiant fiscal départemental', key: 'invariant' },
-          { header: 'Référence cadastrale', key: 'plotId' },
-          { header: 'Code INSEE commune du logement', key: 'geoCode' },
-          { header: 'Adresse LOVAC du logement', key: 'housingRawAddress' },
-          { header: 'Précisions adresse du logement', key: 'buildingLocation' },
-          { header: 'Adresse BAN du logement', key: 'housingAddress' },
-          {
-            header: 'Fiabilité Adresse BAN du logement (%)',
-            key: 'housingAddressScore'
-          },
-          { header: 'Latitude', key: 'latitude' },
-          { header: 'Longitude', key: 'longitude' },
-          { header: 'Type de logement', key: 'housingKind' },
-          { header: 'DPE représentatif', key: 'energyConsumption' },
-          { header: 'Date DPE', key: 'energyConsumptionAt' },
-          { header: 'Surface (m²)', key: 'livingArea' },
-          { header: 'Nombre de pièces', key: 'roomsCount' },
-          { header: 'Année de construction', key: 'buildingYear' },
-          { header: 'Occupation', key: 'occupancy' },
-          { header: 'Année de début de vacance', key: 'vacancyStartYear' },
-          { header: 'Statut', key: 'status' },
-          { header: 'Sous-statut', key: 'subStatus' },
-          { header: 'Points de blocage', key: 'blockingPoints' },
-          { header: 'Évolutions du logement', key: 'evolutions' },
-          { header: 'Dispositifs', key: 'mechanisms' },
-          { header: 'Campagnes', key: 'campaigns' },
-          ...OWNER_WORKSHEET_COLUMNS,
-          OWNER_LOCATION_COLUMN
+          ...HOUSING_COLUMNS.slice(0, 7),
+          { header: addressScoreHeader, key: 'housingAddressScore' },
+          ...HOUSING_COLUMNS.slice(7),
+          ...ownerColumns
         ]
       })
     );
+}
+
+export async function createHousingWorksheet(
+  options: CreateHousingWorksheetOptions
+): Promise<void> {
+  return createHousingWorksheetBase(options, {
+    addressScoreHeader: 'Fiabilité Adresse BAN du logement (%)',
+    formatAddressScore: (score) => `${score * 100} %`,
+    ownerColumns: [...OWNER_WORKSHEET_COLUMNS, OWNER_LOCATION_COLUMN],
+    toOwnerRow: (housing) => ({
+      ...(housing.owner ? toOwnerExcelRow(housing.owner) : {}),
+      ownerRelativeLocation: housing.ownerRelativeLocation
+        ? RELATIVE_LOCATION_LABELS[housing.ownerRelativeLocation]
+        : null
+    })
+  });
 }
 
 /**
  * Columns for the owner section in group exports.
  * Compared to campaign exports:
  * - Address columns removed (LOVAC, BAN, Fiabilité, Numéro, Voie, Code postal, Commune, Complément)
- * - Only keeps owner name + relative location
+ * - Only keeps owner name, birth date + relative location
  */
 export const GROUP_OWNER_WORKSHEET_COLUMNS = [
   {
@@ -391,142 +412,21 @@ export const GROUP_OWNER_WORKSHEET_COLUMNS = [
   OWNER_LOCATION_COLUMN
 ];
 
-/**
- * Housing worksheet for group exports with differentiated columns:
- * - "Identifiant fiscal national" before "Identifiant fiscal départemental" (swapped)
- * - "Point(s) de blocage", "Évolution(s)", "Dispositif(s)" (reordered)
- * - Owner address columns removed
- * - "Propriétaire" renamed
- * - Alternating column colors (white/grey)
- * - New: "Localisation du propriétaire destinataire principal"
- */
 export async function createGroupHousingWorksheet(
   options: CreateHousingWorksheetOptions
 ): Promise<void> {
-  const { workbook, stream, campaigns } = options;
-  return stream
-    .pipeThrough(
-      new TransformStream<
-        HousingApi,
-        { housing: HousingApi; banAddress: AddressApi | null }
-      >({
-        async transform(housing, controller) {
-          const banAddress = await banAddressesRepository.getByRefId(
-            housing.id,
-            AddressKinds.Housing
-          );
-          controller.enqueue({
-            housing,
-            banAddress
-          });
-        }
-      })
-    )
-    .pipeThrough(
-      // @ts-expect-error - Type inference issue in @types/node (https://github.com/microsoft/TypeScript-DOM-lib-generator/pull/1676)
-      map(({ housing, banAddress }) => {
-        const building = getBuildingLocation(housing);
-        return {
-          localId: housing.localId,
-          invariant: housing.invariant,
-          plotId: housing.plotId,
-          geoCode: housing.geoCode,
-          housingRawAddress: housing.rawAddress
-            .filter(Predicate.isNotNullable)
-            .join('\n'),
-          housingAddress: banAddress
-            ? formatAddress(banAddress).join('\n')
-            : null,
-          housingAddressScore: banAddress?.score,
-          latitude: housing.latitude ?? banAddress?.latitude,
-          longitude: housing.longitude ?? banAddress?.longitude,
-          buildingLocation: building
-            ? [
-                building.building,
-                building.entrance,
-                building.level,
-                building.local
-              ].join('\n')
-            : null,
-          housingKind:
-            housing.housingKind === 'APPART' ? 'Appartement' : 'Maison',
-          energyConsumption: housing.energyConsumption,
-          energyConsumptionAt: housing.energyConsumptionAt,
-          livingArea: housing.livingArea,
-          roomsCount: housing.roomsCount,
-          buildingYear: housing.buildingYear,
-          occupancy: OCCUPANCY_LABELS[housing.occupancy],
-          vacancyStartYear: housing.vacancyStartYear,
-          status: HOUSING_STATUS_LABELS[housing.status],
-          subStatus: housing.subStatus,
-          blockingPoints: housing.precisions
-            ?.filter((precision) =>
-              isPrecisionBlockingPointCategory(precision.category)
-            )
-            ?.map((precision) => precision.label)
-            ?.join('\n'),
-          evolutions: housing.precisions
-            ?.filter((precision) =>
-              isPrecisionEvolutionCategory(precision.category)
-            )
-            ?.map((precision) => precision.label)
-            ?.join('\n'),
-          mechanisms: housing.precisions
-            ?.filter((precision) =>
-              isPrecisionMechanismCategory(precision.category)
-            )
-            ?.map((precision) => precision.label)
-            ?.join('\n'),
-          campaigns: housing.campaignIds
-            ?.filter(Predicate.isNotNullable)
-            ?.map((id) => campaigns.find((campaign) => campaign.id === id))
-            ?.map((campaign) => campaign?.title)
-            ?.join('\n'),
-          // Owner properties (only name, no address columns)
-          ownerName: housing.owner?.fullName,
-          ownerBirthDate: housing.owner?.birthDate,
-          ownerRelativeLocation: housing.ownerRelativeLocation
-            ? RELATIVE_LOCATION_LABELS[housing.ownerRelativeLocation]
-            : null
-        };
-      })
-    )
-    .pipeTo(
-      excelUtils.createWorksheet(workbook, {
-        name: 'Logements',
-        alternateColumnColors: true,
-        columns: [
-          { header: 'Identifiant fiscal national', key: 'localId' },
-          { header: 'Identifiant fiscal départemental', key: 'invariant' },
-          { header: 'Référence cadastrale', key: 'plotId' },
-          { header: 'Code INSEE commune du logement', key: 'geoCode' },
-          { header: 'Adresse LOVAC du logement', key: 'housingRawAddress' },
-          { header: 'Précisions adresse du logement', key: 'buildingLocation' },
-          { header: 'Adresse BAN du logement', key: 'housingAddress' },
-          {
-            header: 'Adresse BAN du logement - Fiabilité',
-            key: 'housingAddressScore'
-          },
-          { header: 'Latitude', key: 'latitude' },
-          { header: 'Longitude', key: 'longitude' },
-          { header: 'Type de logement', key: 'housingKind' },
-          { header: 'DPE représentatif', key: 'energyConsumption' },
-          { header: 'Date DPE', key: 'energyConsumptionAt' },
-          { header: 'Surface (m²)', key: 'livingArea' },
-          { header: 'Nombre de pièces', key: 'roomsCount' },
-          { header: 'Année de construction', key: 'buildingYear' },
-          { header: 'Occupation', key: 'occupancy' },
-          { header: 'Année de début de vacance', key: 'vacancyStartYear' },
-          { header: 'Statut', key: 'status' },
-          { header: 'Sous-statut', key: 'subStatus' },
-          { header: 'Points de blocage', key: 'blockingPoints' },
-          { header: 'Évolutions du logement', key: 'evolutions' },
-          { header: 'Dispositifs', key: 'mechanisms' },
-          { header: 'Campagnes', key: 'campaigns' },
-          ...GROUP_OWNER_WORKSHEET_COLUMNS
-        ]
-      })
-    );
+  return createHousingWorksheetBase(options, {
+    addressScoreHeader: 'Adresse BAN du logement - Fiabilité',
+    formatAddressScore: (score) => score,
+    ownerColumns: GROUP_OWNER_WORKSHEET_COLUMNS,
+    toOwnerRow: (housing) => ({
+      ownerName: housing.owner?.fullName,
+      ownerBirthDate: housing.owner?.birthDate,
+      ownerRelativeLocation: housing.ownerRelativeLocation
+        ? RELATIVE_LOCATION_LABELS[housing.ownerRelativeLocation]
+        : null
+    })
+  });
 }
 
 const housingExportController = {

--- a/server/src/models/HousingApi.ts
+++ b/server/src/models/HousingApi.ts
@@ -8,7 +8,8 @@ import {
   toOccupancy,
   type DatafoncierHousing,
   type HousingSource,
-  type OwnershipKindInternal
+  type OwnershipKindInternal,
+  type RelativeLocation
 } from '@zerologementvacant/models';
 import { Array, Equivalence, Order, pipe } from 'effect';
 import type { Point } from 'geojson';
@@ -40,6 +41,10 @@ export interface HousingApi extends HousingRecordApi {
    * Added by joining with the `housing_precisions` and `precisions` tables
    */
   precisions?: Precision[];
+  /**
+   * Added by joining with the `housing_owners` table (rank 1 owner).
+   */
+  ownerRelativeLocation?: RelativeLocation | null;
 }
 
 export function toHousingDTO(housing: HousingApi): HousingDTO {

--- a/server/src/models/HousingApi.ts
+++ b/server/src/models/HousingApi.ts
@@ -33,6 +33,10 @@ export interface HousingApi extends HousingRecordApi {
   localityKind?: string | null;
   geoPerimeters?: string[] | null;
   owner?: OwnerApi | null;
+  /**
+   * Added by joining with the `housing_owners` table (rank 1 owner).
+   */
+  ownerRelativeLocation?: RelativeLocation | null;
   buildingHousingCount?: number | null;
   buildingVacancyRate?: number | null;
   campaignIds?: string[] | null;
@@ -41,10 +45,6 @@ export interface HousingApi extends HousingRecordApi {
    * Added by joining with the `housing_precisions` and `precisions` tables
    */
   precisions?: Precision[];
-  /**
-   * Added by joining with the `housing_owners` table (rank 1 owner).
-   */
-  ownerRelativeLocation?: RelativeLocation | null;
 }
 
 export function toHousingDTO(housing: HousingApi): HousingDTO {

--- a/server/src/repositories/housingRepository.ts
+++ b/server/src/repositories/housingRepository.ts
@@ -57,6 +57,7 @@ import establishmentRepository from './establishmentRepository';
 import { geoPerimetersTable } from './geoRepository';
 import { GROUPS_HOUSING_TABLE } from './groupRepository';
 import {
+  fromRelativeLocationDBO,
   housingOwnersTable,
   relativeLocationFilterToDBO
 } from './housingOwnerRepository';
@@ -303,6 +304,7 @@ function include(includes: HousingInclude[], filters?: HousingFiltersApi) {
         )
         .select(`${ownerTable}.id as owner_id`)
         .select(db.raw(`to_json(${ownerTable}.*) AS owner`))
+        .select(`${housingOwnersTable}.locprop_relative_ban`)
         .leftJoin({ ban: banAddressesTable }, (join) => {
           join
             .on(`${ownerTable}.id`, 'ban.ref_id')
@@ -1276,6 +1278,7 @@ export interface HousingDBO extends HousingRecordDBO {
   campaign_ids?: string[];
   contact_count?: number;
   precisions?: Precision[];
+  locprop_relative_ban?: number | null;
   // TODO: fix and fill this type
 }
 
@@ -1385,6 +1388,9 @@ export const parseHousingApi = (housing: HousingDBO): HousingApi => ({
         ban: housing.owner_ban_address
       })
     : null,
+  ownerRelativeLocation: fromRelativeLocationDBO(
+    housing.locprop_relative_ban ?? null
+  ),
   campaignIds: (housing.campaign_ids ?? []).filter((_: any) => _),
   contactCount: Number(housing.contact_count),
   source: housing.data_source,

--- a/server/src/repositories/housingRepository.ts
+++ b/server/src/repositories/housingRepository.ts
@@ -57,6 +57,7 @@ import establishmentRepository from './establishmentRepository';
 import { geoPerimetersTable } from './geoRepository';
 import { GROUPS_HOUSING_TABLE } from './groupRepository';
 import {
+  fromRelativeLocationDBO,
   housingOwnersTable,
   relativeLocationFilterToDBO
 } from './housingOwnerRepository';
@@ -334,6 +335,7 @@ function include(includes: HousingInclude[], filters?: HousingFiltersApi) {
         )
         .select(`${ownerTable}.id as owner_id`)
         .select(db.raw(`to_json(${ownerTable}.*) AS owner`))
+        .select(`${housingOwnersTable}.locprop_relative_ban`)
         .leftJoin({ ban: banAddressesTable }, (join) => {
           join
             .on(`${ownerTable}.id`, 'ban.ref_id')
@@ -1311,6 +1313,7 @@ export interface HousingDBO extends HousingRecordDBO {
   campaign_ids?: string[];
   contact_count?: number;
   precisions?: Precision[];
+  locprop_relative_ban?: number | null;
   // TODO: fix and fill this type
 }
 
@@ -1420,6 +1423,9 @@ export const parseHousingApi = (housing: HousingDBO): HousingApi => ({
         ban: housing.owner_ban_address
       })
     : null,
+  ownerRelativeLocation: fromRelativeLocationDBO(
+    housing.locprop_relative_ban ?? null
+  ),
   campaignIds: (housing.campaign_ids ?? []).filter((_: any) => _),
   contactCount: Number(housing.contact_count),
   source: housing.data_source,

--- a/server/src/utils/excelUtils.ts
+++ b/server/src/utils/excelUtils.ts
@@ -64,9 +64,48 @@ function setResponseHeaders(
   response.setHeader('Content-Disposition', 'attachment; filename=' + file);
 }
 
+const GREY_FILL: excel.Fill = {
+  type: 'pattern',
+  pattern: 'solid',
+  fgColor: { argb: 'FFF2F2F2' }
+};
+
+const DEFAULT_COLUMN_WIDTH = 22;
+
 export interface WorksheetOptions<A extends Record<string, unknown>> {
   name: string;
   columns: Array<Partial<excel.Column> & { key: keyof A }>;
+  /**
+   * When true, applies alternating white/grey fill on columns for readability.
+   * Also sets a default column width for better readability.
+   */
+  alternateColumnColors?: boolean;
+}
+
+/**
+ * Apply alternating grey fill on even-indexed columns (1-based: 2, 4, 6...).
+ */
+function applyAlternateColumnFill(
+  row: excel.Row,
+  columnCount: number
+): void {
+  for (let i = 1; i <= columnCount; i++) {
+    if (i % 2 === 0) {
+      row.getCell(i).fill = GREY_FILL;
+    }
+  }
+}
+
+/**
+ * Enhance column definitions with default widths.
+ */
+function withDefaultWidths<A extends Record<string, unknown>>(
+  columns: WorksheetOptions<A>['columns']
+): WorksheetOptions<A>['columns'] {
+  return columns.map((col) => ({
+    ...col,
+    width: col.width ?? DEFAULT_COLUMN_WIDTH
+  }));
 }
 
 /**
@@ -83,16 +122,29 @@ function createWorksheet<A extends Record<string, unknown>>(
   workbook: Workbook,
   options: WorksheetOptions<A>
 ) {
-  const { columns, name } = options;
+  const { name, alternateColumnColors } = options;
+  const columns = alternateColumnColors
+    ? withDefaultWidths(options.columns)
+    : options.columns;
+  const columnCount = columns.length;
 
   return new WritableStream<A>({
     start() {
       const worksheet = workbook.addWorksheet(name);
       worksheet.columns = columns;
+      if (alternateColumnColors) {
+        applyAlternateColumnFill(worksheet.getRow(1), columnCount);
+      }
     },
     write(chunk) {
       logger.debug('Processing chunk...', chunk);
-      workbook.getWorksheet(name)?.addRow(chunk)?.commit();
+      const row = workbook.getWorksheet(name)?.addRow(chunk);
+      if (row) {
+        if (alternateColumnColors) {
+          applyAlternateColumnFill(row, columnCount);
+        }
+        row.commit();
+      }
       logger.debug('Wrote row', chunk);
     },
     close() {

--- a/server/src/utils/excelUtils.ts
+++ b/server/src/utils/excelUtils.ts
@@ -83,28 +83,16 @@ export interface WorksheetOptions<A extends Record<string, unknown>> {
 }
 
 /**
- * Apply alternating grey fill on even-indexed columns (1-based: 2, 4, 6...).
+ * Enhance column definitions with default widths and optional alternating grey fill.
  */
-function applyAlternateColumnFill(
-  row: excel.Row,
-  columnCount: number
-): void {
-  for (let i = 1; i <= columnCount; i++) {
-    if (i % 2 === 0) {
-      row.getCell(i).fill = GREY_FILL;
-    }
-  }
-}
-
-/**
- * Enhance column definitions with default widths.
- */
-function withDefaultWidths<A extends Record<string, unknown>>(
-  columns: WorksheetOptions<A>['columns']
+function withColumnOptions<A extends Record<string, unknown>>(
+  columns: WorksheetOptions<A>['columns'],
+  alternateColumnColors: boolean
 ): WorksheetOptions<A>['columns'] {
-  return columns.map((col) => ({
+  return columns.map((col, i) => ({
     ...col,
-    width: col.width ?? DEFAULT_COLUMN_WIDTH
+    width: col.width ?? DEFAULT_COLUMN_WIDTH,
+    style: alternateColumnColors && i % 2 !== 0 ? { fill: GREY_FILL } : undefined
   }));
 }
 
@@ -123,26 +111,17 @@ function createWorksheet<A extends Record<string, unknown>>(
   options: WorksheetOptions<A>
 ) {
   const { name, alternateColumnColors } = options;
-  const columns = alternateColumnColors
-    ? withDefaultWidths(options.columns)
-    : options.columns;
-  const columnCount = columns.length;
+  const columns = withColumnOptions(options.columns, alternateColumnColors ?? false);
 
   return new WritableStream<A>({
     start() {
       const worksheet = workbook.addWorksheet(name);
       worksheet.columns = columns;
-      if (alternateColumnColors) {
-        applyAlternateColumnFill(worksheet.getRow(1), columnCount);
-      }
     },
     write(chunk) {
       logger.debug('Processing chunk...', chunk);
       const row = workbook.getWorksheet(name)?.addRow(chunk);
       if (row) {
-        if (alternateColumnColors) {
-          applyAlternateColumnFill(row, columnCount);
-        }
         row.commit();
       }
       logger.debug('Wrote row', chunk);


### PR DESCRIPTION
## Résumé

Différenciation de l'export XLSX entre **groupes** et **campagnes**, harmonisation des intitulés de colonnes, et formatage de la fiabilité d'adresse.

### 1. Export groupe — colonnes différenciées

- **Inversion** des colonnes « Identifiant fiscal national » et « Identifiant fiscal départemental »
- **Réordonnancement** : Point(s) de blocage → Évolution(s) → Dispositif(s)
- **Suppression** des colonnes d'adresse du propriétaire (LOVAC, BAN, Fiabilité, Numéro, Voie, Code postal, Commune, Complément)
- **Renommage** : « Propriétaire » → « Propriétaire destinataire principal »
- **Nouvelle colonne** : « Localisation du propriétaire destinataire principal » (ex : « Habite dans le même département »)
- **Style** : largeur de colonnes par défaut (22 caractères) + alternance blanc/gris

### 2. Renommage des intitulés de colonnes (groupe + campagne)

| Ancien intitulé | Nouvel intitulé |
|---|---|
| Localisation | Précisions adresse du logement |
| Surface | Surface (m²) |
| Date de construction | Année de construction |
| Date de début de vacance | Année de début de vacance |
| Évolution(s) | Évolutions du logement |
| Dispositif(s) | Dispositifs |
| Point(s) de blocage | Points de blocage |
| Campagne(s) | Campagnes |

### 3. Modification campagne uniquement

- **Renommage** : « Adresse BAN du logement - Fiabilité » → « Fiabilité Adresse BAN du logement (%) »
- **Formatage** : la fiabilité est désormais affichée en pourcentage (ex : `0.788` → `78.8 %`)

### Détail technique

| Fichier | Modification |
|---------|-------------|
| `packages/models/src/RelativeLocation.ts` | Déplacement de `RELATIVE_LOCATION_LABELS` depuis le frontend vers le package partagé |
| `frontend/src/models/HousingOwner.tsx` | Réexport depuis `@zerologementvacant/models` |
| `server/src/models/HousingApi.ts` | Ajout du champ `ownerRelativeLocation` sur `HousingApi` |
| `server/src/repositories/housingRepository.ts` | Sélection de `locprop_relative_ban` dans la jointure propriétaire |
| `server/src/controllers/housingExportController.ts` | Nouvelle fonction `createGroupHousingWorksheet`, renommage des headers, formatage fiabilité |
| `server/src/utils/excelUtils.ts` | Option `alternateColumnColors` + largeur par défaut des colonnes |

## Plan de test

- [ ] Exporter depuis un **groupe** → vérifier colonnes réordonnées, adresses propriétaire absentes, renommage, colonne « Localisation du propriétaire destinataire principal »
- [ ] Exporter depuis une **campagne** → vérifier les renommages communs + fiabilité en pourcentage + colonnes d'adresse propriétaire toujours présentes
- [ ] Ouvrir les fichiers dans Excel/Numbers/Google Sheets et vérifier les largeurs de colonnes

🤖 Generated with [Claude Code](https://claude.com/claude-code)