### PR TITLE
feat(frontend): add loading state to login button

### DIFF
--- a/frontend/src/views/Login/LoginView.tsx
+++ b/frontend/src/views/Login/LoginView.tsx
@@ -3,8 +3,10 @@ import { Alert } from '@codegouvfr/react-dsfr/Alert';
 import Button from '@codegouvfr/react-dsfr/Button';
 import { yupResolver } from '@hookform/resolvers/yup';
 import Box from '@mui/material/Box';
+import CircularProgress from '@mui/material/CircularProgress';
 import Container from '@mui/material/Container';
 import Grid from '@mui/material/Grid';
+import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import { useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
@@ -156,26 +158,36 @@ const LoginView = () => {
                   Mot de passe perdu ?
                 </AppLink>
               </Box>
-              <Grid container alignItems="center" spacing={2}>
-                <Grid size={{ xs: 12, md: 9 }}>
-                  <Typography component="p" variant="body1">
-                    Première visite ?&nbsp;
-                    <AppLink
-                      to="/inscription"
-                      isSimple
-                      iconId="fr-icon-arrow-right-line"
-                      iconPosition="right"
-                    >
-                      Créer votre compte
-                    </AppLink>
+              {auth.logIn.isLoading ? (
+                <Stack direction="row" alignItems="center" gap="1rem" sx={{ mt: '0.5rem' }}>
+                  <CircularProgress
+                    size="1.5rem"
+                    sx={{ color: fr.colors.decisions.text.actionHigh.blueFrance.default, flexShrink: 0 }}
+                  />
+                  <Typography variant="body1" sx={{ fontWeight: 500 }}>
+                    Connexion en cours, veuillez patienter quelques instants…
                   </Typography>
+                </Stack>
+              ) : (
+                <Grid container alignItems="center" spacing={2}>
+                  <Grid size={{ xs: 12, md: 9 }}>
+                    <Typography component="p" variant="body1">
+                      Première visite ?&nbsp;
+                      <AppLink
+                        to="/inscription"
+                        isSimple
+                        iconId="fr-icon-arrow-right-line"
+                        iconPosition="right"
+                      >
+                        Créer votre compte
+                      </AppLink>
+                    </Typography>
+                  </Grid>
+                  <Grid size={{ xs: 12, md: 3 }} sx={{ textAlign: 'right' }}>
+                    <Button type="submit">Se connecter</Button>
+                  </Grid>
                 </Grid>
-                <Grid size={{ xs: 12, md: 3 }} sx={{ textAlign: 'right' }}>
-                  <Button type="submit">
-                    Se connecter
-                  </Button>
-                </Grid>
-              </Grid>
+              )}
             </form>
           </Grid>
           <Grid


### PR DESCRIPTION
## Summary

- Remplace le bouton « Se connecter » par un spinner animé + texte pleine largeur pendant l'authentification
- Utilise `auth.logIn.isLoading` (déjà géré dans le reducer Redux) comme condition
- Empêche les clics répétés pendant les appels API lents

## Changements

- `LoginView.tsx` : ajout d'un `CircularProgress` MUI (1.5rem, couleur blue france DSFR) et d'un `Typography body1` en remplacement conditionnel du bouton et du bloc « Première visite »
- Le bouton et le lien d'inscription réapparaissent dès que l'appel se termine (succès ou erreur)

## Test plan

- [x] Cliquer sur « Se connecter » avec des identifiants valides → spinner + texte apparaissent, redirect vers `/parc-de-logements`
- [x] Cliquer avec des identifiants invalides → spinner + texte apparaissent, puis message d'erreur et bouton réapparaît
- [ ] Vérifier que le formulaire ne peut pas être re-soumis pendant le chargement (bouton absent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)