### PR TITLE
feat(frontend): add tracking status column to campaign recipients table

### DIFF
--- a/frontend/src/components/Campaign/CampaignRecipientsNext.tsx
+++ b/frontend/src/components/Campaign/CampaignRecipientsNext.tsx
@@ -154,7 +154,7 @@ function CampaignRecipients(props: Readonly<CampaignRecipientsProps>) {
         }
       }),
       columnHelper.accessor('owner.additionalAddress', {
-        header: () => <AdvancedTableHeader title="Complément d'adresse" />,
+        header: () => <AdvancedTableHeader title="Complément d’adresse" />,
         meta: {
           styles: multilineStyles
         },
@@ -311,7 +311,7 @@ function CampaignRecipients(props: Readonly<CampaignRecipientsProps>) {
       />
 
       <removeCampaignHousingModal.Component
-        title="Suppression d'un destinataire"
+        title="Suppression d’un destinataire"
         buttons={[
           {
             children: 'Annuler',

--- a/frontend/src/components/Campaign/CampaignRecipientsNext.tsx
+++ b/frontend/src/components/Campaign/CampaignRecipientsNext.tsx
@@ -20,6 +20,7 @@ import { match } from 'ts-pattern';
 import AdvancedTable from '~/components/AdvancedTable/AdvancedTable';
 import AdvancedTableHeader from '~/components/AdvancedTable/AdvancedTableHeader';
 import HousingAddressCell from '~/components/Housing/HousingAddressCell';
+import HousingStatusBadge from '~/components/HousingStatusBadge/HousingStatusBadge';
 import OwnerEditionSideMenu from '~/components/OwnerEditionSideMenu/OwnerEditionSideMenu';
 import { useNotification } from '~/hooks/useNotification';
 import { type Address, isBanEligible } from '~/models/Address';
@@ -153,7 +154,7 @@ function CampaignRecipients(props: Readonly<CampaignRecipientsProps>) {
         }
       }),
       columnHelper.accessor('owner.additionalAddress', {
-        header: () => <AdvancedTableHeader title="Complément d’adresse" />,
+        header: () => <AdvancedTableHeader title="Complément d'adresse" />,
         meta: {
           styles: multilineStyles
         },
@@ -173,6 +174,35 @@ function CampaignRecipients(props: Readonly<CampaignRecipientsProps>) {
           />
         )
       }),
+      columnHelper.accessor(
+        (row) => ({ status: row.status, subStatus: row.subStatus }),
+        {
+          id: 'status',
+          header: () => <AdvancedTableHeader title="Statut de suivi" />,
+          meta: {
+            sort: {
+              title: 'Trier par statut de suivi'
+            },
+            styles: multilineStyles
+          },
+          cell: ({ cell }) => {
+            const { status, subStatus } = cell.getValue();
+            return (
+              <Stack sx={{ alignItems: 'center', textAlign: 'center' }}>
+                <HousingStatusBadge
+                  badgeProps={{ small: true }}
+                  status={status}
+                />
+                {subStatus && (
+                  <Typography align="center" variant="caption">
+                    {subStatus}
+                  </Typography>
+                )}
+              </Stack>
+            );
+          }
+        }
+      ),
       columnHelper.display({
         id: 'actions',
         header: () => (
@@ -281,7 +311,7 @@ function CampaignRecipients(props: Readonly<CampaignRecipientsProps>) {
       />
 
       <removeCampaignHousingModal.Component
-        title="Suppression d’un destinataire"
+        title="Suppression d'un destinataire"
         buttons={[
           {
             children: 'Annuler',


### PR DESCRIPTION
## Contexte

Dans le tableau des destinataires d'une campagne, les agents n'avaient pas accès au statut de suivi de chaque logement. Cette information est pourtant clé pour identifier rapidement les logements comptabilisés dans le taux de retour.

## Changements

Ajout d'une colonne **"Statut de suivi"** dans `CampaignRecipientsNext` :

- **Badge coloré** du statut principal (même rendu que le tableau du parc de logements : `HousingStatusBadge`)
- **Sous-statut** affiché en texte sous le badge si présent (`Typography caption`)
- **Tri** activé sur cette colonne (mapping vers le tri `status` déjà supporté côté serveur)
- Position : entre "Adresse du logement" et "Actions"

Aucun changement côté serveur nécessaire : `status` et `subStatus` sont déjà retournés par l'API housing, et le tri par `status` était déjà implémenté dans `housingSortQuery()`.

## Test plan

- [ ] Ouvrir une campagne en statut "Envoyée" (in-progress)
- [ ] Vérifier l'affichage de la colonne "Statut de suivi" avec les badges colorés
- [ ] Vérifier l'affichage du sous-statut en texte sous le badge pour les logements qui en ont un
- [ ] Cliquer sur l'en-tête de colonne → tri croissant (Non suivi en premier)
- [ ] Re-cliquer → tri décroissant (Bloqué en premier)
- [ ] Vérifier que le tri par "Destinataire principal" fonctionne toujours

🤖 Generated with [Claude Code](https://claude.com/claude-code)