### PR TITLE
feat(frontend): switch to table view when clicking group button from map

### DIFF
--- a/frontend/src/views/HousingList/HousingListView.tsx
+++ b/frontend/src/views/HousingList/HousingListView.tsx
@@ -18,7 +18,7 @@ import { useDocumentTitle } from '~/hooks/useDocumentTitle';
 import { useFilters } from '~/hooks/useFilters';
 import { useNotification } from '~/hooks/useNotification';
 import { useSelection } from '~/hooks/useSelection';
-import { useAppSelector } from '~/hooks/useStore';
+import { useAppDispatch, useAppSelector } from '~/hooks/useStore';
 import { useUser } from '~/hooks/useUser';
 import type { Housing } from '~/models/Housing';
 import {
@@ -26,6 +26,7 @@ import {
   useCreateGroupMutation
 } from '~/services/group.service';
 import { useCountHousingQuery } from '~/services/housing.service';
+import housingSlice from '~/store/reducers/housingReducer';
 import HousingListMap from './HousingListMap';
 import HousingListTabs from './HousingListTabs';
 import { useHousingListTabs } from './HousingListTabsProvider';
@@ -47,6 +48,8 @@ const HousingListView = () => {
     storage: 'store'
   });
 
+  const dispatch = useAppDispatch();
+  const { changeView } = housingSlice.actions;
   const { view } = useAppSelector((state) => state.housing);
 
   const searchWithQuery = (query: string) => {
@@ -203,6 +206,9 @@ const HousingListView = () => {
                           setShowExportAlert(false);
                         }
                       } else {
+                        if (view === 'map') {
+                          dispatch(changeView('list'));
+                        }
                         setShowExportAlert(true);
                       }
                     }}


### PR DESCRIPTION
## Contexte

Sur la page **Parc de logements**, il est impossible de sélectionner des logements depuis la vue Carte. Pourtant, le bouton \"Intégrer dans un groupe\" y était accessible et affichait simplement l'alerte \"Aucun logement sélectionné\" sans changer de vue — laissant l'utilisateur bloqué sur la carte sans pouvoir agir.

## Changement

Lorsque l'utilisateur clique sur **\"Intégrer dans un groupe\"** depuis la vue **Carte** sans avoir sélectionné de logements, il est maintenant automatiquement redirigé vers la vue **Tableau**, où l'alerte \"Aucun logement sélectionné\" s'affiche. L'utilisateur peut alors sélectionner des logements et relancer l'action.

Le comportement est inchangé si :
- des logements sont déjà sélectionnés (la modale s'ouvre directement)
- l'utilisateur est déjà sur le Tableau (l'alerte s'affiche sans changement de vue)

## Fichier modifié

`frontend/src/views/HousingList/HousingListView.tsx` — handler du bouton \"Intégrer dans un groupe\"

## Test

1. Se connecter sur l'app
2. Aller sur \"Parc de logements\"
3. Basculer en vue **Carte**
4. Cliquer sur **\"Intégrer dans un groupe\"**
5. ✅ La vue bascule automatiquement sur le **Tableau** avec l'alerte bleue \"Aucun logement sélectionné\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)