### PR TITLE
feat(housing): turn campaign names into links in housing detail

### DIFF
--- a/frontend/src/components/HousingDetails/MobilizationTab.tsx
+++ b/frontend/src/components/HousingDetails/MobilizationTab.tsx
@@ -9,6 +9,7 @@ import { match, Pattern } from 'ts-pattern';
 import { useHousing } from '~/hooks/useHousing';
 import { useFindCampaignsQuery } from '~/services/campaign.service';
 import { useFindPrecisionsByHousingQuery } from '~/services/precision.service';
+import AppLink from '../_app/AppLink/AppLink';
 import HousingStatusBadge from '../HousingStatusBadge/HousingStatusBadge';
 import PrecisionLists from '../Precision/PrecisionLists';
 import HousingAttribute from './HousingAttribute';
@@ -66,11 +67,17 @@ function MobilizationTab() {
                     housingCampaigns.length === 0 ? (
                       <Typography>Aucune campagne</Typography>
                     ) : (
-                      housingCampaigns.map((campaign) => (
-                        <Typography key={campaign.id}>
-                          {campaign.title}
-                        </Typography>
-                      ))
+                      <Stack spacing="0.25rem">
+                        {housingCampaigns.map((campaign) => (
+                          <AppLink
+                            key={campaign.id}
+                            isSimple
+                            to={`/campagnes/${campaign.id}`}
+                          >
+                            {campaign.title}
+                          </AppLink>
+                        ))}
+                      </Stack>
                     )
                   }
                 />


### PR DESCRIPTION
## Summary

- In the housing detail page, the "Campagnes" section now renders each campaign name as a clickable link pointing to `/campagnes/:id`
- Links are stacked vertically (one per line) for readability

## Test plan

- [ ] Open a housing detail page for a housing that belongs to at least one campaign
- [ ] Go to the "Suivi" tab → "Campagnes" section
- [ ] Verify each campaign name is a link
- [ ] Click a link and confirm it navigates to the correct campaign page

🤖 Generated with [Claude Code](https://claude.com/claude-code)