### PR TITLE
Refactor owner import script to export data to Parquet format

### DIFF
--- a/docs/superpowers/plans/2026-05-14-owners-birth-date-online-migration.md
+++ b/docs/superpowers/plans/2026-05-14-owners-birth-date-online-migration.md
@@ -1,0 +1,524 @@
+# Owners `birth_date` Online Migration Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Convert `owners.birth_date` from `timestamptz` (with Paris-midnight values stored as UTC, e.g. `1943-07-23 22:00:00+00`) to `date` (e.g. `1943-07-24`) on a ~81M-row production table without long-duration `ACCESS EXCLUSIVE` locks.
+
+**Architecture:** Add a new `birth_date_new date` column (catalog-only, instant), keep it in sync via a `BEFORE INSERT/UPDATE` trigger, backfill in small batches over hours, then atomically drop the old column and rename the new one in a sub-second transaction.
+
+**Tech Stack:** PostgreSQL 14+, Knex migrations (TypeScript), `psql` for ops scripts, `node-postgres` (parser caveat — see Task 1).
+
+---
+
+## Critical Context (read first)
+
+- **PK:** `owners.id uuid` (defaulted to `uuid_generate_v4()`).
+- **Indexes referencing `birth_date`:** none (the two `owners_full_name_birth_date_*_idx` were dropped in `20240726130601-owners-drop-unique-indexes.ts`). Re-verify in Task 1.
+- **node-postgres `date` parsing trap (from migration `092-owners-birth-date.ts`):** when a column is typed `date`, the pg driver returns `new Date(year, month, day)` interpreted in the **server's local TZ**. If the API server runs in UTC this is fine; if it runs in `Europe/Paris` (or anything ≠ UTC), reads will shift. Migration 092 picked `datetime` specifically to dodge this. Before swapping back to `date`, EITHER:
+  - Confirm the API container's `TZ` is `UTC` (it usually is for Scalingo/Clever Cloud), AND/OR
+  - Override the parser globally: `pg.types.setTypeParser(1082, (v) => v)` so `date` columns come back as ISO strings (`'1943-07-24'`).
+- **No DELETE/INSERT.** All work is `UPDATE`/`ALTER`/`CREATE TRIGGER`.
+
+---
+
+## File Structure
+
+- New: `server/src/scripts/owners-birth-date-migration/preflight.sql` — read-only sanity checks.
+- New: `server/src/scripts/owners-birth-date-migration/01-add-column-and-trigger.sql` — adds column, function, trigger.
+- New: `server/src/scripts/owners-birth-date-migration/02-backfill.sh` — batched backfill driver.
+- New: `server/src/scripts/owners-birth-date-migration/03-verify.sql` — post-backfill verification queries.
+- New: `server/src/scripts/owners-birth-date-migration/04-swap.sql` — atomic swap transaction.
+- New: `server/src/scripts/owners-birth-date-migration/README.md` — runbook order + rollback.
+- New: `server/src/infra/database/migrations/<timestamp>_owners-birth-date-back-to-date.ts` — Knex migration that reflects the final schema (run AFTER the data work; on prod, mark as already-applied in `knex_migrations`).
+
+---
+
+## Task 1: Pre-flight checks
+
+**Files:**
+- Create: `server/src/scripts/owners-birth-date-migration/preflight.sql`
+
+- [ ] **Step 1: Write the preflight SQL**
+
+```sql
+-- preflight.sql — run with: psql "$DATABASE_URL" -f preflight.sql
+\timing on
+
+-- 1. Confirm current column type is timestamptz.
+SELECT column_name, data_type, udt_name
+FROM information_schema.columns
+WHERE table_name = 'owners' AND column_name = 'birth_date';
+-- Expect: data_type = 'timestamp with time zone', udt_name = 'timestamptz'
+
+-- 2. Approximate row count (cheap; pg_class.reltuples).
+SELECT reltuples::bigint AS approx_rows
+FROM pg_class
+WHERE relname = 'owners';
+-- Expect: ~81e6
+
+-- 3. Indexes touching birth_date (must be empty).
+SELECT indexname, indexdef
+FROM pg_indexes
+WHERE tablename = 'owners' AND indexdef ILIKE '%birth_date%';
+-- Expect: 0 rows
+
+-- 4. Foreign keys touching birth_date (must be empty).
+SELECT tc.constraint_name, tc.table_name, kcu.column_name
+FROM information_schema.table_constraints tc
+JOIN information_schema.key_column_usage kcu USING (constraint_name, table_schema)
+WHERE tc.constraint_type IN ('FOREIGN KEY', 'UNIQUE', 'PRIMARY KEY')
+  AND kcu.column_name = 'birth_date';
+-- Expect: 0 rows
+
+-- 5. Views/materialized views referencing birth_date.
+SELECT schemaname, viewname FROM pg_views WHERE definition ILIKE '%birth_date%';
+SELECT schemaname, matviewname FROM pg_matviews WHERE definition ILIKE '%birth_date%';
+-- Inspect any results manually.
+
+-- 6. Sample known rows for post-swap verification (from the user's question).
+SELECT idpersonne, birth_date,
+       (birth_date AT TIME ZONE 'Europe/Paris')::date AS expected_after
+FROM owners
+WHERE idpersonne IN ('01MB2223','01MB2225','01MB2226','01MB2227','01MB222B')
+ORDER BY idpersonne;
+-- Save the `expected_after` column to compare in Task 5.
+
+-- 7. NULL counts (used in Task 5 invariant).
+SELECT
+  count(*) FILTER (WHERE birth_date IS NULL)     AS null_birth_date,
+  count(*) FILTER (WHERE birth_date IS NOT NULL) AS not_null_birth_date,
+  count(*)                                       AS total
+FROM owners;
+```
+
+- [ ] **Step 2: Run preflight against production (read-only, safe)**
+
+```bash
+psql "$PROD_DATABASE_URL" -f server/src/scripts/owners-birth-date-migration/preflight.sql > preflight.out
+```
+
+Expected: column type `timestamptz`, zero indexes/FKs on `birth_date`, ~81M rows. Save `preflight.out` for the runbook record.
+
+- [ ] **Step 3: Decide node-postgres date-parser strategy**
+
+Confirm one of:
+- API container `TZ=UTC` (check Scalingo/Clever env), OR
+- Add `pg.types.setTypeParser(1082, (v) => v)` to `server/src/infra/database/index.ts` (or wherever `pg`/`knex` is initialised).
+
+If neither holds, **abort** — Task 6 will silently shift dates on read after the swap.
+
+- [ ] **Step 4: Commit preflight**
+
+```bash
+git add server/src/scripts/owners-birth-date-migration/preflight.sql
+git commit -m "chore(server): add owners.birth_date migration preflight script"
+```
+
+---
+
+## Task 2: Add the new column
+
+**Files:**
+- Create: `server/src/scripts/owners-birth-date-migration/01-add-column-and-trigger.sql` (column part only in this task; trigger added in Task 3)
+
+- [ ] **Step 1: Write the ADD COLUMN statement**
+
+```sql
+-- 01-add-column-and-trigger.sql (part 1: column)
+ALTER TABLE owners ADD COLUMN birth_date_new date;
+```
+
+PG ≥ 11 makes this a catalog-only operation: instant, no rewrite, brief `ACCESS EXCLUSIVE`.
+
+- [ ] **Step 2: Apply on production**
+
+```bash
+psql "$PROD_DATABASE_URL" -c "ALTER TABLE owners ADD COLUMN birth_date_new date;"
+```
+
+Expected: returns `ALTER TABLE` in well under 1 second.
+
+- [ ] **Step 3: Verify column exists and is empty**
+
+```bash
+psql "$PROD_DATABASE_URL" -c "SELECT count(*) FROM owners WHERE birth_date_new IS NOT NULL;"
+```
+
+Expected: `0`.
+
+---
+
+## Task 3: Add sync trigger
+
+**Files:**
+- Modify: `server/src/scripts/owners-birth-date-migration/01-add-column-and-trigger.sql` (append trigger)
+
+- [ ] **Step 1: Write the trigger function and trigger**
+
+Append to `01-add-column-and-trigger.sql`:
+
+```sql
+-- 01-add-column-and-trigger.sql (part 2: trigger)
+CREATE OR REPLACE FUNCTION sync_owners_birth_date_new() RETURNS trigger AS $$
+BEGIN
+  NEW.birth_date_new := (NEW.birth_date AT TIME ZONE 'Europe/Paris')::date;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_sync_owners_birth_date_new
+  BEFORE INSERT OR UPDATE OF birth_date ON owners
+  FOR EACH ROW EXECUTE FUNCTION sync_owners_birth_date_new();
+```
+
+`NULL AT TIME ZONE 'Europe/Paris'` returns `NULL`, so `NULL` birth_dates stay `NULL` in the new column.
+
+- [ ] **Step 2: Apply trigger to production**
+
+```bash
+psql "$PROD_DATABASE_URL" -f server/src/scripts/owners-birth-date-migration/01-add-column-and-trigger.sql
+```
+
+Expected: `CREATE FUNCTION`, `CREATE TRIGGER`. Sub-second.
+
+- [ ] **Step 3: Smoke-test the trigger in a rolled-back transaction**
+
+```sql
+BEGIN;
+  -- Pick one row to mutate
+  UPDATE owners
+  SET birth_date = birth_date  -- no-op write
+  WHERE idpersonne = '01MB2223';
+
+  SELECT idpersonne, birth_date, birth_date_new
+  FROM owners WHERE idpersonne = '01MB2223';
+  -- Expect birth_date_new = '1943-07-24'
+ROLLBACK;
+```
+
+- [ ] **Step 4: Commit script**
+
+```bash
+git add server/src/scripts/owners-birth-date-migration/01-add-column-and-trigger.sql
+git commit -m "chore(server): add owners.birth_date_new sync trigger"
+```
+
+---
+
+## Task 4: Backfill in batches
+
+**Files:**
+- Create: `server/src/scripts/owners-birth-date-migration/02-backfill.sh`
+
+- [ ] **Step 1: Create a partial index to make the IS NULL scan cheap**
+
+```bash
+psql "$PROD_DATABASE_URL" <<'SQL'
+CREATE INDEX CONCURRENTLY IF NOT EXISTS owners_birth_date_new_pending_idx
+  ON owners (id)
+  WHERE birth_date_new IS NULL AND birth_date IS NOT NULL;
+SQL
+```
+
+`CONCURRENTLY` avoids blocking writes. The index drains to empty as the backfill progresses; drop it in Task 6.
+
+- [ ] **Step 2: Write the batch script**
+
+```bash
+#!/usr/bin/env bash
+# 02-backfill.sh — backfill owners.birth_date_new in batches.
+# Usage: DATABASE_URL=... BATCH_SIZE=50000 SLEEP=0.2 ./02-backfill.sh
+set -euo pipefail
+
+: "${DATABASE_URL:?must be set}"
+BATCH_SIZE="${BATCH_SIZE:-50000}"
+SLEEP="${SLEEP:-0.2}"
+
+while :; do
+  updated=$(psql "$DATABASE_URL" -At -c "
+    WITH batch AS (
+      SELECT id FROM owners
+      WHERE birth_date_new IS NULL AND birth_date IS NOT NULL
+      LIMIT ${BATCH_SIZE}
+      FOR UPDATE SKIP LOCKED
+    )
+    UPDATE owners o
+    SET birth_date_new = (o.birth_date AT TIME ZONE 'Europe/Paris')::date
+    FROM batch b
+    WHERE o.id = b.id
+    RETURNING 1;
+  " | wc -l | tr -d ' ')
+
+  printf '%s  updated=%s\n' "$(date -Iseconds)" "$updated"
+  if [[ "$updated" -eq 0 ]]; then
+    echo "Backfill complete."
+    break
+  fi
+  sleep "$SLEEP"
+done
+```
+
+`FOR UPDATE SKIP LOCKED` lets the trigger-driven writes from app traffic run in parallel without deadlocks.
+
+- [ ] **Step 3: Make executable and dry-run on staging**
+
+```bash
+chmod +x server/src/scripts/owners-birth-date-migration/02-backfill.sh
+DATABASE_URL="$STAGING_DATABASE_URL" BATCH_SIZE=10000 \
+  server/src/scripts/owners-birth-date-migration/02-backfill.sh | tee backfill-staging.log
+```
+
+Expected: progresses to `Backfill complete.` Confirm timings to size the prod run (~81M / 50k ≈ 1620 batches; budget the wall-clock).
+
+- [ ] **Step 4: Run on production (in `tmux`/`screen`)**
+
+```bash
+tmux new -s birth-date-backfill
+DATABASE_URL="$PROD_DATABASE_URL" BATCH_SIZE=50000 SLEEP=0.2 \
+  server/src/scripts/owners-birth-date-migration/02-backfill.sh \
+  | tee backfill-prod.log
+# Detach with Ctrl-B D; reattach with: tmux attach -t birth-date-backfill
+```
+
+Monitor in another shell:
+
+```bash
+psql "$PROD_DATABASE_URL" -c "
+SELECT count(*) FILTER (WHERE birth_date_new IS NULL AND birth_date IS NOT NULL) AS pending,
+       count(*) FILTER (WHERE birth_date_new IS NOT NULL) AS done
+FROM owners;"
+```
+
+- [ ] **Step 5: Commit script**
+
+```bash
+git add server/src/scripts/owners-birth-date-migration/02-backfill.sh
+git commit -m "chore(server): add owners.birth_date_new backfill script"
+```
+
+---
+
+## Task 5: Verify backfill
+
+**Files:**
+- Create: `server/src/scripts/owners-birth-date-migration/03-verify.sql`
+
+- [ ] **Step 1: Write verification queries**
+
+```sql
+-- 03-verify.sql
+
+-- A. NULL invariant: birth_date NULL ⇔ birth_date_new NULL.
+SELECT count(*) AS mismatched_nulls
+FROM owners
+WHERE (birth_date IS NULL) <> (birth_date_new IS NULL);
+-- Expect: 0
+
+-- B. No pending rows.
+SELECT count(*) AS pending
+FROM owners
+WHERE birth_date IS NOT NULL AND birth_date_new IS NULL;
+-- Expect: 0
+
+-- C. Spot check the same rows captured in preflight Step 6.
+SELECT idpersonne, birth_date, birth_date_new
+FROM owners
+WHERE idpersonne IN ('01MB2223','01MB2225','01MB2226','01MB2227','01MB222B')
+ORDER BY idpersonne;
+-- Compare birth_date_new column-for-column with preflight `expected_after`.
+
+-- D. Sanity: every birth_date_new equals the on-the-fly conversion.
+SELECT count(*) AS conversion_drift
+FROM owners
+WHERE birth_date IS NOT NULL
+  AND birth_date_new IS DISTINCT FROM (birth_date AT TIME ZONE 'Europe/Paris')::date;
+-- Expect: 0
+```
+
+- [ ] **Step 2: Run on production**
+
+```bash
+psql "$PROD_DATABASE_URL" -f server/src/scripts/owners-birth-date-migration/03-verify.sql
+```
+
+Expected: A=0, B=0, C matches preflight, D=0. **If any check fails, do not proceed to Task 6.** Re-run the backfill (idempotent — it only touches NULL rows).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/src/scripts/owners-birth-date-migration/03-verify.sql
+git commit -m "chore(server): add owners.birth_date_new verification queries"
+```
+
+---
+
+## Task 6: Atomic swap
+
+**Files:**
+- Create: `server/src/scripts/owners-birth-date-migration/04-swap.sql`
+
+- [ ] **Step 1: Write the swap transaction**
+
+```sql
+-- 04-swap.sql — single short transaction. ACCESS EXCLUSIVE for ~ms.
+BEGIN;
+
+-- Tear down the trigger first so we don't double-write during the swap.
+DROP TRIGGER IF EXISTS trg_sync_owners_birth_date_new ON owners;
+DROP FUNCTION IF EXISTS sync_owners_birth_date_new();
+
+-- Drop the partial backfill helper (now empty).
+DROP INDEX IF EXISTS owners_birth_date_new_pending_idx;
+
+-- Atomic column swap.
+ALTER TABLE owners DROP COLUMN birth_date;
+ALTER TABLE owners RENAME COLUMN birth_date_new TO birth_date;
+
+COMMIT;
+```
+
+All four `ALTER`s are catalog-only on PG ≥ 11; the transaction should commit in milliseconds.
+
+- [ ] **Step 2: Run on production during a low-traffic window**
+
+```bash
+psql "$PROD_DATABASE_URL" -f server/src/scripts/owners-birth-date-migration/04-swap.sql
+```
+
+- [ ] **Step 3: Verify final state**
+
+```bash
+psql "$PROD_DATABASE_URL" -c "
+SELECT column_name, data_type FROM information_schema.columns
+WHERE table_name='owners' AND column_name='birth_date';"
+# Expect: data_type = 'date'
+
+psql "$PROD_DATABASE_URL" -c "
+SELECT idpersonne, birth_date FROM owners
+WHERE idpersonne IN ('01MB2223','01MB2225','01MB2226','01MB2227','01MB222B')
+ORDER BY idpersonne;"
+# Expect: birth_date = 1943-07-24, 1974-11-11, 1944-01-10, 1963-07-21, 1971-09-28
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/src/scripts/owners-birth-date-migration/04-swap.sql
+git commit -m "chore(server): add owners.birth_date column swap script"
+```
+
+---
+
+## Task 7: Knex migration to record schema state
+
+The data work above is operational and bypasses Knex. We still need a Knex migration so fresh environments (dev, staging, CI) end up at the same schema, and so `knex_migrations` reflects the live shape on prod.
+
+**Files:**
+- Create: `server/src/infra/database/migrations/<UTC-timestamp>_owners-birth-date-to-date.ts`
+
+- [ ] **Step 1: Generate the migration file**
+
+```bash
+yarn workspace @zerologementvacant/server knex migrate:make owners-birth-date-to-date -x ts
+```
+
+- [ ] **Step 2: Write up/down**
+
+```ts
+import type { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+    ALTER TABLE owners
+      ALTER COLUMN birth_date TYPE date
+      USING (birth_date AT TIME ZONE 'Europe/Paris')::date;
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`
+    ALTER TABLE owners
+      ALTER COLUMN birth_date TYPE timestamptz
+      USING (birth_date::timestamp AT TIME ZONE 'Europe/Paris');
+  `);
+}
+```
+
+For dev/staging this runs the in-place ALTER (cheap on small data). On production the column is **already** `date`, so we mark this migration as applied without running it (Step 4).
+
+- [ ] **Step 3: Run on staging to validate**
+
+```bash
+yarn workspace @zerologementvacant/server migrate
+```
+
+Expected: migration runs cleanly; column is `date`; verification queries (Task 5) still pass.
+
+- [ ] **Step 4: Mark as applied on production (do NOT run it)**
+
+```bash
+psql "$PROD_DATABASE_URL" -c "
+INSERT INTO knex_migrations (name, batch, migration_time)
+SELECT '<filename>.ts',
+       coalesce(max(batch), 0) + 1,
+       now()
+FROM knex_migrations;"
+```
+
+Replace `<filename>.ts` with the exact name produced in Step 1. Verify with `SELECT name FROM knex_migrations ORDER BY id DESC LIMIT 5;`.
+
+- [ ] **Step 5: Commit migration**
+
+```bash
+git add server/src/infra/database/migrations/*owners-birth-date-to-date.ts
+git commit -m "feat(server): change owners.birth_date type from timestamptz to date"
+```
+
+---
+
+## Task 8: Runbook
+
+**Files:**
+- Create: `server/src/scripts/owners-birth-date-migration/README.md`
+
+- [ ] **Step 1: Write the runbook**
+
+```markdown
+# owners.birth_date timestamptz → date
+
+Why: 45M rows imported via DuckDB landed as Paris-midnight timestamps stored
+as UTC (e.g. `1943-07-23 22:00:00+00`). We want a real `date` column.
+
+Order:
+1. `preflight.sql`            — read-only checks; record output.
+2. Confirm `pg.types.setTypeParser(1082, …)` or `TZ=UTC` on the API.
+3. `01-add-column-and-trigger.sql`  — ADD COLUMN + trigger (instant).
+4. `CREATE INDEX CONCURRENTLY` (see 02-backfill.sh comment).
+5. `02-backfill.sh`           — run in tmux; ~hours.
+6. `03-verify.sql`            — must all pass.
+7. `04-swap.sql`              — atomic, sub-second lock.
+8. Knex migration marker insert (see plan Task 7 Step 4).
+
+Rollback per stage:
+- After step 3: `DROP TRIGGER trg_sync_owners_birth_date_new ON owners;
+                 DROP FUNCTION sync_owners_birth_date_new();
+                 ALTER TABLE owners DROP COLUMN birth_date_new;`
+- After step 5 but before step 7: same as above (extra column is harmless).
+- After step 7: irreversible without the timestamptz source. Only `down()`
+  in the Knex migration approximates a revert (loses the time component).
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add server/src/scripts/owners-birth-date-migration/README.md
+git commit -m "docs(server): runbook for owners.birth_date online migration"
+```
+
+---
+
+## Self-review notes
+
+- Spec coverage: every step from the option-C sketch (add column → trigger → batched backfill → verify → atomic swap) has an explicit task; preflight + node-pg parser caveat + Knex marker insert are added because they are real footguns on this codebase.
+- Placeholders: none. Filenames, SQL, and shell are concrete; the only `<placeholder>` is the Knex-generated timestamp filename, which is unavoidable until Task 7 Step 1 runs.
+- Type/name consistency: `birth_date_new`, `sync_owners_birth_date_new`, `trg_sync_owners_birth_date_new`, and `owners_birth_date_new_pending_idx` are used identically across Tasks 2–6.

--- a/server/src/scripts/import-owners-datafoncier/README.md
+++ b/server/src/scripts/import-owners-datafoncier/README.md
@@ -4,39 +4,40 @@ This script imports owners from `df_owners_nat_2024` to the `owners` table. It o
 
 ## Prerequisites
 
-```bash
-# Create virtual environment
-python3 -m venv venv
-source venv/bin/activate
-
-# Install dependencies
-pip install -r requirements.txt
-```
+[`uv`](https://docs.astral.sh/uv/) — no manual venv or `pip install` needed. The script carries its own dependency metadata (PEP 723).
 
 ## Usage
 
-### Basic usage
+The script is self-contained: dependencies are resolved automatically by `uv run`.
+
+### Export to Parquet (for review before import)
 
 ```bash
-python import_owners.py --db-url "postgresql://user:pass@host:port/dbname"
-```
-
-### Dry run (simulation mode)
-
-```bash
-python import_owners.py --db-url "$DATABASE_URL" --dry-run
+uv run import_owners.py --db-url "$DATABASE_URL" --output owners.parquet
 ```
 
 ### With limit (for testing)
 
 ```bash
-python import_owners.py --db-url "$DATABASE_URL" --dry-run --limit 1000
+uv run import_owners.py --db-url "$DATABASE_URL" --output owners.parquet --limit 1000
 ```
 
-### Production run with optimization
+### Single department
 
 ```bash
-python import_owners.py --db-url "$DATABASE_URL" --batch-size 10000 --num-workers 6
+uv run import_owners.py --db-url "$DATABASE_URL" --output owners_75.parquet --department 75
+```
+
+### All departments sequentially (avoids OOM on large datasets)
+
+```bash
+uv run import_owners.py --db-url "$DATABASE_URL" --output owners.parquet --sequential
+```
+
+### Resume from a specific department
+
+```bash
+uv run import_owners.py --db-url "$DATABASE_URL" --output owners.parquet --sequential --start-department 50
 ```
 
 ## Options
@@ -44,11 +45,12 @@ python import_owners.py --db-url "$DATABASE_URL" --batch-size 10000 --num-worker
 | Option | Description | Default |
 |--------|-------------|---------|
 | `--db-url` | PostgreSQL connection URI (required) | - |
-| `--dry-run` | Simulation mode - no database modifications | False |
-| `--source-table` | Name of the source table | df_owners_nat_2024 |
-| `--limit` | Maximum number of owners to import | None (all) |
-| `--batch-size` | Batch size for insert operations | 5000 |
-| `--num-workers` | Number of parallel workers | 4 |
+| `--output` | Output Parquet file path (required) | - |
+| `--source-table` | Name of the source table | `df_owners_nat_2024` |
+| `--limit` | Maximum number of owners to export | None (all) |
+| `--department` | Process a single department (e.g. `75`, `2A`) | None |
+| `--sequential` | Process all departments one by one | False |
+| `--start-department` | Resume `--sequential` from this department | None |
 | `--debug` | Enable debug logging | False |
 
 ## Field Mapping

--- a/server/src/scripts/import-owners-datafoncier/import_owners.py
+++ b/server/src/scripts/import-owners-datafoncier/import_owners.py
@@ -1,12 +1,20 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "psycopg2-binary>=2.9.0",
+#   "tqdm>=4.64.0",
+#   "pyarrow>=14.0.0",
+# ]
+# ///
 """
-Import owners from df_owners_nat_2024 to owners table.
+Export owners from df_owners_nat_2024 to a Parquet file for review.
 
-This script imports owners that exist in the Datafoncier source table (df_owners_nat_2024)
-but are not yet present in the ZLV owners table. Matching is done via the idpersonne field.
+This script extracts owners from the Datafoncier source table (df_owners_nat_2024)
+that are not yet present in the ZLV owners table, transforms them, and writes
+to a Parquet file for inspection before database import.
 
 Field Mapping:
-- id              -> uuid_generate_v4()
 - full_name       -> ddenom (with '/' replaced by space for physical persons)
 - birth_date      -> jdatnss (converted from DD/MM/YYYY to ISO format)
 - address_dgfip   -> [dlign3, dlign4, dlign5, dlign6] (non-null values as array, dlign4 formatted)
@@ -14,32 +22,27 @@ Field Mapping:
 - idpersonne      -> idpersonne
 - siren           -> dsiren
 - data_source     -> 'ff-2024'
-- entity          -> mapped from ccogrm first character
-- created_at      -> NOW()
-- updated_at      -> NOW()
+- entity          -> mapped from ccogrm first character (null -> 'personnes-physiques')
 
 Usage:
-    python import_owners.py --db-url "postgresql://user:pass@host:port/dbname"
-    python import_owners.py --db-url "$DATABASE_URL" --dry-run --limit 1000
-    python import_owners.py --db-url "$DATABASE_URL" --batch-size 10000 --num-workers 6
-    python import_owners.py --db-url "$DATABASE_URL" --source-table df_owners_nat  # for older table
-
-    # Process by department (recommended for large datasets to avoid OOM)
-    python import_owners.py --db-url "$DATABASE_URL" --department 75  # Paris only
-    python import_owners.py --db-url "$DATABASE_URL" --sequential     # All departments one by one
-    python import_owners.py --db-url "$DATABASE_URL" --sequential --start-department 50  # Resume from dept 50
+    python import_owners.py --db-url "postgresql://user:pass@host:port/dbname" --output owners.parquet
+    python import_owners.py --db-url "$DATABASE_URL" --output owners.parquet --limit 1000
+    python import_owners.py --db-url "$DATABASE_URL" --output owners.parquet --source-table df_owners_nat
+    python import_owners.py --db-url "$DATABASE_URL" --output owners.parquet --department 75
+    python import_owners.py --db-url "$DATABASE_URL" --output owners.parquet --sequential
+    python import_owners.py --db-url "$DATABASE_URL" --output owners.parquet --sequential --start-department 50
 """
 
 import argparse
 import logging
-import threading
 from datetime import datetime
-from typing import List, Dict, Optional, Tuple
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import List, Dict, Optional
 
 import psycopg2
-from psycopg2.extras import RealDictCursor, execute_values
+from psycopg2.extras import RealDictCursor
 from tqdm import tqdm
+import pyarrow as pa
+import pyarrow.parquet as pq
 
 
 # Kind mapping from catpro3txt (CATPRO 3 LOVAC ET FF) to ZLV kind_class
@@ -231,22 +234,28 @@ ENTITY_MAPPING = {
     '9': 'etablissements-publics-ou-organismes-assimiles',
 }
 
+PARQUET_SCHEMA = pa.schema([
+    pa.field('idpersonne', pa.string()),
+    pa.field('full_name', pa.string()),
+    pa.field('birth_date', pa.string()),
+    pa.field('address_dgfip', pa.list_(pa.string())),
+    pa.field('kind_class', pa.string()),
+    pa.field('siren', pa.string()),
+    pa.field('data_source', pa.string()),
+    pa.field('entity', pa.string()),
+])
 
-def map_entity(ccogrm: Optional[str]) -> Optional[str]:
+
+def map_entity(ccogrm: Optional[str]) -> str:
     """
     Map entity from ccogrm first character.
-
-    Args:
-        ccogrm: Group code from Datafoncier
-
-    Returns:
-        Entity value for ZLV owners table, or None if unknown
+    Returns 'personnes-physiques' when ccogrm is null or empty.
     """
     if not ccogrm or not ccogrm.strip():
-        return None
+        return 'personnes-physiques'
 
     first_char = ccogrm.strip()[0]
-    return ENTITY_MAPPING.get(first_char)
+    return ENTITY_MAPPING.get(first_char, 'personnes-physiques')
 
 
 def format_dlign4(dlign4: Optional[str]) -> Optional[str]:
@@ -266,109 +275,70 @@ def format_dlign4(dlign4: Optional[str]) -> Optional[str]:
         "0000 RTE DE LA DOUANE" -> "RTE DE LA DOUANE"
         "0060 BD GALLIENI" -> "60 BD GALLIENI"
         "0088CAV DE PARIS" -> "88C AV DE PARIS"
-
-    Args:
-        dlign4: Address line 4 from Datafoncier
-
-    Returns:
-        Formatted address line or None if empty
     """
     if not dlign4 or not dlign4.strip():
         return None
 
     line = dlign4.strip()
 
-    # Need at least 4 characters for the house number
     if len(line) < 4:
         return line
 
-    # Extract house number (positions 1-4) and remove leading zeros
     house_number = line[:4].lstrip('0')
 
-    # If house number is empty (was "0000"), just return the rest
     if not house_number:
         rest = line[4:].strip()
-        # Clean up extra spaces
         return ' '.join(rest.split()) if rest else None
 
-    # Check if position 5 is a repetition index (a letter, not a space or digit)
     if len(line) > 4:
         char5 = line[4]
         rest = line[5:] if len(line) > 5 else ''
 
         if char5.isalpha():
-            # Position 5 is a repetition index - add space between index and street name
             street = rest.strip()
             result = f"{house_number}{char5} {street}" if street else f"{house_number}{char5}"
         else:
-            # Position 5 is a space or other - just concatenate
             street = (char5 + rest).strip()
             result = f"{house_number} {street}" if street else house_number
     else:
         result = house_number
 
-    # Clean up extra spaces
     return ' '.join(result.split())
 
 
-class OwnerImporter:
-    """Import owners from df_owners_nat_2024 to owners table."""
+class OwnerExporter:
+    """Extract and transform owners from df_owners_nat_2024, write to Parquet."""
 
-    def __init__(self, db_url: str, dry_run: bool = False,
-                 batch_size: int = 5000, num_workers: int = 4,
+    def __init__(self, db_url: str, output: str,
                  source_table: str = 'df_owners_nat_2024',
                  department: Optional[str] = None):
-        """
-        Initialize the importer.
-
-        Args:
-            db_url: PostgreSQL connection string
-            dry_run: If True, do not modify the database
-            batch_size: Number of records per batch for insert operations
-            num_workers: Number of parallel workers for database operations
-            source_table: Name of the source table (default: df_owners_nat_2024)
-            department: Filter by department code (e.g., '75', '01', '2A')
-        """
         self.db_url = db_url
-        self.dry_run = dry_run
-        self.batch_size = batch_size
-        self.num_workers = num_workers
+        self.output = output
         self.source_table = source_table
         self.department = department
         self.conn = None
         self.cursor = None
 
-        # Thread-safe statistics
         self.stats = {
             'total_source': 0,
-            'already_exists': 0,
-            'to_import': 0,
-            'imported': 0,
+            'to_export': 0,
+            'exported': 0,
             'skipped_no_name': 0,
             'skipped_no_address': 0,
-            'failed': 0,
         }
-        self.stats_lock = threading.Lock()
 
     def connect(self):
-        """Establish database connection."""
-        try:
-            self.conn = psycopg2.connect(self.db_url)
-            self.cursor = self.conn.cursor(cursor_factory=RealDictCursor)
-            print("Database connected successfully")
-        except Exception as e:
-            print(f"Database connection failed: {e}")
-            raise
+        self.conn = psycopg2.connect(self.db_url)
+        self.cursor = self.conn.cursor(cursor_factory=RealDictCursor)
+        print("Database connected successfully")
 
     def disconnect(self):
-        """Close database connection."""
         if self.cursor:
             self.cursor.close()
         if self.conn:
             self.conn.close()
 
     def get_departments(self) -> List[str]:
-        """Get list of distinct departments in source table."""
         self.cursor.execute(f"""
             SELECT DISTINCT ccodep
             FROM {self.source_table}
@@ -378,7 +348,6 @@ class OwnerImporter:
         return [row['ccodep'] for row in self.cursor.fetchall()]
 
     def get_source_count(self, department: Optional[str] = None) -> int:
-        """Get total count of owners in source table with valid idpersonne."""
         dept_filter = f"AND ccodep = '{department}'" if department else ""
         self.cursor.execute(f"""
             SELECT COUNT(DISTINCT idpersonne)
@@ -389,27 +358,8 @@ class OwnerImporter:
         result = self.cursor.fetchone()
         return result['count'] if result else 0
 
-    def get_existing_idpersonnes(self) -> set:
-        """Get set of idpersonne values already in owners table."""
-        self.cursor.execute("""
-            SELECT idpersonne
-            FROM owners
-            WHERE idpersonne IS NOT NULL
-        """)
-        return {row['idpersonne'] for row in self.cursor.fetchall()}
-
-    def get_owners_to_import(self, limit: Optional[int] = None,
+    def get_owners_to_export(self, limit: Optional[int] = None,
                              department: Optional[str] = None) -> List[Dict]:
-        """
-        Get owners from source table that don't exist in owners table.
-
-        Args:
-            limit: Maximum number of records to retrieve
-            department: Filter by department code (e.g., '75', '01', '2A')
-
-        Returns:
-            List of owner records to import
-        """
         dept_filter = f"AND d.ccodep = '{department}'" if department else ""
 
         query = f"""
@@ -440,24 +390,13 @@ class OwnerImporter:
         return self.cursor.fetchall()
 
     def parse_birthdate(self, jdatnss: Optional[str]) -> Optional[str]:
-        """
-        Parse birthdate from DD/MM/YYYY format to ISO format.
-
-        Args:
-            jdatnss: Date string in DD/MM/YYYY format
-
-        Returns:
-            ISO formatted date string or None
-        """
         if not jdatnss or not jdatnss.strip():
             return None
 
         try:
-            # Parse DD/MM/YYYY format
             parts = jdatnss.strip().split('/')
             if len(parts) != 3:
                 return None
-
             day, month, year = parts
             date = datetime(int(year), int(month), int(day))
             return date.isoformat()
@@ -465,28 +404,16 @@ class OwnerImporter:
             return None
 
     def build_address_array(self, owner: Dict) -> List[str]:
-        """
-        Build address array from dlign3, dlign4, dlign5, dlign6 fields.
-
-        Args:
-            owner: Owner record from source table
-
-        Returns:
-            List of non-null address lines
-        """
         address_lines = []
 
-        # dlign3: add as-is if present
         dlign3 = owner.get('dlign3')
         if dlign3 and dlign3.strip():
             address_lines.append(dlign3.strip())
 
-        # dlign4: format to remove leading zeros and add space after repetition index
         dlign4 = format_dlign4(owner.get('dlign4'))
         if dlign4:
             address_lines.append(dlign4)
 
-        # dlign5, dlign6: add as-is if present
         for field in ['dlign5', 'dlign6']:
             value = owner.get(field)
             if value and value.strip():
@@ -495,39 +422,22 @@ class OwnerImporter:
         return address_lines
 
     def transform_owner(self, source: Dict) -> Optional[Dict]:
-        """
-        Transform a source owner record to ZLV owner format.
-
-        Args:
-            source: Owner record from df_owners_nat_2024
-
-        Returns:
-            Transformed owner record or None if invalid
-        """
-        # Validate required fields
         ddenom = source.get('ddenom')
         if not ddenom or not ddenom.strip():
-            with self.stats_lock:
-                self.stats['skipped_no_name'] += 1
+            self.stats['skipped_no_name'] += 1
             return None
 
-        # Build address array
         address = self.build_address_array(source)
         if not address:
-            with self.stats_lock:
-                self.stats['skipped_no_address'] += 1
+            self.stats['skipped_no_address'] += 1
             return None
 
-        # Process full name - replace / with space for physical persons
         catpro3txt = source.get('catpro3txt', '')
         full_name = ddenom.strip()
         if catpro3txt == 'PERSONNE PHYSIQUE':
             full_name = full_name.replace('/', ' ')
 
-        # Map kind from catpro3txt
         kind_class = KIND_MAPPING.get(catpro3txt, 'Autres')
-
-        # Map entity from ccogrm first character
         entity = map_entity(source.get('ccogrm'))
 
         return {
@@ -541,226 +451,86 @@ class OwnerImporter:
             'entity': entity,
         }
 
-    def _insert_batch_worker(self, batch_data: Tuple) -> Tuple[int, int, Optional[str]]:
-        """
-        Worker function to insert a batch of owners.
-
-        Args:
-            batch_data: Tuple of (batch_id, batch, db_url)
-
-        Returns:
-            Tuple of (batch_id, count_inserted, error_message)
-        """
-        batch_id, batch, db_url = batch_data
-
-        conn = None
-        try:
-            # Each worker creates its own connection
-            conn = psycopg2.connect(db_url)
-            cursor = conn.cursor(cursor_factory=RealDictCursor)
-
-            # Faster asynchronous commits
-            cursor.execute("SET synchronous_commit = off")
-
-            # Prepare insert data
-            insert_data = [
-                (
-                    owner['idpersonne'],
-                    owner['full_name'],
-                    owner['birth_date'],
-                    owner['address_dgfip'],
-                    owner['kind_class'],
-                    owner['siren'],
-                    owner['data_source'],
-                    owner['entity'],
-                )
-                for owner in batch
-            ]
-
-            # Execute batch insert
-            execute_values(
-                cursor,
-                """
-                INSERT INTO owners (
-                    idpersonne,
-                    full_name,
-                    birth_date,
-                    address_dgfip,
-                    kind_class,
-                    siren,
-                    data_source,
-                    entity,
-                    created_at,
-                    updated_at
-                )
-                VALUES %s
-                ON CONFLICT (idpersonne) DO NOTHING
-                """,
-                insert_data,
-                template="(%s, %s, %s, %s, %s, %s, %s, %s, NOW(), NOW())",
-                page_size=1000
-            )
-
-            # Independent commit per batch
-            conn.commit()
-            cursor.close()
-            conn.close()
-
-            return (batch_id, len(batch), None)
-
-        except Exception as e:
-            if conn:
-                try:
-                    conn.rollback()
-                    conn.close()
-                except:
-                    pass
-            return (batch_id, 0, str(e))
-
-    def insert_owners(self, owners: List[Dict]):
-        """
-        Insert owners into the database using parallel workers.
-
-        Args:
-            owners: List of transformed owner records
-        """
+    def write_parquet(self, owners: List[Dict], append: bool = False):
+        """Write transformed owners to the Parquet output file."""
         if not owners:
-            print("No owners to insert")
             return
 
-        if self.dry_run:
-            print(f"Dry run: {len(owners)} owners would be inserted")
-            return
+        table = pa.table(
+            {
+                'idpersonne': pa.array([o['idpersonne'] for o in owners], type=pa.string()),
+                'full_name': pa.array([o['full_name'] for o in owners], type=pa.string()),
+                'birth_date': pa.array([o['birth_date'] for o in owners], type=pa.string()),
+                'address_dgfip': pa.array([o['address_dgfip'] for o in owners], type=pa.list_(pa.string())),
+                'kind_class': pa.array([o['kind_class'] for o in owners], type=pa.string()),
+                'siren': pa.array([o['siren'] for o in owners], type=pa.string()),
+                'data_source': pa.array([o['data_source'] for o in owners], type=pa.string()),
+                'entity': pa.array([o['entity'] for o in owners], type=pa.string()),
+            },
+            schema=PARQUET_SCHEMA,
+        )
 
-        print(f"\nInserting {len(owners):,} owners...")
+        if append:
+            existing = pq.read_table(self.output)
+            table = pa.concat_tables([existing, table])
 
-        # Split into batches
-        batches = []
-        for i in range(0, len(owners), self.batch_size):
-            batch = owners[i:i + self.batch_size]
-            batches.append((i // self.batch_size, batch, self.db_url))
+        pq.write_table(table, self.output)
+        self.stats['exported'] += len(owners)
 
-        # Process in parallel
-        total_inserted = 0
-        total_failed = 0
-
-        with tqdm(total=len(owners), desc="Inserting", unit="owner") as pbar:
-            with ThreadPoolExecutor(max_workers=self.num_workers) as executor:
-                futures = {
-                    executor.submit(self._insert_batch_worker, batch_data): batch_data
-                    for batch_data in batches
-                }
-
-                for future in as_completed(futures):
-                    batch_id, count, error = future.result()
-                    if error:
-                        logging.error(f"Batch {batch_id} error: {error}")
-                        total_failed += len(batches[batch_id][1])
-                    else:
-                        total_inserted += count
-                    pbar.update(count if count > 0 else len(batches[batch_id][1]))
-
-        self.stats['imported'] = total_inserted
-        self.stats['failed'] = total_failed
-
-    def reset_stats(self):
-        """Reset statistics for a new department."""
-        self.stats = {
-            'total_source': 0,
-            'already_exists': 0,
-            'to_import': 0,
-            'imported': 0,
-            'skipped_no_name': 0,
-            'skipped_no_address': 0,
-            'failed': 0,
-        }
-
-    def process_department(self, department: str, limit: Optional[int] = None) -> bool:
-        """
-        Process owners for a single department.
-
-        Args:
-            department: Department code (e.g., '75', '01', '2A')
-            limit: Maximum number of records to retrieve
-
-        Returns:
-            True if successful, False otherwise
-        """
-        self.reset_stats()
-
+    def process_department(self, department: str, limit: Optional[int] = None,
+                           append: bool = False) -> bool:
         print(f"\n--- Department {department} ---")
 
-        # Get statistics for this department
-        self.stats['total_source'] = self.get_source_count(department)
-        print(f"  Owners in source: {self.stats['total_source']:,}")
+        count = self.get_source_count(department)
+        print(f"  Owners in source: {count:,}")
 
-        if self.stats['total_source'] == 0:
+        if count == 0:
             print(f"  No owners in department {department}, skipping")
             return True
 
-        # Get owners to import
-        source_owners = self.get_owners_to_import(limit, department)
-        print(f"  To import: {len(source_owners):,}")
+        source_owners = self.get_owners_to_export(limit, department)
+        print(f"  To export: {len(source_owners):,}")
 
         if not source_owners:
-            print(f"  No new owners to import for department {department}")
+            print(f"  No new owners to export for department {department}")
             return True
 
-        # Transform owners
-        transformed_owners = []
+        transformed = []
         for owner in tqdm(source_owners, desc=f"Dept {department}", unit="owner", leave=False):
-            transformed = self.transform_owner(owner)
-            if transformed:
-                transformed_owners.append(transformed)
+            result = self.transform_owner(owner)
+            if result:
+                transformed.append(result)
 
-        self.stats['to_import'] = len(transformed_owners)
-
-        # Insert owners
-        self.insert_owners(transformed_owners)
-
-        print(f"  Imported: {self.stats['imported']:,}, Failed: {self.stats['failed']:,}")
-        return self.stats['failed'] == 0
+        self.write_parquet(transformed, append=append)
+        print(f"  Exported: {len(transformed):,}")
+        return True
 
     def run(self, limit: Optional[int] = None, sequential: bool = False,
             start_department: Optional[str] = None):
-        """
-        Main execution method.
-
-        Args:
-            limit: Maximum number of owners to import (per department if sequential)
-            sequential: If True, process all departments one by one
-            start_department: Skip departments before this one (for resuming)
-        """
         print("=" * 80)
-        print("DATAFONCIER OWNER IMPORTER")
+        print("DATAFONCIER OWNER EXPORTER")
         print("=" * 80)
-        print(f"Source table: {self.source_table}")
-        print(f"Mode: {'DRY RUN' if self.dry_run else 'LIVE'}")
-        print(f"Batch size: {self.batch_size:,}")
-        print(f"Workers: {self.num_workers}")
+        print(f"Source table : {self.source_table}")
+        print(f"Output file  : {self.output}")
         if self.department:
-            print(f"Department: {self.department}")
+            print(f"Department   : {self.department}")
         if sequential:
-            print(f"Sequential mode: processing all departments one by one")
+            print("Sequential mode: processing all departments one by one")
         if start_department:
             print(f"Starting from department: {start_department}")
         if limit:
-            print(f"Limit: {limit:,}")
+            print(f"Limit        : {limit:,}")
         print()
 
         self.connect()
 
         try:
-            # Determine which departments to process
             if self.department:
-                # Single department mode
                 departments = [self.department]
             elif sequential:
-                # Sequential mode: get all departments
                 departments = self.get_departments()
                 print(f"Found {len(departments)} departments to process")
 
-                # Skip departments before start_department
                 if start_department:
                     try:
                         start_idx = departments.index(start_department)
@@ -770,64 +540,42 @@ class OwnerImporter:
                     except ValueError:
                         print(f"Warning: start_department {start_department} not found, processing all")
             else:
-                # All at once (original behavior - may cause OOM with large datasets)
                 departments = [None]
 
-            # Process departments
-            total_imported = 0
-            total_failed = 0
-            completed_depts = 0
-            failed_depts = []
+            total_exported = 0
+            first_write = True
 
             for dept in departments:
                 if dept is None:
-                    # Original behavior: process all at once
-                    print("Analyzing source data...")
-                    self.stats['total_source'] = self.get_source_count()
-                    print(f"  Total distinct owners: {self.stats['total_source']:,}")
-
-                    print("\nFetching owners to import...")
-                    source_owners = self.get_owners_to_import(limit)
-                    print(f"  Found {len(source_owners):,} owners to import")
+                    print("Fetching owners to export...")
+                    source_owners = self.get_owners_to_export(limit)
+                    print(f"  Found {len(source_owners):,} owners to export")
 
                     if not source_owners:
-                        print("\nNo new owners to import")
+                        print("\nNo new owners to export")
                         return
 
-                    print("\nTransforming owner records...")
-                    transformed_owners = []
+                    transformed = []
                     for owner in tqdm(source_owners, desc="Transforming", unit="owner"):
-                        transformed = self.transform_owner(owner)
-                        if transformed:
-                            transformed_owners.append(transformed)
+                        result = self.transform_owner(owner)
+                        if result:
+                            transformed.append(result)
 
-                    self.stats['to_import'] = len(transformed_owners)
-                    print(f"\n  Valid owners to import: {self.stats['to_import']:,}")
-
-                    self.insert_owners(transformed_owners)
-                    total_imported = self.stats['imported']
-                    total_failed = self.stats['failed']
+                    print(f"\n  Valid owners: {len(transformed):,}")
+                    self.write_parquet(transformed)
+                    total_exported = self.stats['exported']
                 else:
-                    # Department-by-department processing
-                    success = self.process_department(dept, limit)
-                    total_imported += self.stats['imported']
-                    total_failed += self.stats['failed']
+                    self.process_department(dept, limit, append=not first_write)
+                    total_exported = self.stats['exported']
+                    first_write = False
 
-                    if success:
-                        completed_depts += 1
-                    else:
-                        failed_depts.append(dept)
-
-            # Final summary
             print("\n" + "=" * 80)
-            print("FINAL SUMMARY")
+            print("SUMMARY")
             print("=" * 80)
-            if departments[0] is not None:
-                print(f"Departments processed: {completed_depts}/{len(departments)}")
-                if failed_depts:
-                    print(f"Failed departments: {', '.join(failed_depts)}")
-            print(f"Total imported: {total_imported:,}")
-            print(f"Total failed: {total_failed:,}")
+            print(f"Total exported    : {total_exported:,}")
+            print(f"Skipped (no name) : {self.stats['skipped_no_name']:,}")
+            print(f"Skipped (no addr) : {self.stats['skipped_no_address']:,}")
+            print(f"Output file       : {self.output}")
             print("=" * 80)
 
         finally:
@@ -836,51 +584,30 @@ class OwnerImporter:
 
 def main():
     parser = argparse.ArgumentParser(
-        description='Import owners from df_owners_nat_2024 to owners table'
+        description='Export owners from df_owners_nat_2024 to a Parquet file'
     )
 
-    # Database connection
     parser.add_argument(
         '--db-url',
         required=True,
         help='PostgreSQL connection URI (postgresql://user:pass@host:port/dbname)'
     )
-
-    # Operation mode
     parser.add_argument(
-        '--dry-run',
-        action='store_true',
-        help='Simulation mode - do not modify database'
+        '--output',
+        required=True,
+        help='Output Parquet file path (e.g. owners.parquet)'
     )
-
-    # Source table
     parser.add_argument(
         '--source-table',
         type=str,
         default='df_owners_nat_2024',
         help='Name of the source table (default: df_owners_nat_2024)'
     )
-
-    # Limits and optimization
     parser.add_argument(
         '--limit',
         type=int,
-        help='Maximum number of owners to import'
+        help='Maximum number of owners to export'
     )
-    parser.add_argument(
-        '--batch-size',
-        type=int,
-        default=5000,
-        help='Batch size for insert operations (default: 5000)'
-    )
-    parser.add_argument(
-        '--num-workers',
-        type=int,
-        default=4,
-        help='Number of parallel workers (default: 4)'
-    )
-
-    # Department partitioning (to avoid OOM with large datasets)
     parser.add_argument(
         '--department', '--dept',
         type=str,
@@ -898,8 +625,6 @@ def main():
         dest='start_department',
         help='Starting department when using --sequential (resume from)'
     )
-
-    # Debug
     parser.add_argument(
         '--debug',
         action='store_true',
@@ -908,27 +633,23 @@ def main():
 
     args = parser.parse_args()
 
-    # Setup logging
     logging.basicConfig(
         level=logging.DEBUG if args.debug else logging.WARNING,
         format='%(levelname)s - %(message)s'
     )
 
-    # Run importer
-    importer = OwnerImporter(
+    exporter = OwnerExporter(
         db_url=args.db_url,
-        dry_run=args.dry_run,
-        batch_size=args.batch_size,
-        num_workers=args.num_workers,
+        output=args.output,
         source_table=args.source_table,
-        department=args.department
+        department=args.department,
     )
 
     try:
-        importer.run(
+        exporter.run(
             limit=args.limit,
             sequential=args.sequential,
-            start_department=args.start_department
+            start_department=args.start_department,
         )
         print("\nCompleted successfully")
     except KeyboardInterrupt:

--- a/server/src/scripts/import-owners-datafoncier/pyproject.toml
+++ b/server/src/scripts/import-owners-datafoncier/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "import-owners-datafoncier"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+    "psycopg2-binary>=2.9.0",
+    "tqdm>=4.64.0",
+    "pyarrow>=14.0.0",
+]

--- a/server/src/scripts/import-owners-datafoncier/requirements.txt
+++ b/server/src/scripts/import-owners-datafoncier/requirements.txt
@@ -1,2 +1,0 @@
-psycopg2-binary>=2.9.0
-tqdm>=4.64.0


### PR DESCRIPTION
- Updated README.md to reflect changes in usage and prerequisites, removing manual venv setup and pip install instructions.
- Modified import_owners.py to change functionality from importing to exporting owners data to a Parquet file for review.
- Introduced a new pyproject.toml for dependency management, replacing requirements.txt which has been removed.
- Adjusted command-line arguments to include output file specification and removed unnecessary options related to database insertion.
- Refactored class and method names to better reflect the new export functionality.