### PR TITLE
test(models): generate coherent sub-status in housing fixtures

### DIFF
--- a/packages/factories/src/factories/housing.ts
+++ b/packages/factories/src/factories/housing.ts
@@ -4,6 +4,7 @@ import {
   CADASTRAL_CLASSIFICATION_VALUES,
   DATA_FILE_YEAR_VALUES,
   ENERGY_CONSUMPTION_VALUES,
+  getSubStatuses,
   HOUSING_KIND_VALUES,
   HOUSING_SOURCE_VALUES,
   HOUSING_STATUS_VALUES,
@@ -57,6 +58,20 @@ export function createHousingFactory(adapter: Adapter) {
           .exhaustive()
       )
       .map(Number);
+    const status = faker.helpers.weightedArrayElement([
+      {
+        value: HousingStatus.NEVER_CONTACTED,
+        weight: HOUSING_STATUS_VALUES.length - 1
+      },
+      ...HOUSING_STATUS_VALUES.filter(
+        (s) => s !== HousingStatus.NEVER_CONTACTED
+      ).map((s) => ({ value: s, weight: 1 }))
+    ]);
+    const subStatuses = [...getSubStatuses(status)];
+    const subStatus =
+      subStatuses.length === 0
+        ? null
+        : faker.helpers.arrayElement(subStatuses);
 
     return {
       id: faker.string.uuid(),
@@ -93,16 +108,8 @@ export function createHousingFactory(adapter: Adapter) {
             ...INTERNAL_CO_CONDOMINIUM_VALUES
           ])
         ) ?? null,
-      status: faker.helpers.weightedArrayElement([
-        {
-          value: HousingStatus.NEVER_CONTACTED,
-          weight: HOUSING_STATUS_VALUES.length - 1
-        },
-        ...HOUSING_STATUS_VALUES.filter(
-          (s) => s !== HousingStatus.NEVER_CONTACTED
-        ).map((s) => ({ value: s, weight: 1 }))
-      ]),
-      subStatus: null,
+      status,
+      subStatus,
       actualEnergyConsumption: faker.helpers.arrayElement([
         null,
         ...ENERGY_CONSUMPTION_VALUES

--- a/packages/models/src/test/fixtures.ts
+++ b/packages/models/src/test/fixtures.ts
@@ -33,7 +33,11 @@ import {
   HousingOwnerDTO,
   type ActiveOwnerRank
 } from '../HousingOwnerDTO';
-import { HOUSING_STATUS_VALUES, HousingStatus } from '../HousingStatus';
+import {
+  getSubStatuses,
+  HOUSING_STATUS_VALUES,
+  HousingStatus
+} from '../HousingStatus';
 import { MUTATION_TYPE_VALUES } from '../Mutation';
 import { NoteDTO } from '../NoteDTO';
 import {
@@ -650,6 +654,13 @@ export function genGroupDTO(
 
 export const FRANCE_BBOX: BBox = [-1.69, 43.19, 6.8, 49.49];
 
+export function genSubStatus(status: HousingStatus): string | null {
+  const subStatuses = [...getSubStatuses(status)];
+  return subStatuses.length === 0
+    ? null
+    : faker.helpers.arrayElement(subStatuses);
+}
+
 export function genHousingDTO(
   geoCode = genGeoCode(),
   building: BuildingDTO | null = null
@@ -673,6 +684,18 @@ export function genHousingDTO(
         .exhaustive()
     )
     .map((year) => Number(year));
+  const status = faker.helpers.weightedArrayElement([
+    {
+      value: HousingStatus.NEVER_CONTACTED,
+      weight: HOUSING_STATUS_VALUES.length - 1
+    },
+    ...HOUSING_STATUS_VALUES.filter(
+      (status) => status !== HousingStatus.NEVER_CONTACTED
+    ).map((status) => ({
+      value: status,
+      weight: 1
+    }))
+  ]);
 
   return {
     id: faker.string.uuid(),
@@ -715,19 +738,8 @@ export function genHousingDTO(
           ...INTERNAL_CO_CONDOMINIUM_VALUES
         ])
       ) ?? null,
-    status: faker.helpers.weightedArrayElement([
-      {
-        value: HousingStatus.NEVER_CONTACTED,
-        weight: HOUSING_STATUS_VALUES.length - 1
-      },
-      ...HOUSING_STATUS_VALUES.filter(
-        (status) => status !== HousingStatus.NEVER_CONTACTED
-      ).map((status) => ({
-        value: status,
-        weight: 1
-      }))
-    ]),
-    subStatus: null,
+    status,
+    subStatus: genSubStatus(status),
     actualEnergyConsumption: faker.helpers.arrayElement([
       null,
       ...ENERGY_CONSUMPTION_VALUES


### PR DESCRIPTION
## Summary
- `genHousingDTO` (in `packages/models/src/test/fixtures.ts`) and `createHousingFactory` (in `packages/factories/src/factories/housing.ts`) now generate a sub-status that is coherent with the chosen housing status, instead of always returning `null`.
- Added an exported `genSubStatus(status)` helper that picks from `getSubStatuses(status)` defined in `packages/models/src/HousingStatus.ts` (the source of truth for the mapping shown in `frontend/src/models/HousingState.tsx`), and returns `null` for statuses with no sub-statuses (`NEVER_CONTACTED`, `WAITING`).
- Downstream fixtures (`genHousingApi`, `genHousing`) and the development housing seed (`server/src/infra/database/seeds/development/20240404235459_housings.ts`) inherit the fix automatically since they all extend `genHousingDTO()`.

## Why
Previously, all fixtures hard-coded `subStatus: null`, so seeded data never exercised the sub-status code paths and tests building on the fixtures could not rely on a realistic status/sub-status pair.

## Test plan
- [x] `yarn nx typecheck models`
- [x] `yarn nx typecheck factories`
- [x] `yarn nx typecheck server`
- [x] `yarn nx typecheck frontend`
- [x] `yarn nx test models` (190/190 passing)
- [ ] Sanity-check the dev seed: re-run `yarn workspace @zerologementvacant/server seed` and verify that housings with `status` in `{FIRST_CONTACT, IN_PROGRESS, COMPLETED, BLOCKED}` now have a non-null `sub_status` matching one of the labels declared in `HOUSING_SUB_STATUS_LABELS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)