### PR TITLE
fix(frontend): import fr from react-dsfr /fr subpath

### DIFF
--- a/frontend/src/components/Map/status-colors.ts
+++ b/frontend/src/components/Map/status-colors.ts
@@ -1,4 +1,4 @@
-import { fr } from '@codegouvfr/react-dsfr';
+import { fr } from '@codegouvfr/react-dsfr/fr';
 import { HousingStatus } from '@zerologementvacant/models';
 import { Array } from 'effect';
 import type { NonEmptyArray } from 'ts-essentials';


### PR DESCRIPTION
## Summary
- Postbuild script `generate-building-images.ts` runs via tsx (Node ESM) and imports `status-colors.ts`, which imports `{ fr }` from `@codegouvfr/react-dsfr`.
- Package root entry is CJS, so Node cannot statically resolve the named export and deploy fails with `SyntaxError: The requested module '@codegouvfr/react-dsfr' does not provide an export named 'fr'`.
- Switch to the dedicated `/fr` subpath, which is ESM-safe and works in both Vite and Node.

## Test plan
- [ ] `yarn nx build @zerologementvacant/front` (includes postbuild) succeeds locally
- [ ] Deploy pipeline reaches the postbuild step without the syntax error