### PR TITLE
docs: update onboarding docs and automate .env.example sync

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -10,6 +10,14 @@ on:
       - packages/**
 
 jobs:
+  check-env-example:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Check .env.example completeness
+        run: bash tools/check-env-example.sh
+
   build:
     runs-on: ubuntu-22.04
     strategy:
@@ -35,7 +43,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          # Allows lerna to compute which packages changed
+          # Allows nx affected to compute which packages changed
           fetch-depth: 0
 
       - name: Enable Corepack

--- a/.talismanrc
+++ b/.talismanrc
@@ -34,7 +34,7 @@ fileignoreconfig:
 - filename: docs/plans/2026-03-04-campaign-view-rework.md
   checksum: 3d029146348a92af21c5d517a98df77d95510bd7c8ef363dd73cc7b79b1f9c3b
 - filename: frontend/.env.example
-  checksum: 7e2a5ff197c49ff9f715b3d189da7282bdb40de53ea49735e9f183ece19168fc
+  checksum: b2a9a90b4638f73c5c3af34fe5e7e6bf5244b18f32f7c96fb35c48429836004d
 - filename: frontend/AGENTS.md
   checksum: e61269bb50cfcf72e05f504edc4e72dddca39e35f6994c958f62ca453467368d
 - filename: frontend/src/components/Draft/DraftSender.tsx
@@ -68,7 +68,11 @@ fileignoreconfig:
 - filename: packages/utils/src/object.ts
   checksum: 9893602dd7197e44a7c361e44c31b5fb86a025227af95c02998a6857bd1a694b
 - filename: server/.env.example
-  checksum: 4955533b2ba29ebc4a052e65ce2aab5b911ebf8e4b4eeecff50b5e83d1857c35
+  checksum: 62a27c6b5ffc4f6f5f92d6e20a38bb897c14858cd2d1c61b30f64b002b76fe89
+- filename: tools/check-env-example.sh
+  checksum: 6c6fe178ec5266d32e19a469547e2cf8e02158ef2e930b5600b0951b5e655a7a
+- filename: README.md
+  checksum: e9453f34a422b94f243daf56302141d9fc22cddf802423f64da72cee91c407d2
 - filename: server/AGENTS.md
   checksum: 7dcff7f92233af9d77b5756e39af3d2aa71cd7dab25d91c2a96bfb7cdd609bca
 - filename: server/src/controllers/campaignController.ts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,29 +12,28 @@ Yarn v4 monorepo with Nx for build orchestration and task running. French govern
 
 ```
 ├── frontend/          # React app (@zerologementvacant/front)
-│                      # See frontend/AGENTS.md for frontend-specific patterns
 ├── server/            # Express API (@zerologementvacant/server)
-│                      # See server/AGENTS.md for backend-specific patterns
-├── e2e/               # End-to-end Cypress tests
-├── queue/             # Background job processor
+├── apps/
+│   └── front-e2e/    # End-to-end Cypress tests
 └── packages/
     ├── api-sdk/       # API client
+    ├── factories/     # Test factory functions (fishery)
     ├── models/        # Shared data models (DTOs)
+    ├── pdf/           # PDF generation
     ├── schemas/       # Validation schemas
     ├── utils/         # Shared utilities
-    ├── healthcheck/   # Health check utilities
-    └── draft/         # Draft models/utilities
+    └── healthcheck/   # Health check utilities
 ```
 
 ## Navigation Guide for AI Agents
 
 **When to work in each workspace:**
 
-- **Frontend work** (React components, UI, state management) → Work in `frontend/`, read [frontend/AGENTS.md](frontend/AGENTS.md)
-- **Backend work** (API endpoints, database, validation) → Work in `server/`, read [server/AGENTS.md](server/AGENTS.md)
+- **Frontend work** (React components, UI, state management) → Work in `frontend/`; conventions in [.claude/rules/frontend-conventions.md](.claude/rules/frontend-conventions.md)
+- **Backend work** (API endpoints, database, validation) → Work in `server/`; conventions in [.claude/rules/backend-conventions.md](.claude/rules/backend-conventions.md)
 - **Shared types/models** → Work in `packages/models/` (DTOs used by both frontend and server)
 - **Validation schemas** → Work in `packages/schemas/` (shared Yup schemas)
-- **E2E tests** → Work in `e2e/`
+- **E2E tests** → Work in `apps/front-e2e/`
 
 **AI agents automatically read the nearest AGENTS.md file in the directory tree.** Work in the appropriate workspace and follow its specific conventions.
 
@@ -235,8 +234,9 @@ Husky configured for pre-commit linting. Configured via `.husky/`.
 
 ## Workspace-Specific Documentation
 
-- **Frontend development** → [frontend/AGENTS.md](frontend/AGENTS.md)
-- **Backend/API development** → [server/AGENTS.md](server/AGENTS.md)
+- **Frontend conventions** → [.claude/rules/frontend-conventions.md](.claude/rules/frontend-conventions.md)
+- **Backend conventions** → [.claude/rules/backend-conventions.md](.claude/rules/backend-conventions.md)
+- **Packages conventions** → [.claude/rules/packages-conventions.md](.claude/rules/packages-conventions.md)
 
 <!-- nx configuration start-->
 <!-- Leave the start & end comments to automatically receive updates. -->

--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@
 
 ## Getting started en 5 minutes
 
+### Prérequis
+
+- **Node.js v24+**
+- **Yarn v4** (activé via Corepack : `corepack enable`)
+- **Docker** (pour PostgreSQL, Redis, etc.)
+
 ### Installation de l'application
 
 ```bash
@@ -62,10 +68,20 @@ Lancer **un service spécifique** :
 docker compose -f .docker/docker-compose.yml up -d <service>
 ```
 
-### Variables d'environnement
+### Variables d’environnement
 
-Chaque application peut définir ses propres variables d’environnement.
-Des exemples sont disponibles comme ici pour l’API : [server/.env.example](server/.env.example).
+Chaque application définit ses propres variables d’environnement. Copiez les fichiers d’exemple et adaptez-les :
+
+```bash
+cp server/.env.example server/.env
+cp frontend/.env.example frontend/.env
+```
+
+**Important :** la valeur de `DATABASE_URL` dans `server/.env` doit correspondre à la base de données créée à l’étape précédente. Si vous avez utilisé les valeurs par défaut du script `setup.sh`, mettez à jour la valeur :
+
+```
+DATABASE_URL=postgres://postgres:postgres@localhost/dev
+```
 
 ### Chargement des données
 
@@ -89,7 +105,7 @@ Permet le chargement de données minimales pour faire fonctionner l'application 
 - Eurométropole de Strasbourg
 - CA Saint-Lô Agglo
 
-et trois utilisateurs dont les mots de passes sont partagés sur https://vaultwarden.incubateur.net/:
+et quatre utilisateurs dont les mots de passe sont partagés sur https://vaultwarden.incubateur.net/ :
 
 - test.strasbourg@zlv.fr => utilisateur avec des droits pour Eurométropole de Strasbourg
 - test.saintlo@zlv.fr => utilisateur avec des droits pour Saint-Lô
@@ -105,7 +121,7 @@ yarn workspace @zerologementvacant/front dev # localhost:3000
 yarn workspace @zerologementvacant/server dev # localhost:3001/api
 ```
 
-L'application est accessible à l'adresse sur <http://localhost:3000> et il est possible de se connecter avec l'un des trois comptes utilisateurs cités plus haut.
+L'application est accessible à l'adresse sur <http://localhost:3000> et il est possible de se connecter avec l'un des quatre comptes utilisateurs cités plus haut.
 
 ### Lancement des tests
 
@@ -118,16 +134,8 @@ yarn test
 Lancer les tests d’un workspace en particulier :
 
 ```shell
-# Avec yarn
-yarn workspace <workspace> test
-# Avec lerna
-yarn lerna run test --scope <workspace> [--include-dependents]
-
-# Exemple
-yarn workspace @zerologementvacant/server test
-yarn lerna run test --scope @zerologementvacant/server --include-dependents
-yarn test --scope @zerologementvacant/server --include-dependents
-# yarn test == yarn lerna run test
+yarn nx test server
+yarn nx test front
 ```
 
 La commande échoue si le package ne comporte pas de commande `test`, ou si un

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,6 +1,31 @@
-REACT_APP_API_URL=http://localhost:3001
-REACT_APP_METABASE_STATS_DASHBOARD=UUID
-REACT_APP_FEATURE_OCCUPANCY=ct1,ct2,ct3
+# API
+VITE_API_URL=http://localhost:3001
 
-REACT_APP_POSTHOG_ENABLED=false
-REACT_APP_POSTHOG_API_KEY=
+# Feature flags (comma-separated list of establishment IDs or flag names)
+VITE_FEATURE_FLAGS=
+
+# BAN (Base Adresse Nationale)
+VITE_BAN_URL=https://api-adresse.data.gouv.fr
+VITE_BAN_ELIGIBLE_SCORE=0.8
+
+# Metabase
+VITE_METABASE_SITE_URL=
+VITE_METABASE_STATS_DASHBOARD=
+
+# PostHog analytics
+VITE_POSTHOG_ENABLED=false
+VITE_POSTHOG_API_KEY=
+
+# Sentry error tracking
+VITE_SENTRY_ENABLED=false
+VITE_SENTRY_DSN=
+VITE_SENTRY_ENV=development
+VITE_SENTRY_SAMPLE_RATE=0.2
+VITE_SENTRY_TRACES_SAMPLE_RATE=0.2
+
+# Set automatically by CI — leave empty for local dev
+VITE_APP_VERSION=
+
+# File upload limits (must match server values)
+VITE_FILE_UPLOAD_MAX_SIZE_MB=5
+VITE_GEO_UPLOAD_MAX_SIZE_MB=100

--- a/packages/README.md
+++ b/packages/README.md
@@ -1,24 +1,5 @@
 # Packages
 
-## Initialize a new package
-
-- Copy the `template` folder to `packages/<your-package>` and rename it
-- Inside `package.json`, change the `"name"` field
-- Inside your package, create a folder named `src`
-
-You are ready to go!
-
-## Add tests
-
-- Inside `package.json`, add a script `"test": "jest"`
-- Copy `template/jest.config.json` to your package root (not `src`)
-- Type `yarn workspace @zerologementvacant/<your-package> add --dev @types/jest
-  jest jest-extended @swc/core @swc/jest`
-
-## Lint
-
-Linting is provided by the root directory. You have nothing to do!
-
 ## Available scripts
 
 ### clean

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,13 +1,25 @@
+NODE_ENV=development
+PORT=3001
+HOST=localhost
+LOG_LEVEL=debug
+# Set to true in review app deployments
+IS_REVIEW_APP=false
+
+AUTH_SECRET=secret
+AUTH_EXPIRES_IN=1d
+ADMIN_2FA_ENABLED=false
+TEST_PASSWORD=
+SYSTEM_ACCOUNT=
+
+DATABASE_URL=postgres://postgres:postgres@localhost/dev
+DATABASE_POOL_MAX=10
+# Override if different from NODE_ENV (rarely needed)
+DATABASE_ENV=
+
 ELASTIC_ENV=development
 ELASTIC_NODE=http://localhost:9200
 ELASTIC_USERNAME=username
 ELASTIC_PASSWORD=password
-
-AUTH_SECRET=secret
-ADMIN_2FA_ENABLED=false
-
-DATABASE_URL=postgres://postgres:zlv@localhost/zlv
-DATABASE_URL_TEST=postgres://postgres:zlv@localhost/test_zlv
 
 E2E_EMAIL=
 E2E_PASSWORD=
@@ -39,9 +51,10 @@ DATAFONCIER_ENABLED=false
 DATAFONCIER_API=https://apidf-preprod.cerema.fr
 DATAFONCIER_TOKEN=
 
-S3_ENDPOINT=
-S3_REGION=any
-S3_BUCKET=
+# Local S3 mock: docker compose exposes it at http://localhost:9090
+S3_ENDPOINT=http://localhost:9090
+S3_REGION=local
+S3_BUCKET=zerologementvacant
 S3_ACCESS_KEY_ID=whatever
 S3_SECRET_ACCESS_KEY=whatever
 
@@ -64,6 +77,11 @@ METABASE_DOMAIN=https://stats.zlv.beta.gouv.fr
 METABASE_TOKEN=METABASE_TOKEN
 METABASE_API_TOKEN=METABASE_API_TOKEN
 
+# BAN (Base Adresse Nationale) API
+BAN_API_ENDPOINT=https://api-adresse.data.gouv.fr
+BAN_UPDATE_PAGE_SIZE=1000
+BAN_UPDATE_DELAY=100
+
 POSTHOG_ENABLED=false
 POSTHOG_API_KEY=
 POSTHOG_HOST=https://eu.i.posthog.com
@@ -72,3 +90,6 @@ SENTRY_ENABLED=false
 SENTRY_DSN=
 
 SWAGGER_ENABLED=false
+
+RATE_LIMIT_MAX=100
+BATCH_SIZE=1000

--- a/tools/check-env-example.sh
+++ b/tools/check-env-example.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Validates that .env.example files cover all env vars consumed in code.
+#
+# Server:   scans env('VAR') calls in server/src/infra/config.ts
+# Frontend: scans import.meta.env.VITE_* across frontend/src/
+#
+# Usage: bash tools/check-env-example.sh
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+errors=0
+
+example_keys() {
+  grep -v '^\s*#' "$1" | grep -v '^\s*$' | cut -d= -f1 | sort -u
+}
+
+check() {
+  local label=$1 example_file=$2
+  shift 2
+  local code_vars
+  code_vars=$(echo "$@" | tr ' ' '\n' | sort -u)
+  local missing
+  missing=$(comm -23 <(echo "$code_vars") <(example_keys "$example_file"))
+  if [ -n "$missing" ]; then
+    echo "✗ $label: missing from .env.example:" >&2
+    echo "$missing" | sed 's/^/    - /' >&2
+    errors=1
+  else
+    echo "✓ $label: .env.example is up-to-date"
+  fi
+}
+
+server_vars=$(grep -oE "env\('[A-Z][A-Z0-9_]+'\)" "$ROOT/server/src/infra/config.ts" | grep -oE "[A-Z][A-Z0-9_]+")
+frontend_vars=$(grep -roh "VITE_[A-Z][A-Z0-9_]*" "$ROOT/frontend/src/" | sort -u)
+
+check "server"   "$ROOT/server/.env.example"   $server_vars
+check "frontend" "$ROOT/frontend/.env.example" $frontend_vars
+
+exit $errors


### PR DESCRIPTION
## Summary

- **AGENTS.md**: fix monorepo structure (correct `apps/front-e2e/` path, add `packages/factories` and `packages/pdf`, remove stale `queue/` and `e2e/`); fix broken doc links pointing to non-existent `frontend/AGENTS.md` and `server/AGENTS.md` → now point to `.claude/rules/`
- **README.md**: add prerequisites block (Node v24, Yarn v4, Docker); fix env setup section with explicit `cp` commands and `DATABASE_URL` alignment note; fix user count ("trois" → "quatre"); replace deprecated `lerna` test commands with `yarn nx`
- **packages/README.md**: remove stale new-package guide (referenced a non-existent `template/` folder and Jest)
- **frontend/.env.example**: full rewrite — all `REACT_APP_*` vars replaced with `VITE_*` following the CRA→Vite migration; 16 new vars documented
- **server/.env.example**: add missing vars (`NODE_ENV`, `PORT`, `HOST`, `LOG_LEVEL`, `IS_REVIEW_APP`, `AUTH_EXPIRES_IN`, `SYSTEM_ACCOUNT`, `BAN_*`, etc.); fix S3 local defaults; remove stale `DATABASE_URL_TEST`
- **tools/check-env-example.sh**: new script that greps env var names from `server/src/infra/config.ts` and `frontend/src/`, diffs against the respective `.env.example`, exits 1 if any are missing
- **pull-request.yml**: new `check-env-example` job that runs the script on every PR — no Node install needed

## Test plan

- [ ] Run `bash tools/check-env-example.sh` locally — should print two ✓ lines and exit 0
- [ ] Add a dummy `env('MISSING_VAR')` to `server/src/infra/config.ts`, re-run the script — should exit 1 and name the missing var
- [ ] Check the new CI job appears on the PR and passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)