### PR TITLE
fix(frontend): rétablit le style DSFR du bouton Légende de la carte

### DIFF
--- a/frontend/src/components/Map/LegendButtonControl.tsx
+++ b/frontend/src/components/Map/LegendButtonControl.tsx
@@ -14,7 +14,7 @@ class LegendControl implements IControl {
 
   onAdd(): HTMLElement {
     this.container = document.createElement('div');
-    this.container.className = 'maplibregl-ctrl maplibregl-ctrl-group';
+    this.container.className = 'maplibregl-ctrl';
     this.root = createRoot(this.container);
     this.root.render(
       <Button priority="secondary" size="small" onClick={this.onOpen}>


### PR DESCRIPTION
## Résumé
- Le bouton « Légende » de la carte était cassé visuellement : son conteneur utilisait la classe `maplibregl-ctrl-group`, dont le CSS MapLibre force tout `<button>` imbriqué à `29×29px`, avec fond transparent et sans bordure ni padding — ce qui écrasait le bouton secondary du DSFR.
- On retire `maplibregl-ctrl-group` et on garde uniquement `maplibregl-ctrl` (positionnement + gestion des clics). Le bouton s'affiche désormais comme un bouton secondary DSFR normal libellé « Légende ».

## Plan de test
- [x] Ouvrir une vue carte (parc de logements) et vérifier que le bouton « Légende » en bas à gauche ressemble à un bouton secondary DSFR standard.
- [x] Cliquer dessus et vérifier que le panneau de légende s'ouvre toujours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)