### PR TITLE
fix(frontend): apply only campaign filter when navigating to housing list

### DIFF
--- a/frontend/src/views/Campaign/CampaignView.tsx
+++ b/frontend/src/views/Campaign/CampaignView.tsx
@@ -27,9 +27,7 @@ import {
   useUpdateCampaignMutation
 } from '~/services/campaign.service';
 import { useCountHousingQuery } from '~/services/housing.service';
-import housingSlice, {
-  initialHousingFilters
-} from '~/store/reducers/housingReducer';
+import housingSlice from '~/store/reducers/housingReducer';
 
 const campaignDeleteModal = createCampaignDeleteModal();
 const sentAtModal = createCampaignSentAtModal();

--- a/frontend/src/views/Campaign/CampaignView.tsx
+++ b/frontend/src/views/Campaign/CampaignView.tsx
@@ -127,7 +127,6 @@ function CampaignView() {
                   onClick: () => {
                     dispatch(
                       housingSlice.actions.changeFilters({
-                        ...initialHousingFilters,
                         campaignIds: [campaign.id]
                       })
                     );


### PR DESCRIPTION
## Summary

- When clicking "Voir les logements" from a campaign detail page, the housing filter was reset to initial values (including `dataFileYearsIncluded: ['lovac-2025']`) **before** applying the campaign filter — resulting in a non-exclusive campaign view with the LOVAC year filter unintentionally active
- Fixed by dispatching only `{ campaignIds: [id] }` to `changeFilters`, without spreading `initialHousingFilters`
- The housing list now shows **exclusively** the housings belonging to the campaign, with no extra LOVAC or other filters active

## Root cause

`changeFilters` performs a full replacement of the filter state. The previous code was:

```ts
dispatch(housingSlice.actions.changeFilters({
  ...initialHousingFilters,   // ← spread dataFileYearsIncluded: ['lovac-2025'] etc.
  campaignIds: [id as string]
}));
```

This unintentionally activated the default LOVAC year filter alongside the campaign filter, reducing the result set incorrectly.

## Fix

```ts
dispatch(housingSlice.actions.changeFilters({
  campaignIds: [id as string]   // ← only campaign filter, nothing else
}));
```

## Dependencies

⚠️ This branch is based on #1797 — it includes those commits as well.

## Test plan

- [ ] Open a campaign detail page
- [ ] Click "Voir les logements"
- [ ] Verify the housing list shows only housings for that campaign (no LOVAC year filter active in the filter panel)
- [ ] Verify filter chips show only the campaign filter, not any year/data-file filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)