### PR TITLE
Mise en production - 08/05/2026

### DIFF
--- a/.claude/skills/mise-en-production/SKILL.md
+++ b/.claude/skills/mise-en-production/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: mise-en-production
+description: >
+  ZLV production deploy summary workflow.
+  Use when preparing a production release (mise en production):
+  writing the GitHub deploy PR summary, finding Notion tickets,
+  and creating the corresponding Notion release note page.
+---
+
+# Mise en Production — ZLV Workflow
+
+## Inputs
+- **Deploy PR number** — the GitHub PR that merges `main` into `prod`
+- **Excluded commits** — any commits pushed directly to `main` (not via PR)
+
+---
+
+## Steps
+
+### 1 — Find all merged PRs
+
+```bash
+git log --oneline --merges origin/prod..HEAD
+```
+
+Each line is a merge commit. Extract the PR number from the message (e.g. `Merge pull request #1762`).
+
+> **Do not rely on the deploy PR's existing description.** Enumerate via git log; then fetch each PR individually to get its title, branch, and description.
+
+### 2 — Fetch PR details + Notion links
+
+For each PR number `N`:
+
+```bash
+# PR metadata
+gh pr view N --json number,title,body,headRefName,url
+
+# PR review comments (inline)
+gh api repos/MTES-MCT/zero-logement-vacant/pulls/N/comments --jq '.[].body'
+
+# PR issue comments (timeline)
+gh api repos/MTES-MCT/zero-logement-vacant/issues/N/comments --jq '.[].body'
+```
+
+Extract any Notion URL found in body or comments. Notion URLs match `https://www.notion.so/...` or `https://notion.so/...`.
+
+### 3 — Categorize PRs
+
+Use the branch name prefix as the primary signal:
+
+| Prefix | Section |
+|--------|---------|
+| `feat/` | Fonctionnalités |
+| `fix/` | Corrections de bugs |
+| `perf/` | Performance |
+| `refactor/` | Refactoring technique |
+| `deps/`, `chore/` | Sécurité / Maintenance |
+
+When the prefix is ambiguous, use the PR title and description to decide. Add new sections if needed (e.g. **Documentation**, **Infrastructure**).
+
+### 4 — Write the summary
+
+Format per entry (inside its section):
+
+```markdown
+### <PR title (translated to French if needed)>
+
+<One-sentence description of what changed and why, in French.>
+
+**Notion :** [<page title>](<notion url>)   ← omit line if no Notion link
+**GitHub :** [<PR title>](<PR url>)
+```
+
+Full structure:
+
+```markdown
+## Fonctionnalités
+
+### ...
+
+## Corrections de bugs
+
+### ...
+
+## Performance
+
+### ...
+
+## Refactoring technique
+
+### ...
+
+## Sécurité
+
+### ...
+```
+
+Omit any section that has no entries.
+
+### 5 — Update the GitHub deploy PR
+
+```bash
+gh pr edit <deploy-pr-number> --body "$(cat <<'EOF'
+<full summary markdown>
+EOF
+)"
+```
+
+Verify with `gh pr view <deploy-pr-number>`.
+
+### 6 — Create the Notion release page
+
+**Database ID:** `ef70347c-cb99-4fad-8c14-0f6f002a901c`  
+**Template page ID:** `12f9ec2a056c80bf84d6d8e6e7d5fded`
+
+Use the Notion MCP tools (available after `/mcp` auth):
+
+1. Create the page from the template:
+```
+mcp__notion__notion-create-pages
+  parent: { database_id: "ef70347c-cb99-4fad-8c14-0f6f002a901c" }
+  properties: { title: [{ text: { content: "Mise en production - DD/MM/YYYY" } }] }
+  template_id (if supported) OR duplicate template page first
+```
+
+2. Append the summary content to the page body using `mcp__notion__notion-update-page` or `mcp__notion__notion-update-data-source`.
+
+> **Note:** The Notion MCP server may not support template cloning directly. If so, use `mcp__notion__notion-duplicate-page` on the template page ID, then move it into the database and rename it.
+
+### 7 — Verify
+
+- [ ] All merged PRs appear in the summary (cross-check count with `git log --merges` output)
+- [ ] Every PR with a Notion link has it displayed
+- [ ] GitHub deploy PR body updated correctly (`gh pr view`)
+- [ ] Notion page created with correct title and content
+
+---
+
+## Constants (ZLV-specific)
+
+| Item | Value |
+|------|-------|
+| Repo slug | `MTES-MCT/zero-logement-vacant` |
+| Notion DB | `ef70347c-cb99-4fad-8c14-0f6f002a901c` |
+| Notion template | `12f9ec2a056c80bf84d6d8e6e7d5fded` |
+| Base branch for prod | `origin/prod` |

