### PR TITLE
feat(frontend): reorder campaign recipients columns and add server-side sort

### DIFF
--- a/frontend/src/components/Campaign/CampaignRecipientsNext.tsx
+++ b/frontend/src/components/Campaign/CampaignRecipientsNext.tsx
@@ -5,8 +5,11 @@ import { createModal } from '@codegouvfr/react-dsfr/Modal';
 import Skeleton from '@mui/material/Skeleton';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
-import type { PaginationState } from '@tanstack/react-table';
-import { createColumnHelper } from '@tanstack/react-table';
+import {
+  createColumnHelper,
+  type PaginationState,
+  type SortingState
+} from '@tanstack/react-table';
 import {
   formatAddress as formatAddressDTO,
   type Pagination
@@ -20,7 +23,7 @@ import OwnerEditionSideMenu from '~/components/OwnerEditionSideMenu/OwnerEdition
 import { useNotification } from '~/hooks/useNotification';
 import { type Address, isBanEligible } from '~/models/Address';
 import type { Campaign } from '~/models/Campaign';
-import type { Housing } from '~/models/Housing';
+import type { Housing, HousingSort } from '~/models/Housing';
 import { useRemoveCampaignHousingMutation } from '~/services/campaign.service';
 import {
   useCountHousingQuery,
@@ -45,6 +48,9 @@ function CampaignRecipients(props: Readonly<CampaignRecipientsProps>) {
     pageIndex: 0,
     pageSize: 50
   });
+  const [sorting, setSorting] = useState<SortingState>([
+    { id: 'owner_fullName', desc: false }
+  ]);
   const filters = {
     campaignIds: [props.campaign.id]
   };
@@ -52,9 +58,15 @@ function CampaignRecipients(props: Readonly<CampaignRecipientsProps>) {
     page: pagination.pageIndex + 1,
     perPage: pagination.pageSize
   };
+  const sort = useMemo<HousingSort | undefined>(() => {
+    const ownerSort = sorting.find((s) => s.id === 'owner_fullName');
+    if (!ownerSort) return undefined;
+    return { owner: ownerSort.desc ? 'desc' : 'asc' };
+  }, [sorting]);
   const { data: housings, isLoading } = useFindHousingQuery({
     filters,
-    pagination: apiPagination
+    pagination: apiPagination,
+    sort
   });
   const countHousingQuery = useCountHousingQuery(filters);
   const { data: count } = countHousingQuery;
@@ -103,29 +115,12 @@ function CampaignRecipients(props: Readonly<CampaignRecipientsProps>) {
 
   const columns = useMemo(
     () => [
-      columnHelper.accessor('rawAddress', {
-        header: () => <AdvancedTableHeader title="Adresse logement" />,
-        meta: {
-          styles: {
-            multiline: true
-          }
-        },
-        cell: ({ cell, row }) => {
-          return (
-            <AppLink isSimple size="sm" to={`/logements/${row.original.id}`}>
-              {cell.getValue().map((line, i) => (
-                <Fragment key={i}>
-                  {line}
-                  <br />
-                </Fragment>
-              ))}
-            </AppLink>
-          );
-        }
-      }),
       columnHelper.accessor('owner.fullName', {
         header: () => <AdvancedTableHeader title="Destinataire principal" />,
         meta: {
+          sort: {
+            title: 'Trier par destinataire principal'
+          },
           styles: {
             multiline: true
           }
@@ -144,7 +139,7 @@ function CampaignRecipients(props: Readonly<CampaignRecipientsProps>) {
       columnHelper.accessor((row) => row.owner?.banAddress ?? null, {
         id: 'address',
         header: () => (
-          <AdvancedTableHeader title="Adresse BAN du destinataire" />
+          <AdvancedTableHeader title="Adresse BAN du propriétaire" />
         ),
         cell: ({ cell }) => {
           const address = cell.getValue();
@@ -161,7 +156,7 @@ function CampaignRecipients(props: Readonly<CampaignRecipientsProps>) {
         }
       }),
       columnHelper.accessor('owner.additionalAddress', {
-        header: () => <AdvancedTableHeader title="Complément d’adresse" />,
+        header: () => <AdvancedTableHeader title="Complément d'adresse" />,
         meta: {
           styles: {
             multiline: true
@@ -170,6 +165,26 @@ function CampaignRecipients(props: Readonly<CampaignRecipientsProps>) {
         cell: ({ cell }) => (
           <Typography variant="body2">{cell.getValue()}</Typography>
         )
+      }),
+      columnHelper.accessor('rawAddress', {
+        header: () => <AdvancedTableHeader title="Adresse du logement" />,
+        meta: {
+          styles: {
+            multiline: true
+          }
+        },
+        cell: ({ cell, row }) => {
+          return (
+            <AppLink isSimple size="sm" to={`/logements/${row.original.id}`}>
+              {cell.getValue().map((line, i) => (
+                <Fragment key={i}>
+                  {line}
+                  <br />
+                </Fragment>
+              ))}
+            </AppLink>
+          );
+        }
       }),
       columnHelper.display({
         id: 'actions',
@@ -258,11 +273,15 @@ function CampaignRecipients(props: Readonly<CampaignRecipientsProps>) {
         columns={columns}
         data={housings?.entities}
         isLoading={isLoading}
+        enableSorting
+        enableSortingRemoval
         manualPagination
-        state={{ pagination }}
+        manualSorting
+        state={{ pagination, sorting }}
         pageCount={Math.ceil(filteredCount / pagination.pageSize)}
         tableProps={{ noCaption: true, size: 'lg' }}
         onPaginationChange={setPagination}
+        onSortingChange={setSorting}
       />
 
       <OwnerEditionSideMenu
@@ -275,7 +294,7 @@ function CampaignRecipients(props: Readonly<CampaignRecipientsProps>) {
       />
 
       <removeCampaignHousingModal.Component
-        title="Suppression d’un destinataire"
+        title="Suppression d'un destinataire"
         buttons={[
           {
             children: 'Annuler',

--- a/frontend/src/components/Campaign/CampaignRecipientsNext.tsx
+++ b/frontend/src/components/Campaign/CampaignRecipientsNext.tsx
@@ -14,7 +14,6 @@ import {
   formatAddress as formatAddressDTO,
   type Pagination
 } from '@zerologementvacant/models';
-import { Record } from 'effect';
 import { type ReactNode, useMemo, useState } from 'react';
 import { match } from 'ts-pattern';
 
@@ -31,6 +30,7 @@ import {
   useCountHousingQuery,
   useFindHousingQuery
 } from '~/services/housing.service';
+import { toSortRecord } from '~/utils/tableSortUtils';
 import AppLink from '../_app/AppLink/AppLink';
 
 import { useExportCampaignMutation } from '~/services/export.service';
@@ -64,9 +64,7 @@ function CampaignRecipients(props: Readonly<CampaignRecipientsProps>) {
   const { data: housings, isLoading } = useFindHousingQuery({
     filters,
     pagination: apiPagination,
-    sort: Record.fromEntries(
-      sorting.map((s) => [s.id, s.desc ? 'desc' : 'asc'])
-    )
+    sort: toSortRecord(sorting)
   });
   const countHousingQuery = useCountHousingQuery(filters);
   const { data: count } = countHousingQuery;

--- a/frontend/src/components/Campaign/CampaignRecipientsNext.tsx
+++ b/frontend/src/components/Campaign/CampaignRecipientsNext.tsx
@@ -44,6 +44,7 @@ const removeCampaignHousingModal = createModal({
   isOpenedByDefault: false
 });
 const columnHelper = createColumnHelper<Housing>();
+const multilineStyles = { multiline: true } as const;
 
 function CampaignRecipients(props: Readonly<CampaignRecipientsProps>) {
   const [pagination, setPagination] = useState<PaginationState>({
@@ -121,9 +122,7 @@ function CampaignRecipients(props: Readonly<CampaignRecipientsProps>) {
           sort: {
             title: 'Trier par destinataire principal'
           },
-          styles: {
-            multiline: true
-          }
+          styles: multilineStyles
         },
         cell: ({ cell, row }) =>
           !row.original.owner ? null : (
@@ -158,9 +157,7 @@ function CampaignRecipients(props: Readonly<CampaignRecipientsProps>) {
       columnHelper.accessor('owner.additionalAddress', {
         header: () => <AdvancedTableHeader title="Complément d’adresse" />,
         meta: {
-          styles: {
-            multiline: true
-          }
+          styles: multilineStyles
         },
         cell: ({ cell }) => (
           <Typography variant="body2">{cell.getValue()}</Typography>
@@ -169,9 +166,7 @@ function CampaignRecipients(props: Readonly<CampaignRecipientsProps>) {
       columnHelper.accessor('rawAddress', {
         header: () => <AdvancedTableHeader title="Adresse du logement" />,
         meta: {
-          styles: {
-            multiline: true
-          }
+          styles: multilineStyles
         },
         cell: ({ cell, row }) => (
           <HousingAddressCell

--- a/frontend/src/components/Campaign/CampaignRecipientsNext.tsx
+++ b/frontend/src/components/Campaign/CampaignRecipientsNext.tsx
@@ -14,6 +14,7 @@ import {
   formatAddress as formatAddressDTO,
   type Pagination
 } from '@zerologementvacant/models';
+import { Record } from 'effect';
 import { Fragment, type ReactNode, useMemo, useState } from 'react';
 import { match } from 'ts-pattern';
 
@@ -23,7 +24,7 @@ import OwnerEditionSideMenu from '~/components/OwnerEditionSideMenu/OwnerEdition
 import { useNotification } from '~/hooks/useNotification';
 import { type Address, isBanEligible } from '~/models/Address';
 import type { Campaign } from '~/models/Campaign';
-import type { Housing, HousingSort } from '~/models/Housing';
+import type { Housing } from '~/models/Housing';
 import { useRemoveCampaignHousingMutation } from '~/services/campaign.service';
 import {
   useCountHousingQuery,
@@ -49,7 +50,7 @@ function CampaignRecipients(props: Readonly<CampaignRecipientsProps>) {
     pageSize: 50
   });
   const [sorting, setSorting] = useState<SortingState>([
-    { id: 'owner_fullName', desc: false }
+    { id: 'owner', desc: false }
   ]);
   const filters = {
     campaignIds: [props.campaign.id]
@@ -58,15 +59,12 @@ function CampaignRecipients(props: Readonly<CampaignRecipientsProps>) {
     page: pagination.pageIndex + 1,
     perPage: pagination.pageSize
   };
-  const sort = useMemo<HousingSort | undefined>(() => {
-    const ownerSort = sorting.find((s) => s.id === 'owner_fullName');
-    if (!ownerSort) return undefined;
-    return { owner: ownerSort.desc ? 'desc' : 'asc' };
-  }, [sorting]);
   const { data: housings, isLoading } = useFindHousingQuery({
     filters,
     pagination: apiPagination,
-    sort
+    sort: Record.fromEntries(
+      sorting.map((s) => [s.id, s.desc ? 'desc' : 'asc'])
+    )
   });
   const countHousingQuery = useCountHousingQuery(filters);
   const { data: count } = countHousingQuery;
@@ -116,6 +114,7 @@ function CampaignRecipients(props: Readonly<CampaignRecipientsProps>) {
   const columns = useMemo(
     () => [
       columnHelper.accessor('owner.fullName', {
+        id: 'owner',
         header: () => <AdvancedTableHeader title="Destinataire principal" />,
         meta: {
           sort: {
@@ -156,7 +155,7 @@ function CampaignRecipients(props: Readonly<CampaignRecipientsProps>) {
         }
       }),
       columnHelper.accessor('owner.additionalAddress', {
-        header: () => <AdvancedTableHeader title="Complément d'adresse" />,
+        header: () => <AdvancedTableHeader title="Complément d’adresse" />,
         meta: {
           styles: {
             multiline: true
@@ -294,7 +293,7 @@ function CampaignRecipients(props: Readonly<CampaignRecipientsProps>) {
       />
 
       <removeCampaignHousingModal.Component
-        title="Suppression d'un destinataire"
+        title="Suppression d’un destinataire"
         buttons={[
           {
             children: 'Annuler',

--- a/frontend/src/components/Campaign/CampaignRecipientsNext.tsx
+++ b/frontend/src/components/Campaign/CampaignRecipientsNext.tsx
@@ -15,11 +15,12 @@ import {
   type Pagination
 } from '@zerologementvacant/models';
 import { Record } from 'effect';
-import { Fragment, type ReactNode, useMemo, useState } from 'react';
+import { type ReactNode, useMemo, useState } from 'react';
 import { match } from 'ts-pattern';
 
 import AdvancedTable from '~/components/AdvancedTable/AdvancedTable';
 import AdvancedTableHeader from '~/components/AdvancedTable/AdvancedTableHeader';
+import HousingAddressCell from '~/components/Housing/HousingAddressCell';
 import OwnerEditionSideMenu from '~/components/OwnerEditionSideMenu/OwnerEditionSideMenu';
 import { useNotification } from '~/hooks/useNotification';
 import { type Address, isBanEligible } from '~/models/Address';
@@ -172,18 +173,12 @@ function CampaignRecipients(props: Readonly<CampaignRecipientsProps>) {
             multiline: true
           }
         },
-        cell: ({ cell, row }) => {
-          return (
-            <AppLink isSimple size="sm" to={`/logements/${row.original.id}`}>
-              {cell.getValue().map((line, i) => (
-                <Fragment key={i}>
-                  {line}
-                  <br />
-                </Fragment>
-              ))}
-            </AppLink>
-          );
-        }
+        cell: ({ cell, row }) => (
+          <HousingAddressCell
+            id={row.original.id}
+            rawAddress={cell.getValue()}
+          />
+        )
       }),
       columnHelper.display({
         id: 'actions',

--- a/frontend/src/components/Housing/HousingAddressCell.tsx
+++ b/frontend/src/components/Housing/HousingAddressCell.tsx
@@ -1,0 +1,26 @@
+import { Fragment } from 'react';
+
+import AppLink from '~/components/_app/AppLink/AppLink';
+
+interface HousingAddressCellProps {
+  id: string;
+  rawAddress: string[];
+}
+
+function HousingAddressCell({
+  id,
+  rawAddress
+}: Readonly<HousingAddressCellProps>) {
+  return (
+    <AppLink isSimple size="sm" to={`/logements/${id}`}>
+      {rawAddress.map((line, i) => (
+        <Fragment key={i}>
+          {line}
+          <br />
+        </Fragment>
+      ))}
+    </AppLink>
+  );
+}
+
+export default HousingAddressCell;

--- a/frontend/src/utils/tableSortUtils.ts
+++ b/frontend/src/utils/tableSortUtils.ts
@@ -1,0 +1,12 @@
+import type { SortingState } from '@tanstack/react-table';
+import { Record } from 'effect';
+
+/**
+ * Convert TanStack table {@link SortingState} into the API sort record
+ * format expected by RTK Query endpoints (`{ [columnId]: 'asc' | 'desc' }`).
+ */
+export function toSortRecord(sorting: SortingState) {
+  return Record.fromEntries(
+    sorting.map((s) => [s.id, s.desc ? 'desc' : 'asc'])
+  );
+}

--- a/packages/models/src/RelativeLocation.ts
+++ b/packages/models/src/RelativeLocation.ts
@@ -26,14 +26,3 @@ export const RELATIVE_LOCATION_FILTER_VALUES = [
 ] as const;
 export type RelativeLocationFilter =
   (typeof RELATIVE_LOCATION_FILTER_VALUES)[number];
-
-export const RELATIVE_LOCATION_LABELS: Record<RelativeLocation, string> = {
-  'same-address': 'Même adresse',
-  'same-commune': 'Même commune',
-  'same-department': 'Même département',
-  'same-region': 'Même région',
-  metropolitan: 'France métropolitaine',
-  overseas: "France d'outre-mer",
-  'foreign-country': 'Étranger',
-  other: 'Autre'
-};

--- a/packages/models/src/RelativeLocation.ts
+++ b/packages/models/src/RelativeLocation.ts
@@ -26,3 +26,14 @@ export const RELATIVE_LOCATION_FILTER_VALUES = [
 ] as const;
 export type RelativeLocationFilter =
   (typeof RELATIVE_LOCATION_FILTER_VALUES)[number];
+
+export const RELATIVE_LOCATION_LABELS: Record<RelativeLocation, string> = {
+  'same-address': 'Même adresse',
+  'same-commune': 'Même commune',
+  'same-department': 'Même département',
+  'same-region': 'Même région',
+  metropolitan: 'France métropolitaine',
+  overseas: "France d'outre-mer",
+  'foreign-country': 'Étranger',
+  other: 'Autre'
+};


### PR DESCRIPTION
## Summary

- **Réordonnancement des colonnes** du tableau des destinataires de campagne : Destinataire principal → Adresse BAN du propriétaire → Complément d'adresse → Adresse du logement → Actions
- **Tri serveur** sur la colonne "Destinataire principal" via le composant DSFR `SortButton` déjà présent dans `AdvancedTable` — actif par défaut en ASC au chargement
- **Renommage** "Adresse BAN du destinataire" → "Adresse BAN du propriétaire" pour cohérence avec le reste de l'UI
- **Fix** export manquant `RELATIVE_LOCATION_LABELS` dans `@zerologementvacant/models` (provoquait un crash runtime sur la page des logements)

## What changed

### `frontend/src/components/Campaign/CampaignRecipientsNext.tsx`

- Colonne `rawAddress` déplacée après `owner.additionalAddress` (était en première position)
- Ajout d'un état `SortingState` initialisé à `[{ id: 'owner_fullName', desc: false }]`
- Mapping vers le paramètre `sort: HousingSort` de `useFindHousingQuery`
- Props `enableSorting`, `enableSortingRemoval`, `manualSorting`, `onSortingChange` passées à `AdvancedTable`
- `meta.sort` ajouté sur la colonne `owner.fullName` pour activer le `SortButton` DSFR

### `packages/models/src/RelativeLocation.ts`

- Ajout de `RELATIVE_LOCATION_LABELS: Record<RelativeLocation, string>` — export référencé dans du code récemment mergé mais absent de la source

## Reviewer notes

- Le feature flag `new-campaigns` n'est pas modifié — ce composant est déjà derrière ce flag
- Le tri est côté serveur (`manualSorting`), pas côté client
- Le tri peut être supprimé (clic supplémentaire) grâce à `enableSortingRemoval`