### PR TITLE
test(models): improve test coverage for shared DTOs

### DIFF
--- a/packages/models/src/test/CampaignDTO.test.ts
+++ b/packages/models/src/test/CampaignDTO.test.ts
@@ -1,8 +1,47 @@
 import { Comparison } from '@zerologementvacant/utils';
-import { byStatus, CampaignDTO, CampaignStatus } from '../CampaignDTO';
+import {
+  byCreatedAt,
+  byHousingCount,
+  byOwnerCount,
+  byReturnCount,
+  byReturnRate,
+  bySentAt,
+  byStatus,
+  byTitle,
+  CAMPAIGN_STATUS_VALUES,
+  CampaignDTO,
+  CampaignStatus,
+  isCampaignStatus,
+  nextStatus
+} from '../CampaignDTO';
 import { genCampaignDTO } from './fixtures';
 
 describe('CampaignDTO', () => {
+  describe('nextStatus', () => {
+    it.each`
+      current          | expected
+      ${'draft'}       | ${'sending'}
+      ${'sending'}     | ${'in-progress'}
+      ${'in-progress'} | ${'archived'}
+      ${'archived'}    | ${null}
+    `('$current → $expected', ({ current, expected }) => {
+      expect(nextStatus(current)).toBe(expected);
+    });
+  });
+
+  describe('isCampaignStatus', () => {
+    it.each(CAMPAIGN_STATUS_VALUES)('returns true for valid status "%s"', (status) => {
+      expect(isCampaignStatus(status)).toBe(true);
+    });
+
+    it.each(['unknown', '', 'DRAFT', 123, null, undefined])(
+      'returns false for invalid value %j',
+      (value) => {
+        expect(isCampaignStatus(value)).toBe(false);
+      }
+    );
+  });
+
   describe('compare', () => {
     function generateCampaign(status: CampaignStatus): CampaignDTO {
       return { ...genCampaignDTO(), status };
@@ -23,5 +62,103 @@ describe('CampaignDTO', () => {
         expect(actual).toBe(expected);
       }
     );
+  });
+
+  describe('byTitle', () => {
+    it('ranks alphabetically earlier title first', () => {
+      const a = { ...genCampaignDTO(), title: 'Alpha' };
+      const b = { ...genCampaignDTO(), title: 'Zeta' };
+      expect(byTitle(a, b)).toBe(Comparison.B_GT_A);
+      expect(byTitle(b, a)).toBe(Comparison.A_GT_B);
+    });
+
+    it('returns equal for same title', () => {
+      const a = { ...genCampaignDTO(), title: 'Same' };
+      const b = { ...genCampaignDTO(), title: 'Same' };
+      expect(byTitle(a, b)).toBe(Comparison.A_EQ_B);
+    });
+  });
+
+  describe('byCreatedAt', () => {
+    it('ranks earlier creation date first', () => {
+      const a = { ...genCampaignDTO(), createdAt: '2023-01-01T00:00:00.000Z' };
+      const b = { ...genCampaignDTO(), createdAt: '2024-01-01T00:00:00.000Z' };
+      expect(byCreatedAt(a, b)).toBe(Comparison.B_GT_A);
+      expect(byCreatedAt(b, a)).toBe(Comparison.A_GT_B);
+    });
+
+    it('returns equal for same creation date', () => {
+      const date = '2023-06-15T12:00:00.000Z';
+      const a = { ...genCampaignDTO(), createdAt: date };
+      const b = { ...genCampaignDTO(), createdAt: date };
+      expect(byCreatedAt(a, b)).toBe(Comparison.A_EQ_B);
+    });
+  });
+
+  describe('bySentAt', () => {
+    it('ranks earlier sent date first', () => {
+      const a = { ...genCampaignDTO(), sentAt: '2023-01-01T00:00:00.000Z' };
+      const b = { ...genCampaignDTO(), sentAt: '2024-01-01T00:00:00.000Z' };
+      expect(bySentAt(a, b)).toBe(Comparison.B_GT_A);
+      expect(bySentAt(b, a)).toBe(Comparison.A_GT_B);
+    });
+
+    it('treats null sentAt as empty string (sorts before any date)', () => {
+      const a = { ...genCampaignDTO(), sentAt: null };
+      const b = { ...genCampaignDTO(), sentAt: '2023-01-01T00:00:00.000Z' };
+      expect(bySentAt(a, b)).toBe(Comparison.B_GT_A);
+    });
+  });
+
+  describe('byHousingCount', () => {
+    it('ranks lower housing count first', () => {
+      const a = { ...genCampaignDTO(), housingCount: 10 };
+      const b = { ...genCampaignDTO(), housingCount: 20 };
+      expect(byHousingCount(a, b)).toBe(Comparison.B_GT_A);
+      expect(byHousingCount(b, a)).toBe(Comparison.A_GT_B);
+    });
+
+    it('returns equal for same housing count', () => {
+      const a = { ...genCampaignDTO(), housingCount: 15 };
+      const b = { ...genCampaignDTO(), housingCount: 15 };
+      expect(byHousingCount(a, b)).toBe(Comparison.A_EQ_B);
+    });
+  });
+
+  describe('byOwnerCount', () => {
+    it('ranks lower owner count first', () => {
+      const a = { ...genCampaignDTO(), ownerCount: 5 };
+      const b = { ...genCampaignDTO(), ownerCount: 10 };
+      expect(byOwnerCount(a, b)).toBe(Comparison.B_GT_A);
+      expect(byOwnerCount(b, a)).toBe(Comparison.A_GT_B);
+    });
+  });
+
+  describe('byReturnCount', () => {
+    it('ranks lower return count first', () => {
+      const a = { ...genCampaignDTO(), returnCount: 1 };
+      const b = { ...genCampaignDTO(), returnCount: 5 };
+      expect(byReturnCount(a, b)).toBe(Comparison.B_GT_A);
+    });
+
+    it('treats null returnCount as 0', () => {
+      const a = { ...genCampaignDTO(), returnCount: null };
+      const b = { ...genCampaignDTO(), returnCount: 0 };
+      expect(byReturnCount(a, b)).toBe(Comparison.A_EQ_B);
+    });
+  });
+
+  describe('byReturnRate', () => {
+    it('ranks lower return rate first', () => {
+      const a = { ...genCampaignDTO(), returnRate: 0.1 };
+      const b = { ...genCampaignDTO(), returnRate: 0.5 };
+      expect(byReturnRate(a, b)).toBe(Comparison.B_GT_A);
+    });
+
+    it('treats null returnRate as 0', () => {
+      const a = { ...genCampaignDTO(), returnRate: null };
+      const b = { ...genCampaignDTO(), returnRate: 0 };
+      expect(byReturnRate(a, b)).toBe(Comparison.A_EQ_B);
+    });
   });
 });

--- a/packages/models/src/test/EstablishmentKind.test.ts
+++ b/packages/models/src/test/EstablishmentKind.test.ts
@@ -1,0 +1,56 @@
+import { Comparison } from '@zerologementvacant/utils';
+import { byKind, byKindDesc, EstablishmentKind } from '../EstablishmentKind';
+
+describe('EstablishmentKind', () => {
+  describe('byKindDesc', () => {
+    it('ranks broader scope (REG) before narrower scope (COM)', () => {
+      expect(byKindDesc('REG', 'COM')).toBe(Comparison.B_GT_A);
+      expect(byKindDesc('COM', 'REG')).toBe(Comparison.A_GT_B);
+    });
+
+    it('returns equal for same kind', () => {
+      expect(byKindDesc('DEP', 'DEP')).toBe(Comparison.A_EQ_B);
+    });
+
+    it.each<[EstablishmentKind, EstablishmentKind]>([
+      ['REG', 'TOM'],
+      ['TOM', 'DEP'],
+      ['DEP', 'METRO'],
+      ['METRO', 'CU'],
+      ['CU', 'CA'],
+      ['CA', 'CC'],
+      ['CC', 'EPT'],
+      ['EPT', 'COM'],
+      ['COM', 'COM-TOM'],
+      ['COM-TOM', 'ARR']
+    ])('ranks %s before %s in descending order', (broader, narrower) => {
+      expect(byKindDesc(broader, narrower)).toBe(Comparison.B_GT_A);
+    });
+  });
+
+  describe('byKind', () => {
+    it('is the reverse of byKindDesc', () => {
+      expect(byKind('REG', 'COM')).toBe(Comparison.A_GT_B);
+      expect(byKind('COM', 'REG')).toBe(Comparison.B_GT_A);
+    });
+
+    it('returns equal for same kind', () => {
+      expect(byKind('DEP', 'DEP')).toBe(Comparison.A_EQ_B);
+    });
+
+    it.each<[EstablishmentKind, EstablishmentKind]>([
+      ['REG', 'TOM'],
+      ['TOM', 'DEP'],
+      ['DEP', 'METRO'],
+      ['METRO', 'CU'],
+      ['CU', 'CA'],
+      ['CA', 'CC'],
+      ['CC', 'EPT'],
+      ['EPT', 'COM'],
+      ['COM', 'COM-TOM'],
+      ['COM-TOM', 'ARR']
+    ])('ranks %s after %s (reversed)', (broader, narrower) => {
+      expect(byKind(broader, narrower)).toBe(Comparison.A_GT_B);
+    });
+  });
+});

--- a/packages/models/src/test/HousingDTO.test.ts
+++ b/packages/models/src/test/HousingDTO.test.ts
@@ -1,11 +1,25 @@
 import {
   diffHousingUpdatePayload,
+  hasPrimaryOwner,
   HousingUpdatePayloadDTO
 } from '../HousingDTO';
 import { HousingStatus } from '../HousingStatus';
 import { Occupancy } from '../Occupancy';
+import { genHousingDTO, genOwnerDTO } from './fixtures';
 
 describe('HousingDTO', () => {
+  describe('hasPrimaryOwner', () => {
+    it('returns false when owner is null', () => {
+      const housing = { ...genHousingDTO(), owner: null };
+      expect(hasPrimaryOwner(housing)).toBe(false);
+    });
+
+    it('returns true when owner is set', () => {
+      const housing = { ...genHousingDTO(), owner: genOwnerDTO() };
+      expect(hasPrimaryOwner(housing)).toBe(true);
+    });
+  });
+
   describe('diff', () => {
     it('should diff all changed properties', () => {
       const before: HousingUpdatePayloadDTO = {
@@ -76,6 +90,26 @@ describe('HousingDTO', () => {
           before: { occupancyIntended: null },
           after: { occupancyIntended: Occupancy.RENT },
           changed: ['occupancyIntended']
+        }
+      );
+    });
+
+    it('returns empty changed array when nothing changed', () => {
+      const payload: HousingUpdatePayloadDTO = {
+        status: HousingStatus.NEVER_CONTACTED,
+        subStatus: null,
+        occupancy: Occupancy.VACANT,
+        occupancyIntended: null,
+        actualEnergyConsumption: null
+      };
+
+      const actual = diffHousingUpdatePayload(payload, payload);
+
+      expect(actual).toStrictEqual<ReturnType<typeof diffHousingUpdatePayload>>(
+        {
+          before: {},
+          after: {},
+          changed: []
         }
       );
     });

--- a/packages/models/src/test/HousingOwnerDTO.test.ts
+++ b/packages/models/src/test/HousingOwnerDTO.test.ts
@@ -1,0 +1,94 @@
+import {
+  ACTIVE_OWNER_RANKS,
+  INACTIVE_OWNER_RANKS,
+  isActiveOwnerRank,
+  isAwaitingOwnerRank,
+  isDeceasedOwnerRank,
+  isInactiveOwnerRank,
+  isIncorrectOwnerRank,
+  isPreviousOwnerRank,
+  isPrimaryOwner,
+  isSecondaryOwner
+} from '../HousingOwnerDTO';
+
+describe('HousingOwnerDTO', () => {
+  describe('isActiveOwnerRank', () => {
+    it.each(ACTIVE_OWNER_RANKS)('returns true for active rank %i', (rank) => {
+      expect(isActiveOwnerRank(rank)).toBe(true);
+    });
+
+    it.each(INACTIVE_OWNER_RANKS)('returns false for inactive rank %i', (rank) => {
+      expect(isActiveOwnerRank(rank)).toBe(false);
+    });
+  });
+
+  describe('isPreviousOwnerRank', () => {
+    it('returns true for rank 0', () => {
+      expect(isPreviousOwnerRank(0)).toBe(true);
+    });
+
+    it.each([-3, -2, -1, 1, 2])('returns false for rank %i', (rank) => {
+      expect(isPreviousOwnerRank(rank)).toBe(false);
+    });
+  });
+
+  describe('isIncorrectOwnerRank', () => {
+    it('returns true for rank -1', () => {
+      expect(isIncorrectOwnerRank(-1)).toBe(true);
+    });
+
+    it.each([-3, -2, 0, 1, 2])('returns false for rank %i', (rank) => {
+      expect(isIncorrectOwnerRank(rank)).toBe(false);
+    });
+  });
+
+  describe('isAwaitingOwnerRank', () => {
+    it('returns true for rank -2', () => {
+      expect(isAwaitingOwnerRank(-2)).toBe(true);
+    });
+
+    it.each([-3, -1, 0, 1, 2])('returns false for rank %i', (rank) => {
+      expect(isAwaitingOwnerRank(rank)).toBe(false);
+    });
+  });
+
+  describe('isDeceasedOwnerRank', () => {
+    it('returns true for rank -3', () => {
+      expect(isDeceasedOwnerRank(-3)).toBe(true);
+    });
+
+    it.each([-2, -1, 0, 1, 2])('returns false for rank %i', (rank) => {
+      expect(isDeceasedOwnerRank(rank)).toBe(false);
+    });
+  });
+
+  describe('isInactiveOwnerRank', () => {
+    it.each([-3, -2, -1, 0])('returns true for inactive rank %i', (rank) => {
+      expect(isInactiveOwnerRank(rank)).toBe(true);
+    });
+
+    it.each(ACTIVE_OWNER_RANKS)('returns false for active rank %i', (rank) => {
+      expect(isInactiveOwnerRank(rank)).toBe(false);
+    });
+  });
+
+  describe('isPrimaryOwner', () => {
+    it('returns true when rank is 1', () => {
+      expect(isPrimaryOwner({ rank: 1 })).toBe(true);
+    });
+
+    it.each([-3, -2, -1, 0, 2, 3, 6])('returns false when rank is %i', (rank) => {
+      expect(isPrimaryOwner({ rank: rank as any })).toBe(false);
+    });
+  });
+
+  describe('isSecondaryOwner', () => {
+    it.each([2, 3, 4, 5, 6])('returns true when rank is %i', (rank) => {
+      expect(isSecondaryOwner({ rank: rank as any })).toBe(true);
+    });
+
+    it.each([-3, -2, -1, 0, 1])('returns false when rank is %i', (rank) => {
+      expect(isSecondaryOwner({ rank: rank as any })).toBe(false);
+    });
+  });
+});

--- a/packages/models/src/test/HousingStatus.test.ts
+++ b/packages/models/src/test/HousingStatus.test.ts
@@ -1,0 +1,37 @@
+import {
+  HOUSING_STATUS_IDS,
+  HousingStatus,
+  HOUSING_STATUS_VALUES,
+  isHousingStatus,
+  toHousingStatusId
+} from '../HousingStatus';
+
+describe('HousingStatus', () => {
+  describe('isHousingStatus', () => {
+    it.each(HOUSING_STATUS_VALUES)('returns true for valid status %i', (status) => {
+      expect(isHousingStatus(status)).toBe(true);
+    });
+
+    it.each([-1, 6, 7, 100])('returns false for out-of-range number %i', (value) => {
+      expect(isHousingStatus(value)).toBe(false);
+    });
+  });
+
+  describe('toHousingStatusId', () => {
+    it.each<[HousingStatus, string]>([
+      [HousingStatus.NEVER_CONTACTED, 'never-contacted'],
+      [HousingStatus.WAITING, 'waiting'],
+      [HousingStatus.FIRST_CONTACT, 'first-contact'],
+      [HousingStatus.IN_PROGRESS, 'in-progress'],
+      [HousingStatus.COMPLETED, 'completed'],
+      [HousingStatus.BLOCKED, 'blocked']
+    ])('maps HousingStatus.%s (%i) to "%s"', (status, expected) => {
+      expect(toHousingStatusId(status)).toBe(expected);
+    });
+
+    it('covers all status IDs', () => {
+      const mapped = HOUSING_STATUS_VALUES.map(toHousingStatusId);
+      expect(mapped).toEqual([...HOUSING_STATUS_IDS]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **CampaignDTO**: added tests for `nextStatus`, `isCampaignStatus`, and all 7 ordering functions (`byTitle`, `byCreatedAt`, `bySentAt`, `byHousingCount`, `byOwnerCount`, `byReturnCount`, `byReturnRate`)
- **HousingDTO**: added tests for `hasPrimaryOwner` and the no-change case in `diffHousingUpdatePayload`
- **HousingOwnerDTO**: new test file covering all rank predicates (`isActiveOwnerRank`, `isPreviousOwnerRank`, `isIncorrectOwnerRank`, `isAwaitingOwnerRank`, `isDeceasedOwnerRank`, `isInactiveOwnerRank`) and owner helpers (`isPrimaryOwner`, `isSecondaryOwner`)
- **EstablishmentKind**: new test file covering `byKind` and `byKindDesc` ordering across all 11 establishment kinds
- **HousingStatus**: new test file covering `isHousingStatus` and `toHousingStatusId`

Test count: 58 → 190 (+132 tests, 3 new files)

## Test plan

- [x] `yarn nx test models` — 190 tests, 12 test files, all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)