--- a/.mcp.json
+++ b/.mcp.json
@@ -3,7 +3,14 @@
     "nx-mcp": {
       "type": "stdio",
       "command": "npx",
-      "args": ["nx", "mcp"]
+      "args": [
+        "nx",
+        "mcp"
+      ]
+    },
+    "notion": {
+      "type": "http",
+      "url": "https://mcp.notion.com/mcp"
     }
   }
 }

--- a/packages/pdf/project.json
+++ b/packages/pdf/project.json
@@ -10,7 +10,8 @@
       "cache": true,
       "options": {
         "configFile": "packages/pdf/vite.config.mts",
-        "outputPath": "packages/pdf/dist/lib"
+        "outputPath": "packages/pdf/dist/lib",
+        "generatePackageJson": false
       },
       "inputs": [
         "{projectRoot}/package.json",

--- a/packages/pdf/src/generators/campaign-worker-wrapper.ts
+++ b/packages/pdf/src/generators/campaign-worker-wrapper.ts
@@ -1,20 +1,21 @@
+import { createRequire } from 'node:module';
 import { Worker } from 'node:worker_threads';
-import { resolve as resolvePath } from 'node:path';
 
 import type { GenerateCampaignOptions } from './campaigns.js';
+
+// Resolve the worker via the package's `./worker` export so the path is
+// stable regardless of where Rollup places this wrapper after bundling.
+const workerPath = createRequire(import.meta.url).resolve(
+  '@zerologementvacant/pdf/worker'
+);
 
 export function generateCampaignPDFInWorker(
   options: GenerateCampaignOptions
 ): Promise<ReadableStream<Uint8Array>> {
   return new Promise((resolve, reject) => {
-    const worker = new Worker(
-      // Limitation: works only with JavaScript workers
-      // so we need to point to the compiled .js file
-      resolvePath(import.meta.dirname, 'campaign.worker.js'),
-      {
-        workerData: options
-      }
-    );
+    const worker = new Worker(workerPath, {
+      workerData: options
+    });
     worker.on('message', (buffer: Buffer) => {
       resolve(
         new ReadableStream({

--- a/server/src/controllers/housingController.ts
+++ b/server/src/controllers/housingController.ts
@@ -80,7 +80,7 @@ import housingOwnerRepository from '~/repositories/housingOwnerRepository';
 
 import housingRepository from '~/repositories/housingRepository';
 import noteRepository from '~/repositories/noteRepository';
-import ownerRepository from '~/repositories/ownerRepository';
+import ownerRepository, { refreshMultiOwnerFlags } from '~/repositories/ownerRepository';
 import precisionRepository from '~/repositories/precisionRepository';
 import { createBanAPI } from '~/services/ban/ban-api';
 
@@ -442,8 +442,9 @@ const create: RequestHandler<
         merge: false
       })
     ]);
-    await housingOwnerRepository.saveMany(housingOwners);
+    const affectedOwnerIds = await housingOwnerRepository.saveMany(housingOwners);
     await Promise.all([
+      refreshMultiOwnerFlags(affectedOwnerIds),
       banAddress ? banAddressesRepository.save(banAddress) : Promise.resolve(),
       eventRepository.insertManyHousingEvents(housingEvents),
       eventRepository.insertManyOwnerEvents(ownerEvents),

--- a/server/src/controllers/ownerController.ts
+++ b/server/src/controllers/ownerController.ts
@@ -35,7 +35,7 @@ import banAddressesRepository from '~/repositories/banAddressesRepository';
 import eventRepository from '~/repositories/eventRepository';
 import housingOwnerRepository from '~/repositories/housingOwnerRepository';
 import housingRepository from '~/repositories/housingRepository';
-import ownerRepository from '~/repositories/ownerRepository';
+import ownerRepository, { refreshMultiOwnerFlags } from '~/repositories/ownerRepository';
 import ownerDistanceService from '~/services/ownerDistanceService';
 import { isArrayOf, isString } from '~/utils/validators';
 
@@ -480,8 +480,11 @@ const updateHousingOwners: RequestHandler<
   ];
 
   await startTransaction(async () => {
-    await housingOwnerRepository.saveMany(housingOwners);
-    await eventRepository.insertManyHousingOwnerEvents(events);
+    const affectedOwnerIds = await housingOwnerRepository.saveMany(housingOwners);
+    await Promise.all([
+      refreshMultiOwnerFlags(affectedOwnerIds),
+      eventRepository.insertManyHousingOwnerEvents(events)
+    ]);
   });
   response
     .status(constants.HTTP_STATUS_OK)

--- a/server/src/controllers/test/housing-owner-api.test.ts
+++ b/server/src/controllers/test/housing-owner-api.test.ts
@@ -1,4 +1,5 @@
 import { faker } from '@faker-js/faker/locale/fr';
+import { HousingOwnerPayloadDTO } from '@zerologementvacant/models';
 import { constants } from 'node:http2';
 import request from 'supertest';
 
@@ -38,6 +39,45 @@ describe('Housing owner API', () => {
 
     await Establishments().insert(formatEstablishmentApi(establishment));
     await Users().insert(toUserDBO(user));
+  });
+
+  describe('PUT /housing/:housingId/owners', () => {
+    const testRoute = (housingId: string) =>
+      `/api/housing/${housingId}/owners`;
+
+    it('should refresh is_multi_owner for affected owners', async () => {
+      const housing1 = genHousingApi(establishment.geoCodes[0]);
+      const housing2 = genHousingApi(establishment.geoCodes[0]);
+      const owner = genOwnerApi();
+      await Housing().insert([housing1, housing2].map(formatHousingRecordApi));
+      await Owners().insert(formatOwnerApi(owner));
+      // owner is already rank=1 in housing1 → will become multi-owner after this call
+      await HousingOwners().insert(
+        formatHousingOwnerApi({
+          ...genHousingOwnerApi(housing1, owner),
+          rank: 1
+        })
+      );
+
+      const payload: HousingOwnerPayloadDTO[] = [
+        {
+          id: owner.id,
+          rank: 1,
+          idprocpte: null,
+          idprodroit: null,
+          locprop: null,
+          propertyRight: null
+        }
+      ];
+
+      await request(url)
+        .put(testRoute(housing2.id))
+        .send(payload)
+        .use(tokenProvider(user));
+
+      const actual = await Owners().where({ id: owner.id }).first();
+      expect(actual?.is_multi_owner).toBe(true);
+    });
   });
 
   describe('GET /owners/:id/housings', () => {

--- a/server/src/infra/database/migrations/20260506000000_housing-owners-add-geo-code-index.ts
+++ b/server/src/infra/database/migrations/20260506000000_housing-owners-add-geo-code-index.ts
@@ -1,0 +1,45 @@
+import type { Knex } from 'knex';
+
+// CONCURRENTLY operations cannot run inside a transaction
+export const config = { transaction: false };
+
+const NEW_INDEX = 'owners_housing_geo_code_rank_owner_idx';
+
+export async function up(knex: Knex): Promise<void> {
+  // New index: allows WHERE housing_geo_code IN (...) AND rank = 1 to use an
+  // index scan instead of a full sequential scan. Needed by the multiOwners and
+  // beneficiaryCounts filters in housingRepository.count().
+  await knex.raw(`
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS ${NEW_INDEX}
+    ON owners_housing (housing_geo_code, rank, owner_id)
+  `);
+
+  // idx_owners_housing_update and idx_owners_housing_owner_housing are both
+  // non-unique (owner_id, housing_id) indexes — exact duplicates of each other
+  // and redundant with the PK (owner_id, housing_id, housing_geo_code).
+  await knex.raw(
+    'DROP INDEX CONCURRENTLY IF EXISTS idx_owners_housing_update'
+  );
+  await knex.raw(
+    'DROP INDEX CONCURRENTLY IF EXISTS idx_owners_housing_owner_housing'
+  );
+
+  // idx_end_date indexes a column only used in ORDER BY after a high-selectivity
+  // WHERE owner_id = ? filter. The result set is tiny; the index is never chosen.
+  await knex.raw('DROP INDEX CONCURRENTLY IF EXISTS idx_end_date');
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(
+    `DROP INDEX CONCURRENTLY IF EXISTS ${NEW_INDEX}`
+  );
+  await knex.raw(
+    'CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_owners_housing_update ON owners_housing (owner_id, housing_id)'
+  );
+  await knex.raw(
+    'CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_owners_housing_owner_housing ON owners_housing (owner_id, housing_id)'
+  );
+  await knex.raw(
+    'CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_end_date ON owners_housing (end_date)'
+  );
+}

--- a/server/src/infra/database/migrations/20260506000000_housing-owners-add-geo-code-index.ts
+++ b/server/src/infra/database/migrations/20260506000000_housing-owners-add-geo-code-index.ts
@@ -3,15 +3,15 @@ import type { Knex } from 'knex';
 // CONCURRENTLY operations cannot run inside a transaction
 export const config = { transaction: false };
 
-const NEW_INDEX = 'owners_housing_geo_code_rank_owner_idx';
+const NEW_INDEX = 'owners_housing_owner_rank_idx';
 
 export async function up(knex: Knex): Promise<void> {
-  // New index: allows WHERE housing_geo_code IN (...) AND rank = 1 to use an
-  // index scan instead of a full sequential scan. Needed by the multiOwners and
-  // beneficiaryCounts filters in housingRepository.count().
+  // New index: allows WHERE owner_id = ? AND rank = 1 to skip non-rank-1
+  // rows without a heap filter. Used by refreshMultiOwnerFlags in
+  // ownerRepository to efficiently count rank=1 entries per owner.
   await knex.raw(`
     CREATE INDEX CONCURRENTLY IF NOT EXISTS ${NEW_INDEX}
-    ON owners_housing (housing_geo_code, rank, owner_id)
+    ON owners_housing (owner_id, rank)
   `);
 
   // idx_owners_housing_update and idx_owners_housing_owner_housing are both
@@ -30,9 +30,7 @@ export async function up(knex: Knex): Promise<void> {
 }
 
 export async function down(knex: Knex): Promise<void> {
-  await knex.raw(
-    `DROP INDEX CONCURRENTLY IF EXISTS ${NEW_INDEX}`
-  );
+  await knex.raw(`DROP INDEX CONCURRENTLY IF EXISTS ${NEW_INDEX}`);
   await knex.raw(
     'CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_owners_housing_update ON owners_housing (owner_id, housing_id)'
   );

--- a/server/src/infra/database/migrations/20260506122850_owners-add-is-multi-owner.ts
+++ b/server/src/infra/database/migrations/20260506122850_owners-add-is-multi-owner.ts
@@ -1,0 +1,23 @@
+import type { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('owners', (table) => {
+    table.boolean('is_multi_owner').nullable();
+  });
+
+  await knex.raw(`
+    UPDATE owners
+    SET is_multi_owner = (
+      SELECT COUNT(*) > 1
+      FROM owners_housing
+      WHERE owner_id = owners.id
+        AND rank = 1
+    )
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('owners', (table) => {
+    table.dropColumn('is_multi_owner');
+  });
+}

--- a/server/src/infra/database/scripts/001-load-establishments_com_epci_reg_dep.sql
+++ b/server/src/infra/database/scripts/001-load-establishments_com_epci_reg_dep.sql
@@ -1,4 +1,4 @@
-DROP TABLE _localities_;
+DROP TABLE IF EXISTS _localities_;
 CREATE TABLE _localities_
 (
     com_code    text,

--- a/server/src/infra/database/scripts/001-load-establishments_com_epci_reg_dep.sql
+++ b/server/src/infra/database/scripts/001-load-establishments_com_epci_reg_dep.sql
@@ -1,3 +1,4 @@
+DROP TABLE _localities_;
 CREATE TABLE _localities_
 (
     com_code    text,
@@ -93,10 +94,6 @@ INSERT INTO establishments_localities (
 DELETE FROM localities
 WHERE NOT EXISTS (
     SELECT  * FROM _localities_ WHERE geo_code=lpad(com_code, 5, '0')
-);
-DELETE FROM settings s
-WHERE NOT EXISTS (
-    SELECT * FROM establishments_localities el WHERE s.establishment_id = el.establishment_id
 );
 DELETE FROM establishments e
 WHERE NOT EXISTS (

--- a/server/src/repositories/housingOwnerRepository.ts
+++ b/server/src/repositories/housingOwnerRepository.ts
@@ -7,7 +7,6 @@ import { match } from 'ts-pattern';
 
 import db from '~/infra/database';
 import { withinTransaction } from '~/infra/database/transaction';
-import { refreshMultiOwnerFlags } from './ownerRepository';
 import { logger } from '~/infra/logger';
 import { HousingRecordApi } from '~/models/HousingApi';
 import { HousingOwnerApi } from '~/models/HousingOwnerApi';
@@ -85,8 +84,8 @@ async function insert(housingOwner: HousingOwnerApi): Promise<void> {
 
 async function saveMany(
   housingOwners: ReadonlyArray<Omit<HousingOwnerApi, keyof OwnerApi>>
-): Promise<void> {
-  if (!housingOwners.length) return;
+): Promise<ReadonlyArray<string>> {
+  if (!housingOwners.length) return [];
 
   housingOwners.forEach((housingOwner) => {
     logger.debug('Saving housing owner...', { housingOwner });
@@ -113,8 +112,8 @@ async function saveMany(
     );
   });
 
-  await refreshMultiOwnerFlags(affectedOwnerIds);
   logger.debug(`Saved ${housingOwners.length} housing owners.`);
+  return affectedOwnerIds;
 }
 
 export interface HousingOwnerDBO {

--- a/server/src/repositories/housingOwnerRepository.ts
+++ b/server/src/repositories/housingOwnerRepository.ts
@@ -7,6 +7,7 @@ import { match } from 'ts-pattern';
 
 import db from '~/infra/database';
 import { withinTransaction } from '~/infra/database/transaction';
+import { refreshMultiOwnerFlags } from './ownerRepository';
 import { logger } from '~/infra/logger';
 import { HousingRecordApi } from '~/models/HousingApi';
 import { HousingOwnerApi } from '~/models/HousingOwnerApi';
@@ -85,29 +86,35 @@ async function insert(housingOwner: HousingOwnerApi): Promise<void> {
 async function saveMany(
   housingOwners: ReadonlyArray<Omit<HousingOwnerApi, keyof OwnerApi>>
 ): Promise<void> {
-  if (housingOwners.length) {
-    housingOwners.forEach((housingOwner) => {
-      logger.debug('Saving housing owner...', {
-        housingOwner
-      });
-    });
+  if (!housingOwners.length) return;
 
-    // Remove owners before inserting them back
-    await withinTransaction(async (transaction) => {
-      const housingGeoCode = housingOwners[0].housingGeoCode;
-      const housingId = housingOwners[0].housingId;
-      await HousingOwners(transaction)
-        .where({
-          housing_geo_code: housingGeoCode,
-          housing_id: housingId
-        })
-        .delete();
-      await HousingOwners(transaction).insert(
-        housingOwners.map(formatHousingOwnerApi)
-      );
-    });
-    logger.debug(`Saved ${housingOwners.length} housing owners.`);
-  }
+  housingOwners.forEach((housingOwner) => {
+    logger.debug('Saving housing owner...', { housingOwner });
+  });
+
+  const housingGeoCode = housingOwners[0].housingGeoCode;
+  const housingId = housingOwners[0].housingId;
+  const newOwnerIds = housingOwners.map((ho) => ho.ownerId);
+  let affectedOwnerIds: string[] = newOwnerIds;
+
+  // Remove owners before inserting them back
+  await withinTransaction(async (transaction) => {
+    const existing = await HousingOwners(transaction)
+      .where({ housing_geo_code: housingGeoCode, housing_id: housingId })
+      .select('owner_id');
+    affectedOwnerIds = [
+      ...new Set([...existing.map((r) => r.owner_id), ...newOwnerIds])
+    ];
+    await HousingOwners(transaction)
+      .where({ housing_geo_code: housingGeoCode, housing_id: housingId })
+      .delete();
+    await HousingOwners(transaction).insert(
+      housingOwners.map(formatHousingOwnerApi)
+    );
+  });
+
+  await refreshMultiOwnerFlags(affectedOwnerIds);
+  logger.debug(`Saved ${housingOwners.length} housing owners.`);
 }
 
 export interface HousingOwnerDBO {

--- a/server/src/repositories/housingRepository.ts
+++ b/server/src/repositories/housingRepository.ts
@@ -194,6 +194,7 @@ async function count(filters: HousingFiltersApi): Promise<HousingCountApi> {
   const filterByOwner = [
     filters.ownerKinds,
     filters.ownerAges,
+    filters.multiOwners,
     filters.query
   ].some((filter) => filter?.length);
 
@@ -663,32 +664,12 @@ function filteredQuery(opts: FilteredQueryOptions) {
       });
     }
     if (filters.multiOwners?.length) {
-      const multiOwnersSubquery = () =>
-        db(housingOwnersTable)
-          .select(`${housingOwnersTable}.owner_id`)
-          .where(`${housingOwnersTable}.rank`, 1)
-          .modify((query) => {
-            if (filters.localities?.length) {
-              query.whereIn(
-                `${housingOwnersTable}.housing_geo_code`,
-                filters.localities
-              );
-            }
-          })
-          .groupBy(`${housingOwnersTable}.owner_id`);
-
       queryBuilder.where((where) => {
         if (filters.multiOwners?.includes(true)) {
-          where.orWhereIn(
-            `${housingOwnersTable}.owner_id`,
-            multiOwnersSubquery().havingRaw('COUNT(*) > 1')
-          );
+          where.orWhere(`${ownerTable}.is_multi_owner`, true);
         }
         if (filters.multiOwners?.includes(false)) {
-          where.orWhereIn(
-            `${housingOwnersTable}.owner_id`,
-            multiOwnersSubquery().havingRaw('COUNT(*) = 1')
-          );
+          where.orWhere(`${ownerTable}.is_multi_owner`, false);
         }
       });
     }

--- a/server/src/repositories/ownerRepository.ts
+++ b/server/src/repositories/ownerRepository.ts
@@ -50,6 +50,7 @@ export interface OwnerRecordDBO {
   entity: OwnerEntity | null;
   created_at: Date | string | null;
   updated_at: Date | string | null;
+  is_multi_owner: boolean | null;
 }
 
 export interface OwnerDBO extends OwnerRecordDBO {
@@ -644,8 +645,26 @@ export const formatOwnerApi = (owner: OwnerApi): OwnerRecordDBO => ({
   kind_class: owner.kind ?? null,
   entity: owner.entity,
   created_at: owner.createdAt ? new Date(owner.createdAt) : null,
-  updated_at: owner.updatedAt ? new Date(owner.updatedAt) : null
+  updated_at: owner.updatedAt ? new Date(owner.updatedAt) : null,
+  is_multi_owner: null
 });
+
+async function refreshMultiOwnerFlags(
+  ownerIds: ReadonlyArray<string>
+): Promise<void> {
+  if (!ownerIds.length) return;
+  await withinTransaction(async (transaction) => {
+    await Owners(transaction)
+      .whereIn('id', ownerIds)
+      .update({
+        is_multi_owner: db.raw(
+          `(SELECT COUNT(*) > 1 FROM ${housingOwnersTable} WHERE owner_id = owners.id AND rank = 1)`
+        )
+      });
+  });
+}
+
+export { refreshMultiOwnerFlags };
 
 export default {
   find,
@@ -663,5 +682,6 @@ export default {
   update,
   updateAddressList,
   deleteHousingOwners,
-  insertHousingOwners
+  insertHousingOwners,
+  refreshMultiOwnerFlags
 };

--- a/server/src/repositories/test/housingOwnerRepository.test.ts
+++ b/server/src/repositories/test/housingOwnerRepository.test.ts
@@ -146,5 +146,39 @@ describe('housingOwnerRepository', () => {
         }
       ]);
     });
+
+    it('should update is_multi_owner for affected owners', async () => {
+      const multiOwner = genOwnerApi();
+      const singleOwner = genOwnerApi();
+      const housing1 = genHousingApi();
+      const housing2 = genHousingApi();
+
+      await Promise.all([
+        Owners().insert([formatOwnerApi(multiOwner), formatOwnerApi(singleOwner)]),
+        Housing().insert([
+          formatHousingRecordApi(housing1),
+          formatHousingRecordApi(housing2)
+        ])
+      ]);
+      // multiOwner already owns housing1 at rank=1
+      await HousingOwners().insert(
+        formatHousingOwnerApi({ ...genHousingOwnerApi(housing1, multiOwner), rank: 1 })
+      );
+
+      // assign both owners to housing2 (multiOwner at rank=1, singleOwner at rank=2)
+      await housingOwnerRepository.saveMany([
+        { ...genHousingOwnerApi(housing2, multiOwner), rank: 1 },
+        { ...genHousingOwnerApi(housing2, singleOwner), rank: 2 }
+      ]);
+
+      const [actualMulti, actualSingle] = await Promise.all([
+        Owners().where({ id: multiOwner.id }).first(),
+        Owners().where({ id: singleOwner.id }).first()
+      ]);
+      // multiOwner has rank=1 in housing1 and housing2 → multi owner
+      expect(actualMulti?.is_multi_owner).toBe(true);
+      // singleOwner only has rank=2 entries → not a multi owner
+      expect(actualSingle?.is_multi_owner).toBe(false);
+    });
   });
 });

--- a/server/src/repositories/test/housingOwnerRepository.test.ts
+++ b/server/src/repositories/test/housingOwnerRepository.test.ts
@@ -147,38 +147,24 @@ describe('housingOwnerRepository', () => {
       ]);
     });
 
-    it('should update is_multi_owner for affected owners', async () => {
-      const multiOwner = genOwnerApi();
-      const singleOwner = genOwnerApi();
-      const housing1 = genHousingApi();
-      const housing2 = genHousingApi();
+    it('should return affected owner IDs (existing and incoming)', async () => {
+      const existingOwner = genOwnerApi();
+      const newOwner = genOwnerApi();
+      const housing = genHousingApi();
 
       await Promise.all([
-        Owners().insert([formatOwnerApi(multiOwner), formatOwnerApi(singleOwner)]),
-        Housing().insert([
-          formatHousingRecordApi(housing1),
-          formatHousingRecordApi(housing2)
-        ])
+        Owners().insert([formatOwnerApi(existingOwner), formatOwnerApi(newOwner)]),
+        Housing().insert(formatHousingRecordApi(housing))
       ]);
-      // multiOwner already owns housing1 at rank=1
       await HousingOwners().insert(
-        formatHousingOwnerApi({ ...genHousingOwnerApi(housing1, multiOwner), rank: 1 })
+        formatHousingOwnerApi({ ...genHousingOwnerApi(housing, existingOwner), rank: 1 })
       );
 
-      // assign both owners to housing2 (multiOwner at rank=1, singleOwner at rank=2)
-      await housingOwnerRepository.saveMany([
-        { ...genHousingOwnerApi(housing2, multiOwner), rank: 1 },
-        { ...genHousingOwnerApi(housing2, singleOwner), rank: 2 }
+      const affectedOwnerIds = await housingOwnerRepository.saveMany([
+        { ...genHousingOwnerApi(housing, newOwner), rank: 1 }
       ]);
 
-      const [actualMulti, actualSingle] = await Promise.all([
-        Owners().where({ id: multiOwner.id }).first(),
-        Owners().where({ id: singleOwner.id }).first()
-      ]);
-      // multiOwner has rank=1 in housing1 and housing2 → multi owner
-      expect(actualMulti?.is_multi_owner).toBe(true);
-      // singleOwner only has rank=2 entries → not a multi owner
-      expect(actualSingle?.is_multi_owner).toBe(false);
+      expect(affectedOwnerIds).toIncludeAllMembers([existingOwner.id, newOwner.id]);
     });
   });
 });

--- a/server/src/repositories/test/housingRepository.test.ts
+++ b/server/src/repositories/test/housingRepository.test.ts
@@ -106,7 +106,7 @@ import housingRepository, {
   ReferenceDataYear
 } from '../housingRepository';
 import { formatLocalityApi, Localities } from '../localityRepository';
-import { formatOwnerApi, Owners } from '../ownerRepository';
+import { formatOwnerApi, Owners, refreshMultiOwnerFlags } from '../ownerRepository';
 import { toUserDBO, Users } from '../userRepository';
 
 describe('Housing repository', () => {
@@ -884,6 +884,7 @@ describe('Housing repository', () => {
                 )
             );
           await HousingOwners().insert(housingOwners);
+          await refreshMultiOwnerFlags([owner.id, anotherOwner.id]);
         });
 
         function countOwners(
@@ -2579,6 +2580,7 @@ describe('Housing repository', () => {
             ...formatHousingOwnersApi(multiHousing2, [multiOwner]),
             ...formatHousingOwnersApi(singleHousing, [singleOwner])
           ]);
+          await refreshMultiOwnerFlags([multiOwner.id, singleOwner.id]);
         });
 
         it('should count only housings belonging to owners who have multiple properties', async () => {

--- a/server/src/repositories/test/ownerRepository.test.ts
+++ b/server/src/repositories/test/ownerRepository.test.ts
@@ -1,11 +1,16 @@
 import db from '~/infra/database';
 import { OwnerApi } from '~/models/OwnerApi';
-import { genOwnerApi } from '~/test/testFixtures';
+import { genHousingApi, genHousingOwnerApi, genOwnerApi } from '~/test/testFixtures';
 import ownerRepository, {
   formatOwnerApi,
   Owners,
   ownerTable
 } from '../ownerRepository';
+import {
+  formatHousingOwnerApi,
+  HousingOwners
+} from '../housingOwnerRepository';
+import { formatHousingRecordApi, Housing } from '../housingRepository';
 import { collect } from '@zerologementvacant/utils/node';
 import { faker } from '@faker-js/faker';
 
@@ -246,6 +251,50 @@ describe('Owner repository', () => {
           .map((owner: OwnerApi) => owner.fullName)
           .includes(owner.fullName);
       });
+    });
+  });
+
+  describe('refreshMultiOwnerFlags', () => {
+    it('should set is_multi_owner to true for owners with rank=1 in more than one housing', async () => {
+      const owner = genOwnerApi();
+      await Owners().insert(formatOwnerApi(owner));
+      const housings = [genHousingApi(), genHousingApi()];
+      await Housing().insert(housings.map(formatHousingRecordApi));
+      await HousingOwners().insert(
+        housings.map((housing) =>
+          formatHousingOwnerApi({ ...genHousingOwnerApi(housing, owner), rank: 1 })
+        )
+      );
+
+      await ownerRepository.refreshMultiOwnerFlags([owner.id]);
+
+      const actual = await Owners().where({ id: owner.id }).first();
+      expect(actual?.is_multi_owner).toBe(true);
+    });
+
+    it('should set is_multi_owner to false for owners with rank=1 in only one housing', async () => {
+      const owner = genOwnerApi();
+      await Owners().insert({ ...formatOwnerApi(owner), is_multi_owner: true });
+      const housing = genHousingApi();
+      await Housing().insert(formatHousingRecordApi(housing));
+      await HousingOwners().insert(
+        formatHousingOwnerApi({ ...genHousingOwnerApi(housing, owner), rank: 1 })
+      );
+
+      await ownerRepository.refreshMultiOwnerFlags([owner.id]);
+
+      const actual = await Owners().where({ id: owner.id }).first();
+      expect(actual?.is_multi_owner).toBe(false);
+    });
+
+    it('should not update owners not in the list', async () => {
+      const ownerToSkip = genOwnerApi();
+      await Owners().insert({ ...formatOwnerApi(ownerToSkip), is_multi_owner: true });
+
+      await ownerRepository.refreshMultiOwnerFlags([]);
+
+      const actual = await Owners().where({ id: ownerToSkip.id }).first();
+      expect(actual?.is_multi_owner).toBe(true);
     });
   });
 });

--- a/server/src/scripts/import-lovac/source-housing-owners/source-housing-owner-command.ts
+++ b/server/src/scripts/import-lovac/source-housing-owners/source-housing-owner-command.ts
@@ -17,7 +17,7 @@ import { OwnerApi } from '~/models/OwnerApi';
 import eventRepository from '~/repositories/eventRepository';
 import housingOwnerRepository from '~/repositories/housingOwnerRepository';
 import housingRepository from '~/repositories/housingRepository';
-import ownerRepository from '~/repositories/ownerRepository';
+import ownerRepository, { refreshMultiOwnerFlags } from '~/repositories/ownerRepository';
 import userRepository from '~/repositories/userRepository';
 import { createLoggerReporter } from '~/scripts/import-lovac/infra';
 import { FromOptionValue } from '~/scripts/import-lovac/infra/options/from';
@@ -125,6 +125,8 @@ export function createSourceHousingOwnerCommand() {
           .pipeThrough(flatten())
           .tee();
 
+      const allAffectedOwnerIds = new Set<string>();
+
       await Promise.all([
         // Update housing owners
         housingOwnerStream
@@ -139,7 +141,8 @@ export function createSourceHousingOwnerCommand() {
             new WritableStream<HousingOwnerApi[]>({
               async write(housingOwners) {
                 if (!options.dryRun) {
-                  await housingOwnerRepository.saveMany(housingOwners);
+                  const ids = await housingOwnerRepository.saveMany(housingOwners);
+                  ids.forEach((id) => allAffectedOwnerIds.add(id));
                 }
               }
             })
@@ -164,6 +167,11 @@ export function createSourceHousingOwnerCommand() {
             })
           )
       ]);
+
+      if (!options.dryRun && allAffectedOwnerIds.size > 0) {
+        logger.info('Refreshing multi-owner flags...', { count: allAffectedOwnerIds.size });
+        await refreshMultiOwnerFlags([...allAffectedOwnerIds]);
+      }
 
       logger.info(`File ${file} imported.`);
     } catch (error) {


### PR DESCRIPTION
## Performance

### Remplacement de la requête `multiOwners` par une colonne précalculée `is_multi_owner`

Le filtre « multi-propriétaires » provoquait des timeouts de 28 s sur les grosses collectivités (Île-de-France notamment) parce qu'il déclenchait un GROUP BY ou une sous-requête corrélée scannant l'intégralité de `owners_housing` à chaque requête. La colonne `is_multi_owner` est désormais maintenue sur `owners` et le filtre devient une lecture indexée O(1).

**GitHub :** [Replace multiOwners query with precomputed is_multi_owner column](https://github.com/MTES-MCT/zero-logement-vacant/pull/1798)

## Corrections de bugs

### Résolution du worker de campagne via les exports du package

L'export des courriers de campagne crashait en production avec `Cannot find module '.../packages/pdf/dist/lib/campaign.worker.js'`. Le wrapper résolvait le worker par chemin relatif, qui devient incorrect après le hoisting de Vite, et un `package.json` parasite copié dans `dist/lib/` détournait le self-resolve. La résolution passe maintenant par l'export `@zerologementvacant/pdf/worker`, et `generatePackageJson` est désactivé pour le package PDF.

**GitHub :** [Resolve campaign worker via package exports](https://github.com/MTES-MCT/zero-logement-vacant/pull/1799)