### PR TITLE
feat(campaign): make description optional and simplify creation modal

### DIFF
--- a/frontend/src/components/Group/CreateCampaignFromGroupModal.tsx
+++ b/frontend/src/components/Group/CreateCampaignFromGroupModal.tsx
@@ -1,5 +1,5 @@
-import Alert from '@codegouvfr/react-dsfr/Alert';
 import { yupResolver } from '@hookform/resolvers/yup';
+import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import { useForm, type SubmitHandler } from 'react-hook-form';
@@ -31,7 +31,7 @@ export type CreateCampaignFromGroupModalProps = Omit<
 
 const schema = object({
   title: string().trim().required('Veuillez renseigner un nom'),
-  description: string().trim().required('Veuillez renseigner une description'),
+  description: string().trim().optional().default(''),
   sentAt: schemas.dateString.optional().nullable().default(null)
 });
 
@@ -79,7 +79,7 @@ export function createCampaignFromGroupModal(
             onClose={form.reset}
             title="Créer une campagne"
           >
-            <Stack direction="row" spacing="1rem" useFlexGap sx={{ mb: 2 }}>
+            <Stack direction="row" spacing="1rem" useFlexGap sx={{ mt: '-1rem', mb: '0.5rem' }}>
               <Stack
                 direction="row"
                 spacing="0.25rem"
@@ -104,34 +104,36 @@ export function createCampaignFromGroupModal(
               </Stack>
             </Stack>
 
-            <AppTextInputNext<FormSchema>
-              label="Nom (obligatoire)"
-              name="title"
-              control={form.control}
-            />
+            <Typography variant="body2" sx={{ mb: '0.25rem' }}>
+              Une fois la campagne créée, les logements « Non suivi » passeront « En attente de retour ».
+            </Typography>
 
-            <AppTextInputNext<FormSchema>
-              label="Description (obligatoire)"
-              hintText="Vous pouvez par exemple définir les critères de votre campagne, comment vous l’avez construite, le planning de celle-ci, etc."
-              name="description"
-              control={form.control}
-              textArea
-            />
+            <Box sx={{ '& .fr-input-group': { marginBottom: '0.75rem' } }}>
+              <AppTextInputNext<FormSchema>
+                label="Nom (obligatoire)"
+                name="title"
+                control={form.control}
+              />
 
-            <AppTextInputNext<FormSchema>
-              label="Date d’envoi"
-              name="sentAt"
-              control={form.control}
-              nativeInputProps={{ type: 'date' }}
-              mapValue={(value) => value ?? ''}
-              contramapValue={(value) => value || null}
-            />
+              <AppTextInputNext<FormSchema>
+                label="Description"
+                hintText="Vous pouvez par exemple définir les critères de votre campagne, comment vous l'avez construite, le planning de celle-ci, etc."
+                name="description"
+                control={form.control}
+                textArea
+                nativeTextAreaProps={{ rows: 2 }}
+              />
 
-            <Alert
-              severity="info"
-              small
-              description="Une fois la campagne créée : les logements seront enregistrés comme ayant fait l’objet d’un courrier ; le statut des logements “Non suivi” passera au statut “En attente de retour” ; vous pourrez télécharger les fichiers vous permettant d’effectuer votre publipostage."
-            />
+              <AppTextInputNext<FormSchema>
+                label="Date d'envoi"
+                name="sentAt"
+                control={form.control}
+                nativeInputProps={{ type: 'date' }}
+                mapValue={(value) => value ?? ''}
+                contramapValue={(value) => value || null}
+              />
+            </Box>
+
           </modal.Component>
         </form>
       );

--- a/frontend/src/components/Group/CreateCampaignFromGroupModal.tsx
+++ b/frontend/src/components/Group/CreateCampaignFromGroupModal.tsx
@@ -125,7 +125,7 @@ export function createCampaignFromGroupModal(
               />
 
               <AppTextInputNext<FormSchema>
-                label="Date d'envoi"
+                label="Date d’envoi"
                 name="sentAt"
                 control={form.control}
                 nativeInputProps={{ type: 'date' }}

--- a/packages/schemas/src/campaign-creation-payload.ts
+++ b/packages/schemas/src/campaign-creation-payload.ts
@@ -5,6 +5,6 @@ import { dateString } from './date-string';
 
 export const campaignCreationPayload: ObjectSchema<CampaignCreationPayload> = object({
   title: string().trim().required('Veuillez renseigner un titre'),
-  description: string().trim().required('Veuillez renseigner une description'),
+  description: string().trim().optional().default(''),
   sentAt: dateString.nullable().optional().default(null)
 });


### PR DESCRIPTION
## Summary

- **Description optionnelle** : le champ Description n'est plus obligatoire dans la modale de création de campagne depuis un groupe — ni côté frontend (schéma local) ni côté API (`packages/schemas`). Il vaut `''` par défaut.
- **Alerte supprimée** : le composant `Alert` (texte verbose sur le publipostage) est remplacé par une courte phrase `Typography` directement sous le titre : *« Une fois la campagne créée, les logements « Non suivi » passeront « En attente de retour ». »*
- **Espacement réduit** : marges resserrées et textarea Description limitée à 2 lignes pour éviter le scroll dans la modale.

## Files changed

- `frontend/src/components/Group/CreateCampaignFromGroupModal.tsx`
- `packages/schemas/src/campaign-creation-payload.ts`

## Test plan

- [ ] Ouvrir la modale depuis un groupe
- [ ] Vérifier que le champ Description n'a plus `(obligatoire)` dans son label
- [ ] Soumettre le formulaire sans description → la campagne se crée sans erreur
- [ ] Vérifier que la phrase informative courte s'affiche sous les stats logements/propriétaires
- [ ] Vérifier que l'alerte bleue a disparu
- [ ] Vérifier qu'il n'y a plus de scroll dans la modale

🤖 Generated with [Claude Code](https://claude.com/claude-code)