### PR TITLE
fix(dbt): LOVAC 2026 zlovac import + dagster CI manifest

### DIFF
--- a/.github/workflows/github-actions-data-stack.yml
+++ b/.github/workflows/github-actions-data-stack.yml
@@ -25,6 +25,14 @@ jobs:
         working-directory: analytics/dagster
         run: uv sync --all-extras
 
+      - name: Install dbt dependencies
+        working-directory: analytics/dbt
+        run: uv --project ../dagster run dbt deps
+
+      - name: Parse dbt project (generate manifest.json)
+        working-directory: analytics/dbt
+        run: uv --project ../dagster run dbt parse --target dev
+
       - name: Run compilation tests
         working-directory: analytics/dagster
         run: uv run pytest tests/ -v --tb=short


### PR DESCRIPTION
## Summary
- Rebind zlovac `rnb_footprint` to `geomrnb` and document RNB/geolocation columns
- Convert dbt 1.10 `arguments:` test syntax to flat legacy syntax (dbt 1.9 compatible)
- Promote MD INVEST collapse test to error severity
- CI: run `dbt deps` and `dbt parse --target dev` before pytest so `target/manifest.json` exists when tests import `src/`

## Test plan
- [ ] Data Stack CI green on this branch
- [ ] Dagster prod deploy parses manifest without `dbt_macro__test_relationships` error