### PR TITLE
feat(frontend): add housing list navigation from campaign page

### DIFF
--- a/frontend/src/views/Campaign/CampaignView.tsx
+++ b/frontend/src/views/Campaign/CampaignView.tsx
@@ -118,6 +118,7 @@ function CampaignView() {
 
           <Box sx={{ flexShrink: 0 }}>
             <ButtonsGroup
+              alignment="right"
               buttonsEquisized
               buttons={[
                 {


### PR DESCRIPTION
## Summary

- Adds a **'Voir les logements'** button on the campaign detail page (`/campagnes/:id`) that navigates to the housing list pre-filtered by campaign
- Campaign name in the campaign list table links back to the campaign page (not the housing list)
- Moves feature flags from an inline `localFlags` constant in `FeatureFlagLayout.tsx` to `config.ts` (via `VITE_FEATURE_FLAGS` env var)
- Uses `FullWidthButton` in a semantic `<ul>/<li>` list for the campaign action buttons, consistent with `GroupNext.tsx`
- Adds integration tests covering navigation from campaign page to housing list

## Changes

- `CampaignViewNext.tsx` — action buttons (view housings, delete campaign) in a vertical `FullWidthButton` list aligned to the right
- `CampaignTableNext.tsx` — campaign name reverted to link to `/campagnes/:id`
- `config.ts` — new `featureFlags` field (CSV from `VITE_FEATURE_FLAGS`)
- `FeatureFlagLayout.tsx` — uses `config.featureFlags` instead of inline constant
- `CampaignViewNext.test.tsx` — integration test for housing list navigation; `renderView` returns only `{ router }`
- `CampaignListViewNext.test.tsx` — `renderView` returns only `{ router }`

## Test plan

- [ ] Log in with `test.saintlo@zlv.fr` / `Password123!`
- [ ] Open a campaign page — two buttons appear on the right: **Voir les logements** and **Supprimer la campagne**
- [ ] Click **Voir les logements** → redirects to `/parc-de-logements` filtered on the campaign
- [ ] From the campaign list, clicking the campaign name → navigates to the campaign page
- [ ] `yarn nx test frontend -- CampaignViewNext` passes
- [ ] `yarn nx test frontend -- CampaignListViewNext` passes
- [ ] `yarn nx typecheck frontend` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)