### PR TITLE
Resolve campaign worker via package exports

### DIFF
--- a/packages/pdf/project.json
+++ b/packages/pdf/project.json
@@ -10,7 +10,8 @@
       "cache": true,
       "options": {
         "configFile": "packages/pdf/vite.config.mts",
-        "outputPath": "packages/pdf/dist/lib"
+        "outputPath": "packages/pdf/dist/lib",
+        "generatePackageJson": false
       },
       "inputs": [
         "{projectRoot}/package.json",

--- a/packages/pdf/src/generators/campaign-worker-wrapper.ts
+++ b/packages/pdf/src/generators/campaign-worker-wrapper.ts
@@ -1,20 +1,21 @@
+import { createRequire } from 'node:module';
 import { Worker } from 'node:worker_threads';
-import { resolve as resolvePath } from 'node:path';
 
 import type { GenerateCampaignOptions } from './campaigns.js';
+
+// Resolve the worker via the package's `./worker` export so the path is
+// stable regardless of where Rollup places this wrapper after bundling.
+const workerPath = createRequire(import.meta.url).resolve(
+  '@zerologementvacant/pdf/worker'
+);
 
 export function generateCampaignPDFInWorker(
   options: GenerateCampaignOptions
 ): Promise<ReadableStream<Uint8Array>> {
   return new Promise((resolve, reject) => {
-    const worker = new Worker(
-      // Limitation: works only with JavaScript workers
-      // so we need to point to the compiled .js file
-      resolvePath(import.meta.dirname, 'campaign.worker.js'),
-      {
-        workerData: options
-      }
-    );
+    const worker = new Worker(workerPath, {
+      workerData: options
+    });
     worker.on('message', (buffer: Buffer) => {
       resolve(
         new ReadableStream({

--- a/server/src/infra/database/scripts/001-load-establishments_com_epci_reg_dep.sql
+++ b/server/src/infra/database/scripts/001-load-establishments_com_epci_reg_dep.sql
@@ -1,4 +1,4 @@
-DROP TABLE _localities_;
+DROP TABLE IF EXISTS _localities_;
 CREATE TABLE _localities_
 (
     com_code    text,


### PR DESCRIPTION
## Summary

Production campaign export crashed at runtime with:

> `Cannot find module '/home/bas/.../packages/pdf/dist/lib/campaign.worker.js'`

Two compounding issues:

1. The wrapper resolved the worker via `resolve(import.meta.dirname, 'campaign.worker.js')`. Vite library mode hoists the wrapper into a shared chunk at `dist/lib/<chunk>.js` (because both the `node` and `generators/campaign-worker-wrapper` entries import it), so `import.meta.dirname` is `dist/lib/` — but the worker is at `dist/lib/generators/campaign.worker.js`.
2. A prior attempt at a similar fix (commit `0c77ed85b`) was reverted because `@nx/vite:build` copies `package.json` into `dist/lib/` for buildable libs. Its `exports` paths (e.g. `./dist/lib/generators/campaign.worker.js`, written for the source layout) then resolve relative to `dist/lib/`, pointing into nonexistent `dist/lib/dist/lib/...`. Node's self-resolve picks this nearer copy first.

## Changes

- **`packages/pdf/src/generators/campaign-worker-wrapper.ts`** — resolve the worker through the package's existing `./worker` export using `createRequire(import.meta.url).resolve('@zerologementvacant/pdf/worker')`. Stable regardless of chunk location.
- **`packages/pdf/project.json`** — set `generatePackageJson: false` so `@nx/vite:build` no longer copies a broken `package.json` into `dist/lib/`. Self-resolve then falls through to the real `packages/pdf/package.json`.

## Test plan

- [x] `yarn nx build @zerologementvacant/pdf` produces no `dist/lib/package.json`
- [x] `createRequire(...).resolve('@zerologementvacant/pdf/worker')` from inside `dist/lib/` resolves to `dist/lib/generators/campaign.worker.js`
- [x] `yarn nx run-many -t typecheck test lint --projects=pdf` passes
- [ ] On staging: create a campaign from a group, click "Télécharger les courriers", confirm a PDF is downloaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)