### PR TITLE
feat(frontend): display bar charts from Metabase API with transcription accordion

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -119,6 +119,8 @@ fileignoreconfig:
   checksum: 591ac9d206504aca86efc0731cc283b2e2adb68b2d338cdc47d5c9263713f35f
 - filename: docs/superpowers/specs/2026-06-08-metabase-bar-charts-design.md
   checksum: 3b404f31883e5fc4f4171bcc3418127e4d60fc4636f8e8dae290423cff9e4284
+- filename: docs/superpowers/plans/2026-06-08-metabase-bar-charts.md
+  checksum: f543602319c43d5d38886e7ac48977ea0ac371164fe9390e16243847784ed596
 scopeconfig:
 - scope: node
 allowed_patterns:

--- a/.talismanrc
+++ b/.talismanrc
@@ -117,6 +117,8 @@ fileignoreconfig:
   checksum: 0fb9d4f85c2920d387b1fa71f068d81edbbb82962f7f64a05c583eec579e2652
 - filename: scripts/bundle-metrics.mjs
   checksum: 591ac9d206504aca86efc0731cc283b2e2adb68b2d338cdc47d5c9263713f35f
+- filename: docs/superpowers/specs/2026-06-08-metabase-bar-charts-design.md
+  checksum: 3b404f31883e5fc4f4171bcc3418127e4d60fc4636f8e8dae290423cff9e4284
 scopeconfig:
 - scope: node
 allowed_patterns:

--- a/docs/superpowers/plans/2026-06-08-metabase-bar-charts.md
+++ b/docs/superpowers/plans/2026-06-08-metabase-bar-charts.md
@@ -1,0 +1,1026 @@
+# Metabase Bar Charts Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add bar chart support to the Analysis page, including backend Metabase detection, a DSFR `BarChart` renderer, and an accessible transcription accordion for both bar and pie charts.
+
+**Architecture:** Extend the existing discriminated-union pattern (`CardType` / `CardDataDTO`) with a `'bar-chart'` variant. The backend detects `display: 'bar'` (vertical) and `display: 'row'` (horizontal) from Metabase and resolves `direction` before returning `BarChartDataDTO`. The frontend renders a DSFR `BarChart` and a new shared `ChartTranscription` accordion (auto-generated from `labels` + `data`) used by both chart types.
+
+**Tech Stack:** TypeScript, React, `@codegouvfr/react-dsfr/Chart/BarChart`, `@codegouvfr/react-dsfr/Accordion`, `effect` (Array/pipe), `ts-pattern`, Vitest, MSW, nock, supertest
+
+---
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `packages/models/src/DashboardDTO.ts` | Add `BarChartCard`, `BarChartDataDTO`, extend unions |
+| `packages/models/src/test/fixtures.ts` | Add `genBarChartCard()`, `genBarChartDataDTO()` |
+| `server/src/services/metabase/metabase-service.ts` | Add `BarChartValue`, extend `DashcardRef`, extend `CardValue` |
+| `server/src/services/metabase/metabase-api.ts` | Detect `bar`/`row`, resolve `direction`, handle bar chart in `getCardValue` |
+| `server/src/controllers/dashboardController.ts` | Pass `direction`, handle `BarChartDataDTO` response |
+| `server/src/controllers/test/dashboard-api.test.ts` | Add bar chart API tests |
+| `frontend/src/components/Analysis/AnalysisCard.tsx` | Add `ChartTranscription`, `BarChartDisplay`, update dispatch |
+| `frontend/src/components/Analysis/test/AnalysisCard.test.tsx` | Add bar chart + transcription tests |
+
+---
+
+## Task 1: Extend data model types
+
+**Files:**
+- Modify: `packages/models/src/DashboardDTO.ts`
+
+- [ ] **Step 1: Add `BarChartCard`, `BarChartDataDTO`, extend the unions**
+
+Replace the contents of `packages/models/src/DashboardDTO.ts` with:
+
+```typescript
+// packages/models/src/DashboardDTO.ts
+
+export type CardType = 'flat-number' | 'percentage' | 'pie-chart' | 'bar-chart';
+
+export interface CardCommon {
+  id: number;
+  type: CardType;
+  title: string;
+  description: string | null;
+  decimals: number;
+  position: { col: number; row: number };
+  size: { width: number; height: number };
+}
+
+export interface FlatNumberCard extends CardCommon {
+  type: 'flat-number';
+}
+
+export interface PercentageCard extends CardCommon {
+  type: 'percentage';
+}
+
+export interface PieChartCard extends CardCommon {
+  type: 'pie-chart';
+}
+
+export interface BarChartCard extends CardCommon {
+  type: 'bar-chart';
+}
+
+export type DashboardCard =
+  | FlatNumberCard
+  | PercentageCard
+  | PieChartCard
+  | BarChartCard;
+
+export interface Tab {
+  id: number;
+  title: string;
+  cards: ReadonlyArray<DashboardCard>;
+}
+
+interface WithTabs {
+  tabs: ReadonlyArray<Tab>;
+}
+
+interface WithoutTabs {
+  cards: ReadonlyArray<DashboardCard>;
+}
+
+export type DashboardDTO = { id: number; url: string } & (WithTabs | WithoutTabs);
+
+export interface ScalarCardDataDTO {
+  id: number;
+  type: 'flat-number' | 'percentage';
+  data: number;
+}
+
+export interface PieChartDataDTO {
+  id: number;
+  type: 'pie-chart';
+  data: number[];
+  labels: string[];
+}
+
+export interface BarChartDataDTO {
+  id: number;
+  type: 'bar-chart';
+  direction: 'horizontal' | 'vertical';
+  labels: string[];
+  data: number[];
+}
+
+export type CardDataDTO = ScalarCardDataDTO | PieChartDataDTO | BarChartDataDTO;
+
+export const RESOURCE_VALUES = [
+  '6-utilisateurs-de-zlv-sur-votre-structure',
+  '7-autres-structures-de-votre-territoires-inscrites-sur-zlv',
+  '13-analyses',
+  '15-analyses-activites'
+] as const;
+
+export type Resource = (typeof RESOURCE_VALUES)[number];
+```
+
+- [ ] **Step 2: Run typecheck to verify no breakage**
+
+```bash
+yarn nx run-many -t typecheck --exclude=zero-logement-vacant
+```
+
+Expected: all workspaces pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/models/src/DashboardDTO.ts
+git commit -m "feat(models): add BarChartCard and BarChartDataDTO types"
+```
+
+---
+
+## Task 2: Add fixtures
+
+**Files:**
+- Modify: `packages/models/src/test/fixtures.ts`
+
+- [ ] **Step 1: Add `genBarChartCard` and `genBarChartDataDTO` after `genPieChartCard`**
+
+In `packages/models/src/test/fixtures.ts`, locate `genPieChartCard` (around line 998) and add the two new functions immediately after `genPieChartCard`:
+
+```typescript
+export function genBarChartCard(
+  override?: Partial<BarChartCard>
+): BarChartCard {
+  return {
+    id: faker.number.int({ min: 1, max: 9999 }),
+    type: 'bar-chart',
+    title: faker.lorem.words(3),
+    description: null,
+    decimals: 0,
+    position: { col: 0, row: 0 },
+    size: { width: 6, height: 4 },
+    ...override
+  };
+}
+
+export function genBarChartDataDTO(
+  override?: Partial<BarChartDataDTO>
+): BarChartDataDTO {
+  const series = faker.number.int({ min: 2, max: 5 });
+  const labels: string[] = [];
+  const data: number[] = [];
+  for (let i = 0; i < series; i++) {
+    labels.push(faker.word.noun());
+    data.push(faker.number.int({ min: 1, max: 10000 }));
+  }
+  return {
+    id: faker.number.int({ min: 1, max: 9999 }),
+    type: 'bar-chart',
+    direction: faker.helpers.arrayElement(['horizontal', 'vertical'] as const),
+    labels,
+    data,
+    ...override
+  };
+}
+```
+
+Make sure `BarChartCard` and `BarChartDataDTO` are imported at the top of the file alongside the other types from `../DashboardDTO`.
+
+- [ ] **Step 2: Run typecheck**
+
+```bash
+yarn nx run-many -t typecheck --exclude=zero-logement-vacant
+```
+
+Expected: passes.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/models/src/test/fixtures.ts
+git commit -m "feat(models): add genBarChartCard and genBarChartDataDTO fixtures"
+```
+
+---
+
+## Task 3: Backend failing tests
+
+**Files:**
+- Modify: `server/src/controllers/test/dashboard-api.test.ts`
+
+- [ ] **Step 1: Add mock Metabase dashboard and query-result data at the top of the test file**
+
+After `mockPieCardQueryResult` (around line 186), add:
+
+```typescript
+const mockMetabaseDashboardWithBarCard = {
+  id: 13,
+  dashcards: [
+    {
+      id: 960,
+      card_id: 810,
+      dashboard_tab_id: null,
+      row: 0,
+      col: 0,
+      size_x: 6,
+      size_y: 4,
+      visualization_settings: { 'card.title': 'Répartition par date de construction' },
+      card: {
+        id: 810,
+        name: 'Répartition par date de construction',
+        display: 'bar',
+        description: null,
+        visualization_settings: {}
+      }
+    }
+  ]
+};
+
+const mockMetabaseDashboardWithRowCard = {
+  id: 13,
+  dashcards: [
+    {
+      id: 961,
+      card_id: 811,
+      dashboard_tab_id: null,
+      row: 0,
+      col: 0,
+      size_x: 6,
+      size_y: 4,
+      visualization_settings: { 'card.title': 'Répartition horizontale' },
+      card: {
+        id: 811,
+        name: 'Répartition horizontale',
+        display: 'row',
+        description: null,
+        visualization_settings: {}
+      }
+    }
+  ]
+};
+
+const mockBarCardQueryResult = {
+  data: {
+    rows: [
+      ['1991 et apres', 3200],
+      ['1946 - 1990', 1800]
+    ],
+    cols: [{ name: 'period' }, { name: 'count' }]
+  },
+  status: 'completed'
+};
+```
+
+- [ ] **Step 2: Add failing tests in the `GET /dashboards/:id` block**
+
+In the `describe('GET /dashboards/:id')` block, after the pie-chart test, add:
+
+```typescript
+it('returns a bar-chart card when display is "bar"', async () => {
+  nock(METABASE_URL)
+    .get('/api/dashboard/13')
+    .reply(200, mockMetabaseDashboardWithBarCard);
+
+  const response = await request(url)
+    .get('/dashboards/13-analyses')
+    .use(tokenProvider(user));
+
+  expect(response.status).toBe(constants.HTTP_STATUS_OK);
+  const body = response.body as DashboardDTO;
+  expect('cards' in body).toBe(true);
+  if ('cards' in body) {
+    expect(body.cards).toHaveLength(1);
+    expect(body.cards[0]).toMatchObject({
+      id: 960,
+      type: 'bar-chart',
+      title: 'Répartition par date de construction'
+    });
+  }
+});
+
+it('returns a bar-chart card when display is "row"', async () => {
+  nock(METABASE_URL)
+    .get('/api/dashboard/13')
+    .reply(200, mockMetabaseDashboardWithRowCard);
+
+  const response = await request(url)
+    .get('/dashboards/13-analyses')
+    .use(tokenProvider(user));
+
+  expect(response.status).toBe(constants.HTTP_STATUS_OK);
+  const body = response.body as DashboardDTO;
+  expect('cards' in body).toBe(true);
+  if ('cards' in body) {
+    expect(body.cards).toHaveLength(1);
+    expect(body.cards[0]).toMatchObject({
+      id: 961,
+      type: 'bar-chart',
+      title: 'Répartition horizontale'
+    });
+  }
+});
+```
+
+- [ ] **Step 3: Add failing tests in the `GET /dashboards/:did/cards/:cid` block**
+
+After the pie-chart card test, add:
+
+```typescript
+it('returns BarChartDataDTO with direction "vertical" for display "bar"', async () => {
+  nock(METABASE_URL)
+    .get('/api/dashboard/13')
+    .reply(200, mockMetabaseDashboardWithBarCard);
+  nock(METABASE_URL)
+    .post('/api/dashboard/13/dashcard/960/card/810/query')
+    .reply(200, mockBarCardQueryResult);
+
+  const response = await request(url)
+    .get('/dashboards/13-analyses/cards/960')
+    .use(tokenProvider(user));
+
+  expect(response.status).toBe(constants.HTTP_STATUS_OK);
+  expect(response.body).toMatchObject({
+    id: 960,
+    type: 'bar-chart',
+    direction: 'vertical',
+    labels: ['1991 et apres', '1946 - 1990'],
+    data: [3200, 1800]
+  });
+});
+
+it('returns BarChartDataDTO with direction "horizontal" for display "row"', async () => {
+  nock(METABASE_URL)
+    .get('/api/dashboard/13')
+    .reply(200, mockMetabaseDashboardWithRowCard);
+  nock(METABASE_URL)
+    .post('/api/dashboard/13/dashcard/961/card/811/query')
+    .reply(200, mockBarCardQueryResult);
+
+  const response = await request(url)
+    .get('/dashboards/13-analyses/cards/961')
+    .use(tokenProvider(user));
+
+  expect(response.status).toBe(constants.HTTP_STATUS_OK);
+  expect(response.body).toMatchObject({
+    id: 961,
+    type: 'bar-chart',
+    direction: 'horizontal',
+    labels: ['1991 et apres', '1946 - 1990'],
+    data: [3200, 1800]
+  });
+});
+```
+
+- [ ] **Step 4: Run tests and confirm they fail**
+
+```bash
+yarn nx test server -- dashboard-api
+```
+
+Expected: 4 new tests fail with errors like `"expected 'flat-number' to equal 'bar-chart'"` or similar type errors.
+
+---
+
+## Task 4: Extend MetabaseService types
+
+**Files:**
+- Modify: `server/src/services/metabase/metabase-service.ts`
+
+- [ ] **Step 1: Add `BarChartValue`, extend `DashcardRef` and `CardValue`**
+
+Replace the entire file content:
+
+```typescript
+import type { CardType, DashboardCard, Tab } from '@zerologementvacant/models';
+
+export type DashboardData =
+  | { tabs: ReadonlyArray<Tab> }
+  | { cards: ReadonlyArray<DashboardCard> };
+
+export interface DashboardParameter {
+  id: string;
+  slug: string;
+  type: string;
+}
+
+export interface DashcardRef {
+  dashcardId: number;
+  cardId: number;
+  type: CardType;
+  valueColumn: string | null;
+  direction: 'horizontal' | 'vertical' | null;
+  dashboardParameters: ReadonlyArray<DashboardParameter>;
+}
+
+export type PieChartValue = { labels: string[]; data: number[] };
+export type BarChartValue = {
+  direction: 'horizontal' | 'vertical';
+  labels: string[];
+  data: number[];
+};
+export type CardValue = number | PieChartValue | BarChartValue;
+
+export interface MetabaseService {
+  getDashboard(id: number): Promise<DashboardData>;
+  findDashcard(dashboardId: number, dashcardId: number): Promise<DashcardRef | null>;
+  getCardValue(
+    dashboardId: number,
+    dashcardId: number,
+    cardId: number,
+    parameters: ReadonlyArray<DashboardParameter & { value: string }>,
+    valueColumn: string | null,
+    cardType: CardType,
+    direction: 'horizontal' | 'vertical' | null
+  ): Promise<CardValue>;
+}
+```
+
+- [ ] **Step 2: Run typecheck — expect errors in `metabase-api.ts` (not yet updated)**
+
+```bash
+yarn nx typecheck server
+```
+
+Expected: TypeScript errors in `metabase-api.ts` — this is fine, the next task fixes them.
+
+---
+
+## Task 5: Implement bar chart detection in `metabase-api.ts`
+
+**Files:**
+- Modify: `server/src/services/metabase/metabase-api.ts`
+
+- [ ] **Step 1: Add `BarChartValue` import**
+
+At the top of the file, update the import from `./metabase-service`:
+
+```typescript
+import type {
+  BarChartValue,
+  CardValue,
+  DashboardData,
+  DashboardParameter,
+  DashcardRef,
+  MetabaseService,
+  PieChartValue
+} from './metabase-service';
+```
+
+- [ ] **Step 2: Detect bar and row display types in `normalizeDashcard`**
+
+In `normalizeDashcard`, add the bar chart branch immediately after the pie chart branch (before the `if (card.display !== 'scalar') return null;` line):
+
+```typescript
+if (card.display === 'bar' || card.display === 'row') {
+  return {
+    id: dashcard.id,
+    type: 'bar-chart',
+    title: dashcard.visualization_settings['card.title'] ?? card.name,
+    description: card.description,
+    decimals: 0,
+    position: { col: dashcard.col, row: dashcard.row },
+    size: { width: dashcard.size_x, height: dashcard.size_y }
+  };
+}
+```
+
+- [ ] **Step 3: Add `direction: null` to the existing pie-chart and scalar branches in `findDashcardRef`**
+
+In `findDashcardRef`, update the pie-chart branch to include `direction: null`:
+
+```typescript
+if (normalized.type === 'pie-chart') {
+  return {
+    dashcardId: found.id,
+    cardId: found.card_id,
+    type: 'pie-chart',
+    valueColumn: null,
+    direction: null,
+    dashboardParameters: (raw.parameters ?? []).map(
+      (p): DashboardParameter => ({ id: p.id, slug: p.slug, type: p.type })
+    )
+  };
+}
+```
+
+Update the scalar return at the end of `findDashcardRef` to include `direction: null`:
+
+```typescript
+return {
+  dashcardId: found.id,
+  cardId: found.card_id,
+  type: normalized.type,
+  valueColumn: settings['scalar.field'] ?? null,
+  direction: null,
+  dashboardParameters: (raw.parameters ?? []).map(
+    (p): DashboardParameter => ({ id: p.id, slug: p.slug, type: p.type })
+  )
+};
+```
+
+- [ ] **Step 4: Add the bar-chart branch in `findDashcardRef`**
+
+In `findDashcardRef`, add the bar-chart branch after the pie-chart branch:
+
+```typescript
+if (normalized.type === 'bar-chart') {
+  return {
+    dashcardId: found.id,
+    cardId: found.card_id,
+    type: 'bar-chart',
+    valueColumn: null,
+    direction: found.card!.display === 'bar' ? 'vertical' : 'horizontal',
+    dashboardParameters: (raw.parameters ?? []).map(
+      (p): DashboardParameter => ({ id: p.id, slug: p.slug, type: p.type })
+    )
+  };
+}
+```
+
+- [ ] **Step 5: Update `getCardValue` signature to accept `direction`**
+
+In the `MetabaseAPI` class, update the `getCardValue` method signature:
+
+```typescript
+async getCardValue(
+  dashboardId: number,
+  dashcardId: number,
+  cardId: number,
+  parameters: ReadonlyArray<DashboardParameter & { value: string }>,
+  valueColumn: string | null,
+  cardType: CardType,
+  direction: 'horizontal' | 'vertical' | null
+): Promise<CardValue> {
+```
+
+- [ ] **Step 6: Add the bar-chart branch in `getCardValue`**
+
+In `getCardValue`, add the bar-chart branch immediately after the pie-chart branch:
+
+```typescript
+if (cardType === 'bar-chart') {
+  const result: BarChartValue = {
+    direction: direction!,
+    labels: data.data.rows.map((row) => String(row[0])),
+    data: data.data.rows.map((row) => Number(row[1]))
+  };
+  return result;
+}
+```
+
+- [ ] **Step 7: Run typecheck**
+
+```bash
+yarn nx typecheck server
+```
+
+Expected: only the controller has remaining errors (not yet updated).
+
+---
+
+## Task 6: Update the dashboard controller
+
+**Files:**
+- Modify: `server/src/controllers/dashboardController.ts`
+
+- [ ] **Step 1: Import `BarChartValue` and `PieChartValue`**
+
+Update the import from `~/services/metabase/metabase-api`:
+
+```typescript
+import type { BarChartValue, PieChartValue } from '~/services/metabase/metabase-service';
+```
+
+Add this alongside the existing imports at the top of the file.
+
+- [ ] **Step 2: Pass `dashcard.direction` to `getCardValue` and handle the bar-chart response**
+
+Replace the `findOneCard` function body from the `getCardValue` call through the response section:
+
+```typescript
+const raw = await metabaseAPI.getCardValue(
+  numericDid,
+  dashcard.dashcardId,
+  dashcard.cardId,
+  queryParameters,
+  dashcard.valueColumn,
+  dashcard.type,
+  dashcard.direction
+);
+
+if (dashcard.type === 'bar-chart' && typeof raw === 'object' && raw !== null) {
+  const barRaw = raw as BarChartValue;
+  response.status(constants.HTTP_STATUS_OK).json({
+    id: numericCid,
+    type: 'bar-chart',
+    direction: barRaw.direction,
+    labels: barRaw.labels,
+    data: barRaw.data
+  });
+  return;
+}
+
+if (typeof raw === 'object' && raw !== null) {
+  const pieRaw = raw as PieChartValue;
+  response.status(constants.HTTP_STATUS_OK).json({
+    id: numericCid,
+    type: 'pie-chart',
+    labels: pieRaw.labels,
+    data: pieRaw.data
+  });
+  return;
+}
+
+const data = dashcard.type === 'percentage' ? raw / 100 : raw;
+response.status(constants.HTTP_STATUS_OK).json({
+  id: numericCid,
+  type: dashcard.type as 'flat-number' | 'percentage',
+  data
+});
+```
+
+- [ ] **Step 3: Run typecheck**
+
+```bash
+yarn nx typecheck server
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Run backend tests**
+
+```bash
+yarn nx test server -- dashboard-api
+```
+
+Expected: all tests pass including the 4 new bar-chart tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add \
+  server/src/services/metabase/metabase-service.ts \
+  server/src/services/metabase/metabase-api.ts \
+  server/src/controllers/dashboardController.ts \
+  server/src/controllers/test/dashboard-api.test.ts
+git commit -m "feat(server): detect and map Metabase bar charts"
+```
+
+---
+
+## Task 7: Frontend failing tests
+
+**Files:**
+- Modify: `frontend/src/components/Analysis/test/AnalysisCard.test.tsx`
+
+- [ ] **Step 1: Add imports for bar chart fixtures**
+
+Update the import from `@zerologementvacant/models/fixtures`:
+
+```typescript
+import {
+  genBarChartCard,
+  genBarChartDataDTO,
+  genFlatNumberCard,
+  genPercentageCard,
+  genPieChartCard,
+  genPieChartDataDTO,
+  genScalarCardDataDTO
+} from '@zerologementvacant/models/fixtures';
+```
+
+- [ ] **Step 2: Add failing bar chart rendering test**
+
+Add at the end of the `describe('AnalysisCard')` block:
+
+```typescript
+it('renders a bar chart card without error when card type is bar-chart', async () => {
+  const barCard = genBarChartCard({ id: 80, title: 'Répartition par date de construction' });
+  const cardData = genBarChartDataDTO({
+    id: 80,
+    direction: 'vertical',
+    labels: ['1991 et apres', '1946 - 1990'],
+    data: [3200, 1800]
+  });
+  mockAPI.use(
+    http.get(
+      `${config.apiEndpoint}/dashboards/:did/cards/:cid`,
+      () => HttpResponse.json(cardData)
+    )
+  );
+
+  setup({ card: barCard, dashboardId });
+
+  await screen.findByText('Répartition par date de construction');
+  expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+});
+```
+
+- [ ] **Step 3: Add failing transcription tests for pie chart**
+
+```typescript
+it('shows a transcription accordion for a pie chart', async () => {
+  const pieCard = genPieChartCard({ id: 77, title: 'Répartition par type' });
+  const cardData = genPieChartDataDTO({
+    id: 77,
+    labels: ['APPART', 'MAISON'],
+    data: [4876, 652]
+  });
+  mockAPI.use(
+    http.get(
+      `${config.apiEndpoint}/dashboards/:did/cards/:cid`,
+      () => HttpResponse.json(cardData)
+    )
+  );
+
+  setup({ card: pieCard, dashboardId });
+
+  await screen.findByText('Répartition par type');
+  expect(screen.getByRole('button', { name: /Transcription/i })).toBeInTheDocument();
+});
+
+it('shows percentage transcription items for a pie chart', async () => {
+  const pieCard = genPieChartCard({ id: 77, title: 'Répartition par type' });
+  // 4876 / (4876 + 652) * 100 = 88.2 → 88%
+  // 652  / (4876 + 652) * 100 = 11.8 → 12%
+  const cardData = genPieChartDataDTO({
+    id: 77,
+    labels: ['APPART', 'MAISON'],
+    data: [4876, 652]
+  });
+  mockAPI.use(
+    http.get(
+      `${config.apiEndpoint}/dashboards/:did/cards/:cid`,
+      () => HttpResponse.json(cardData)
+    )
+  );
+
+  setup({ card: pieCard, dashboardId });
+
+  await screen.findByText('Répartition par type');
+  expect(screen.getByText('APPART : 88 %')).toBeInTheDocument();
+  expect(screen.getByText('MAISON : 12 %')).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 4: Add failing transcription tests for bar chart**
+
+```typescript
+it('shows a transcription accordion for a bar chart', async () => {
+  const barCard = genBarChartCard({ id: 80, title: 'Répartition par date de construction' });
+  const cardData = genBarChartDataDTO({
+    id: 80,
+    direction: 'vertical',
+    labels: ['1991 et apres', '1946 - 1990'],
+    data: [3200, 1800]
+  });
+  mockAPI.use(
+    http.get(
+      `${config.apiEndpoint}/dashboards/:did/cards/:cid`,
+      () => HttpResponse.json(cardData)
+    )
+  );
+
+  setup({ card: barCard, dashboardId });
+
+  await screen.findByText('Répartition par date de construction');
+  expect(screen.getByRole('button', { name: /Transcription/i })).toBeInTheDocument();
+});
+
+it('shows raw value transcription items for a bar chart', async () => {
+  const barCard = genBarChartCard({ id: 80, title: 'Répartition par date de construction' });
+  const cardData = genBarChartDataDTO({
+    id: 80,
+    direction: 'vertical',
+    labels: ['1991 et apres', '1946 - 1990'],
+    data: [3200, 1800]
+  });
+  mockAPI.use(
+    http.get(
+      `${config.apiEndpoint}/dashboards/:did/cards/:cid`,
+      () => HttpResponse.json(cardData)
+    )
+  );
+
+  setup({ card: barCard, dashboardId });
+
+  await screen.findByText('Répartition par date de construction');
+  expect(screen.getByText('1991 et apres : 3200')).toBeInTheDocument();
+  expect(screen.getByText('1946 - 1990 : 1800')).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 5: Run tests and confirm they fail**
+
+```bash
+yarn nx test frontend -- AnalysisCard
+```
+
+Expected: 6 new tests fail (no `BarChart` component, no transcription accordion).
+
+---
+
+## Task 8: Implement `ChartTranscription`, `BarChartDisplay`, and update dispatch
+
+**Files:**
+- Modify: `frontend/src/components/Analysis/AnalysisCard.tsx`
+
+- [ ] **Step 1: Add new imports**
+
+At the top of `AnalysisCard.tsx`, add:
+
+```typescript
+import Accordion from '@codegouvfr/react-dsfr/Accordion';
+import { BarChart } from '@codegouvfr/react-dsfr/Chart/BarChart';
+import { Array, pipe } from 'effect';
+import { match } from 'ts-pattern';
+```
+
+And extend the models import to include `BarChartDataDTO`:
+
+```typescript
+import type {
+  BarChartDataDTO,
+  DashboardCard,
+  PieChartDataDTO,
+  Resource
+} from '@zerologementvacant/models';
+```
+
+- [ ] **Step 2: Add `ChartTranscription` component**
+
+Add this component after the `formatValue` function:
+
+```typescript
+interface ChartTranscriptionProps {
+  title: string;
+  labels: string[];
+  data: number[];
+  type: 'pie-chart' | 'bar-chart';
+}
+
+function ChartTranscription({
+  title,
+  labels,
+  data,
+  type
+}: Readonly<ChartTranscriptionProps>) {
+  const items = match(type)
+    .with('pie-chart', () => {
+      const total = pipe(
+        data,
+        Array.reduce(0, (acc, v) => acc + v)
+      );
+      return pipe(
+        Array.zip(labels, data),
+        Array.map(([label, value]) => `${label} : ${Math.round((value / total) * 100)} %`)
+      );
+    })
+    .with('bar-chart', () =>
+      pipe(
+        Array.zip(labels, data),
+        Array.map(([label, value]) => `${label} : ${value}`)
+      )
+    )
+    .exhaustive();
+
+  return (
+    <Accordion label="Transcription">
+      <p>{title}</p>
+      <ul>
+        {items.map((item) => (
+          <li key={item}>{item}</li>
+        ))}
+      </ul>
+    </Accordion>
+  );
+}
+```
+
+- [ ] **Step 3: Update `PieChartDisplay` to include the transcription**
+
+Replace the existing `PieChartDisplay`:
+
+```typescript
+interface PieChartDisplayProps {
+  card: DashboardCard;
+  cardData: PieChartDataDTO;
+}
+
+function PieChartDisplay({ card, cardData }: Readonly<PieChartDisplayProps>) {
+  return (
+    <>
+      <PieChart
+        x={cardData.labels}
+        y={cardData.data}
+        name={cardData.labels}
+        color={[
+          'blue-france',
+          'blue-cumulus',
+          'blue-ecume',
+          'green-archipel',
+          'green-bourgeon',
+          'green-emeraude',
+          'green-menthe',
+          'green-tilleul-verveine'
+        ]}
+      />
+      <ChartTranscription
+        title={card.title}
+        labels={cardData.labels}
+        data={cardData.data}
+        type="pie-chart"
+      />
+    </>
+  );
+}
+```
+
+- [ ] **Step 4: Add `BarChartDisplay` component**
+
+Add after `PieChartDisplay`:
+
+```typescript
+interface BarChartDisplayProps {
+  card: DashboardCard;
+  cardData: BarChartDataDTO;
+}
+
+function BarChartDisplay({ card, cardData }: Readonly<BarChartDisplayProps>) {
+  return (
+    <>
+      <BarChart
+        x={cardData.labels}
+        y={cardData.data}
+        horizontal={cardData.direction === 'horizontal'}
+      />
+      <ChartTranscription
+        title={card.title}
+        labels={cardData.labels}
+        data={cardData.data}
+        type="bar-chart"
+      />
+    </>
+  );
+}
+```
+
+- [ ] **Step 5: Update the dispatch in `AnalysisCard` to use `ts-pattern` and pass `card` to chart displays**
+
+Replace the chart dispatch section in the `AnalysisCard` return:
+
+```typescript
+{match(data)
+  .with({ type: 'pie-chart' }, (d) => (
+    <PieChartDisplay card={card} cardData={d} />
+  ))
+  .with({ type: 'bar-chart' }, (d) => (
+    <BarChartDisplay card={card} cardData={d} />
+  ))
+  .otherwise((d) => (
+    <ShowcaseValue>{formatValue(d.data, card)}</ShowcaseValue>
+  ))}
+```
+
+- [ ] **Step 6: Run frontend tests**
+
+```bash
+yarn nx test frontend -- AnalysisCard
+```
+
+Expected: all tests pass including the 6 new ones.
+
+- [ ] **Step 7: Run typecheck**
+
+```bash
+yarn nx typecheck frontend
+```
+
+Expected: no errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add frontend/src/components/Analysis/AnalysisCard.tsx \
+        frontend/src/components/Analysis/test/AnalysisCard.test.tsx
+git commit -m "feat(frontend): render bar charts with DSFR BarChart and add transcription accordion"
+```
+
+---
+
+## Final verification
+
+- [ ] **Run the full test suite for affected projects**
+
+```bash
+yarn nx run-many -t test -p models server frontend
+```
+
+Expected: all tests pass.
+
+- [ ] **Run typecheck across all workspaces**
+
+```bash
+yarn nx run-many -t typecheck --exclude=zero-logement-vacant
+```
+
+Expected: no errors.

--- a/docs/superpowers/specs/2026-06-08-metabase-bar-charts-design.md
+++ b/docs/superpowers/specs/2026-06-08-metabase-bar-charts-design.md
@@ -1,0 +1,184 @@
+# Metabase bar charts — design spec
+
+**Date:** 2026-06-08  
+**Ticket:** [GEN-1409](https://app.notion.com/p/30b9ec2a056c801ead09d61a85addcef)  
+**Branch:** `feat/metabase-dsfr-bar-charts`
+
+---
+
+## Goal
+
+Add support for Metabase bar charts in the Analysis page, with an accessible text transcription (RGAA). The transcription is also added retroactively to pie charts.
+
+---
+
+## Architecture
+
+Three layers are touched in the same order as the existing pie chart feature: `packages/models` → `server` → `frontend`.
+
+---
+
+## 1. Data model (`packages/models`)
+
+**`DashboardDTO.ts`** additions:
+
+```typescript
+// Extend existing union
+type CardType = 'flat-number' | 'percentage' | 'pie-chart' | 'bar-chart'
+
+// Card metadata (no new fields beyond CardCommon)
+interface BarChartCard extends CardCommon {
+  type: 'bar-chart'
+}
+
+// Data DTO — direction is a rendering property, lives on the data response
+interface BarChartDataDTO {
+  id: number
+  type: 'bar-chart'
+  direction: 'horizontal' | 'vertical'
+  labels: string[]
+  data: number[]
+}
+
+// Updated unions
+type DashboardCard = FlatNumberCard | PercentageCard | PieChartCard | BarChartCard
+type CardDataDTO = ScalarCardDataDTO | PieChartDataDTO | BarChartDataDTO
+```
+
+**New fixtures** in `packages/models/src/test/fixtures.ts`:
+
+- `genBarChartCard(override?)` — extends `CardCommon` pattern
+- `genBarChartDataDTO(override?)` — generates 2–5 random label/value pairs with a random `direction`
+
+---
+
+## 2. Backend (`server`)
+
+All changes in `src/services/metabase/metabase-api.ts`.
+
+**`normalizeDashcard`** — detect both Metabase bar chart display types:
+
+```typescript
+if (card.display === 'bar' || card.display === 'row') {
+  return {
+    id: dashcard.id,
+    type: 'bar-chart',
+    title: dashcard.visualization_settings['card.title'] ?? card.name,
+    description: card.description,
+    decimals: 0,
+    position: { col: dashcard.col, row: dashcard.row },
+    size: { width: dashcard.size_x, height: dashcard.size_y }
+  }
+}
+```
+
+**`DashcardRef`** — gains `direction: 'horizontal' | 'vertical'` (resolved at `findDashcard` time from `card.display`) so `getCardValue` can include it in the response without re-reading the raw display string.
+
+**`getCardValue`** — bar chart rows have the same shape as pie chart rows (`[label, value]`):
+
+```typescript
+if (cardType === 'bar-chart') {
+  return {
+    direction: dashcard.direction,
+    labels: data.data.rows.map((row) => String(row[0])),
+    data: data.data.rows.map((row) => Number(row[1]))
+  }
+}
+```
+
+**`dashboardController.ts` — `findOneCard`** — maps the result to `BarChartDataDTO`, mirroring the pie chart branch.
+
+No percentage detection for bar charts — not needed yet.
+
+---
+
+## 3. Frontend (`frontend`)
+
+All changes in `src/components/Analysis/AnalysisCard.tsx`.
+
+### `BarChartDisplay`
+
+```typescript
+import { BarChart } from '@codegouvfr/react-dsfr/Chart/BarChart'
+
+function BarChartDisplay({ cardData }: Readonly<{ cardData: BarChartDataDTO }>) {
+  return (
+    <BarChart
+      x={cardData.labels}
+      y={cardData.data}
+      horizontal={cardData.direction === 'horizontal'}
+    />
+  )
+}
+```
+
+### `ChartTranscription` (new shared component)
+
+An Accordion with a heading + bullet list. Used by both `PieChartDisplay` and `BarChartDisplay`.
+
+- Accordion label: `"Transcription"` (fixed string)
+- Accordion content: card `title` as a heading, followed by bullet list items
+- **Pie chart**: `${label} : ${Math.round(value / total * 100)} %`
+- **Bar chart**: `${label} : ${value}`
+
+`ChartTranscription` receives `title`, `labels`, `data`, and `type` as props. The `title` is passed down from the `card` prop already available in `AnalysisCard`.
+
+Uses `effect` (`Array`, `pipe`) and `ts-pattern` (`match(...).exhaustive()`):
+
+```typescript
+import { Array, pipe } from 'effect'
+import { match } from 'ts-pattern'
+
+const items = match(type)
+  .with('pie-chart', () => {
+    const total = pipe(data, Array.reduce(0, (acc, v) => acc + v))
+    return pipe(
+      Array.zip(labels, data),
+      Array.map(([label, value]) => `${label} : ${Math.round(value / total * 100)} %`)
+    )
+  })
+  .with('bar-chart', () =>
+    pipe(Array.zip(labels, data), Array.map(([label, value]) => `${label} : ${value}`))
+  )
+  .exhaustive()
+```
+
+The `.exhaustive()` call ensures a compile error if a new chart type is added without updating the transcription.
+
+### Dispatch in `AnalysisCard`
+
+Replaces the existing ternary with `ts-pattern`:
+
+```typescript
+import { match } from 'ts-pattern'
+
+{match(data)
+  .with({ type: 'pie-chart' }, (d) => <PieChartDisplay cardData={d} />)
+  .with({ type: 'bar-chart' }, (d) => <BarChartDisplay cardData={d} />)
+  .otherwise((d) => <ShowcaseValue>{formatValue(d.data, card)}</ShowcaseValue>)}
+```
+
+---
+
+## Testing
+
+**`packages/models`**: no new test files — fixtures are covered by the existing fixture test suite.
+
+**`server`** (`controllers/test/dashboard-api.test.ts`):
+- Bar chart card appears in dashboard response when `card.display === 'bar'` or `'row'`
+- `GET /dashboards/:did/cards/:cid` returns `BarChartDataDTO` with correct `direction`
+
+**`frontend`** (`components/Analysis/test/AnalysisCard.test.tsx`):
+- Renders `BarChart` when data type is `'bar-chart'`
+- Transcription accordion is rendered for both pie and bar charts
+- Pie chart transcription items use percentage format
+- Bar chart transcription items use raw value format
+- Direction prop (`horizontal`) is passed correctly to `BarChart`
+
+---
+
+## Out of scope
+
+- Percentage detection for bar chart values
+- Any other chart types (line, scatter, gauge, etc.)
+- Vertical layout for pie charts

--- a/frontend/src/components/Analysis/AnalysisCard.tsx
+++ b/frontend/src/components/Analysis/AnalysisCard.tsx
@@ -1,25 +1,17 @@
 import { fr } from '@codegouvfr/react-dsfr';
-import Accordion from '@codegouvfr/react-dsfr/Accordion';
 import Alert from '@codegouvfr/react-dsfr/Alert';
-import { BarChart } from '@codegouvfr/react-dsfr/Chart/BarChart';
-import { PieChart } from '@codegouvfr/react-dsfr/Chart/PieChart';
 import Box from '@mui/material/Box';
-import List from '@mui/material/List';
-import ListItem from '@mui/material/ListItem';
 import Skeleton from '@mui/material/Skeleton';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import { styled } from '@mui/material/styles';
-import type {
-  BarChartDataDTO,
-  DashboardCard,
-  PieChartDataDTO,
-  Resource
-} from '@zerologementvacant/models';
-import { Array, pipe } from 'effect';
+import type { DashboardCard, Resource } from '@zerologementvacant/models';
 import { match } from 'ts-pattern';
 
 import { useFindOneCardQuery } from '~/services/dashboard.service';
+
+import BarChartDisplay from './BarChartDisplay';
+import PieChartDisplay from './PieChartDisplay';
 
 interface Props {
   card: DashboardCard;
@@ -52,101 +44,9 @@ function formatValue(data: number, card: DashboardCard): string {
   }).format(data);
 }
 
-interface ChartTranscriptionProps {
-  labels: string[];
-  data: number[];
-  type: 'pie-chart' | 'bar-chart';
-}
+function AnalysisCard(props: Readonly<Props>) {
+  const { card, dashboardId } = props;
 
-function ChartTranscription({
-  labels,
-  data,
-  type
-}: Readonly<ChartTranscriptionProps>) {
-  const items = match(type)
-    .with('pie-chart', () => {
-      const total = pipe(
-        data,
-        Array.reduce(0, (acc, v) => acc + v)
-      );
-      if (total === 0) return [];
-      return pipe(
-        Array.zip(labels, data),
-        Array.map(([label, value]) => `${label} : ${Math.round((value / total) * 100)} %`)
-      );
-    })
-    .with('bar-chart', () =>
-      pipe(
-        Array.zip(labels, data),
-        Array.map(([label, value]) => `${label} : ${value}`)
-      )
-    )
-    .exhaustive();
-
-  return (
-    <Accordion label="Transcription">
-      <List>
-        {items.map((item, index) => (
-          <ListItem key={index}>{item}</ListItem>
-        ))}
-      </List>
-    </Accordion>
-  );
-}
-
-interface PieChartDisplayProps {
-  cardData: PieChartDataDTO;
-}
-
-function PieChartDisplay({ cardData }: Readonly<PieChartDisplayProps>) {
-  return (
-    <>
-      <PieChart
-        x={cardData.labels}
-        y={cardData.data}
-        name={cardData.labels}
-        color={[
-          'blue-france',
-          'blue-cumulus',
-          'blue-ecume',
-          'green-archipel',
-          'green-bourgeon',
-          'green-emeraude',
-          'green-menthe',
-          'green-tilleul-verveine'
-        ]}
-      />
-      <ChartTranscription
-        labels={cardData.labels}
-        data={cardData.data}
-        type="pie-chart"
-      />
-    </>
-  );
-}
-
-interface BarChartDisplayProps {
-  cardData: BarChartDataDTO;
-}
-
-function BarChartDisplay({ cardData }: Readonly<BarChartDisplayProps>) {
-  return (
-    <>
-      <BarChart
-        x={[cardData.labels]}
-        y={[cardData.data]}
-        horizontal={cardData.direction === 'horizontal'}
-      />
-      <ChartTranscription
-        labels={cardData.labels}
-        data={cardData.data}
-        type="bar-chart"
-      />
-    </>
-  );
-}
-
-function AnalysisCard({ card, dashboardId }: Readonly<Props>) {
   const { data, isLoading, isError } = useFindOneCardQuery({
     did: dashboardId,
     cid: card.id
@@ -190,10 +90,10 @@ function AnalysisCard({ card, dashboardId }: Readonly<Props>) {
 
       {match(data)
         .with({ type: 'pie-chart' }, (d) => (
-          <PieChartDisplay cardData={d} />
+          <PieChartDisplay chart={d} />
         ))
         .with({ type: 'bar-chart' }, (d) => (
-          <BarChartDisplay cardData={d} />
+          <BarChartDisplay chart={d} />
         ))
         .otherwise((d) => (
           <ShowcaseValue>{formatValue(d.data, card)}</ShowcaseValue>

--- a/frontend/src/components/Analysis/AnalysisCard.tsx
+++ b/frontend/src/components/Analysis/AnalysisCard.tsx
@@ -67,6 +67,7 @@ function ChartTranscription({
         data,
         Array.reduce(0, (acc, v) => acc + v)
       );
+      if (total === 0) return [];
       return pipe(
         Array.zip(labels, data),
         Array.map(([label, value]) => `${label} : ${Math.round((value / total) * 100)} %`)
@@ -83,8 +84,8 @@ function ChartTranscription({
   return (
     <Accordion label="Transcription">
       <ul>
-        {items.map((item) => (
-          <li key={item}>{item}</li>
+        {items.map((item, index) => (
+          <li key={index}>{item}</li>
         ))}
       </ul>
     </Accordion>

--- a/frontend/src/components/Analysis/AnalysisCard.tsx
+++ b/frontend/src/components/Analysis/AnalysisCard.tsx
@@ -113,9 +113,9 @@ function AnalysisCard({ card, dashboardId }: Readonly<Props>) {
 
       {data.type === 'pie-chart' ? (
         <PieChartDisplay cardData={data} />
-      ) : (
+      ) : data.type === 'flat-number' || data.type === 'percentage' ? (
         <ShowcaseValue>{formatValue(data.data, card)}</ShowcaseValue>
-      )}
+      ) : null}
     </CardBox>
   );
 }

--- a/frontend/src/components/Analysis/AnalysisCard.tsx
+++ b/frontend/src/components/Analysis/AnalysisCard.tsx
@@ -4,6 +4,8 @@ import Alert from '@codegouvfr/react-dsfr/Alert';
 import { BarChart } from '@codegouvfr/react-dsfr/Chart/BarChart';
 import { PieChart } from '@codegouvfr/react-dsfr/Chart/PieChart';
 import Box from '@mui/material/Box';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
 import Skeleton from '@mui/material/Skeleton';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
@@ -83,11 +85,11 @@ function ChartTranscription({
 
   return (
     <Accordion label="Transcription">
-      <ul>
+      <List>
         {items.map((item, index) => (
-          <li key={index}>{item}</li>
+          <ListItem key={index}>{item}</ListItem>
         ))}
-      </ul>
+      </List>
     </Accordion>
   );
 }

--- a/frontend/src/components/Analysis/AnalysisCard.tsx
+++ b/frontend/src/components/Analysis/AnalysisCard.tsx
@@ -1,5 +1,7 @@
 import { fr } from '@codegouvfr/react-dsfr';
+import Accordion from '@codegouvfr/react-dsfr/Accordion';
 import Alert from '@codegouvfr/react-dsfr/Alert';
+import { BarChart } from '@codegouvfr/react-dsfr/Chart/BarChart';
 import { PieChart } from '@codegouvfr/react-dsfr/Chart/PieChart';
 import Box from '@mui/material/Box';
 import Skeleton from '@mui/material/Skeleton';
@@ -7,10 +9,13 @@ import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import { styled } from '@mui/material/styles';
 import type {
+  BarChartDataDTO,
   DashboardCard,
   PieChartDataDTO,
   Resource
 } from '@zerologementvacant/models';
+import { Array, pipe } from 'effect';
+import { match } from 'ts-pattern';
 
 import { useFindOneCardQuery } from '~/services/dashboard.service';
 
@@ -45,27 +50,96 @@ function formatValue(data: number, card: DashboardCard): string {
   }).format(data);
 }
 
+interface ChartTranscriptionProps {
+  labels: string[];
+  data: number[];
+  type: 'pie-chart' | 'bar-chart';
+}
+
+function ChartTranscription({
+  labels,
+  data,
+  type
+}: Readonly<ChartTranscriptionProps>) {
+  const items = match(type)
+    .with('pie-chart', () => {
+      const total = pipe(
+        data,
+        Array.reduce(0, (acc, v) => acc + v)
+      );
+      return pipe(
+        Array.zip(labels, data),
+        Array.map(([label, value]) => `${label} : ${Math.round((value / total) * 100)} %`)
+      );
+    })
+    .with('bar-chart', () =>
+      pipe(
+        Array.zip(labels, data),
+        Array.map(([label, value]) => `${label} : ${value}`)
+      )
+    )
+    .exhaustive();
+
+  return (
+    <Accordion label="Transcription">
+      <ul>
+        {items.map((item) => (
+          <li key={item}>{item}</li>
+        ))}
+      </ul>
+    </Accordion>
+  );
+}
+
 interface PieChartDisplayProps {
   cardData: PieChartDataDTO;
 }
 
 function PieChartDisplay({ cardData }: Readonly<PieChartDisplayProps>) {
   return (
-    <PieChart
-      x={cardData.labels}
-      y={cardData.data}
-      name={cardData.labels}
-      color={[
-        'blue-france',
-        'blue-cumulus',
-        'blue-ecume',
-        'green-archipel',
-        'green-bourgeon',
-        'green-emeraude',
-        'green-menthe',
-        'green-tilleul-verveine'
-      ]}
-    />
+    <>
+      <PieChart
+        x={cardData.labels}
+        y={cardData.data}
+        name={cardData.labels}
+        color={[
+          'blue-france',
+          'blue-cumulus',
+          'blue-ecume',
+          'green-archipel',
+          'green-bourgeon',
+          'green-emeraude',
+          'green-menthe',
+          'green-tilleul-verveine'
+        ]}
+      />
+      <ChartTranscription
+        labels={cardData.labels}
+        data={cardData.data}
+        type="pie-chart"
+      />
+    </>
+  );
+}
+
+interface BarChartDisplayProps {
+  cardData: BarChartDataDTO;
+}
+
+function BarChartDisplay({ cardData }: Readonly<BarChartDisplayProps>) {
+  return (
+    <>
+      <BarChart
+        x={[cardData.labels]}
+        y={[cardData.data]}
+        horizontal={cardData.direction === 'horizontal'}
+      />
+      <ChartTranscription
+        labels={cardData.labels}
+        data={cardData.data}
+        type="bar-chart"
+      />
+    </>
   );
 }
 
@@ -111,11 +185,16 @@ function AnalysisCard({ card, dashboardId }: Readonly<Props>) {
         )}
       </Stack>
 
-      {data.type === 'pie-chart' ? (
-        <PieChartDisplay cardData={data} />
-      ) : data.type === 'flat-number' || data.type === 'percentage' ? (
-        <ShowcaseValue>{formatValue(data.data, card)}</ShowcaseValue>
-      ) : null}
+      {match(data)
+        .with({ type: 'pie-chart' }, (d) => (
+          <PieChartDisplay cardData={d} />
+        ))
+        .with({ type: 'bar-chart' }, (d) => (
+          <BarChartDisplay cardData={d} />
+        ))
+        .otherwise((d) => (
+          <ShowcaseValue>{formatValue(d.data, card)}</ShowcaseValue>
+        ))}
     </CardBox>
   );
 }

--- a/frontend/src/components/Analysis/AnalysisCard.tsx
+++ b/frontend/src/components/Analysis/AnalysisCard.tsx
@@ -9,7 +9,6 @@ import { styled } from '@mui/material/styles';
 import type {
   DashboardCard,
   PieChartDataDTO,
-  BarChartDataDTO,
   Resource
 } from '@zerologementvacant/models';
 
@@ -70,18 +69,6 @@ function PieChartDisplay({ cardData }: Readonly<PieChartDisplayProps>) {
   );
 }
 
-interface BarChartDisplayProps {
-  cardData: BarChartDataDTO;
-}
-
-function BarChartDisplay({ cardData }: Readonly<BarChartDisplayProps>) {
-  // Placeholder for bar chart rendering
-  // TODO: implement actual bar chart display
-  return (
-    <Typography>Bar chart ({cardData.direction}) coming soon</Typography>
-  );
-}
-
 function AnalysisCard({ card, dashboardId }: Readonly<Props>) {
   const { data, isLoading, isError } = useFindOneCardQuery({
     did: dashboardId,
@@ -126,8 +113,6 @@ function AnalysisCard({ card, dashboardId }: Readonly<Props>) {
 
       {data.type === 'pie-chart' ? (
         <PieChartDisplay cardData={data} />
-      ) : data.type === 'bar-chart' ? (
-        <BarChartDisplay cardData={data} />
       ) : (
         <ShowcaseValue>{formatValue(data.data, card)}</ShowcaseValue>
       )}

--- a/frontend/src/components/Analysis/AnalysisCard.tsx
+++ b/frontend/src/components/Analysis/AnalysisCard.tsx
@@ -9,6 +9,7 @@ import { styled } from '@mui/material/styles';
 import type {
   DashboardCard,
   PieChartDataDTO,
+  BarChartDataDTO,
   Resource
 } from '@zerologementvacant/models';
 
@@ -69,6 +70,18 @@ function PieChartDisplay({ cardData }: Readonly<PieChartDisplayProps>) {
   );
 }
 
+interface BarChartDisplayProps {
+  cardData: BarChartDataDTO;
+}
+
+function BarChartDisplay({ cardData }: Readonly<BarChartDisplayProps>) {
+  // Placeholder for bar chart rendering
+  // TODO: implement actual bar chart display
+  return (
+    <Typography>Bar chart ({cardData.direction}) coming soon</Typography>
+  );
+}
+
 function AnalysisCard({ card, dashboardId }: Readonly<Props>) {
   const { data, isLoading, isError } = useFindOneCardQuery({
     did: dashboardId,
@@ -113,6 +126,8 @@ function AnalysisCard({ card, dashboardId }: Readonly<Props>) {
 
       {data.type === 'pie-chart' ? (
         <PieChartDisplay cardData={data} />
+      ) : data.type === 'bar-chart' ? (
+        <BarChartDisplay cardData={data} />
       ) : (
         <ShowcaseValue>{formatValue(data.data, card)}</ShowcaseValue>
       )}

--- a/frontend/src/components/Analysis/BarChartDisplay.tsx
+++ b/frontend/src/components/Analysis/BarChartDisplay.tsx
@@ -1,0 +1,39 @@
+import { BarChart } from '@codegouvfr/react-dsfr/Chart/BarChart';
+import { styled } from '@mui/material/styles';
+import type { BarChartDataDTO } from '@zerologementvacant/models';
+
+import ChartTranscription from './ChartTranscription';
+
+const NoLegend = styled('div')({
+  '& .flex:has(.legende_dot)': {
+    display: 'none',
+  },
+});
+
+interface BarChartDisplayProps {
+  chart: BarChartDataDTO;
+}
+
+function BarChartDisplay(props: Readonly<BarChartDisplayProps>) {
+  const { chart } = props;
+
+  return (
+    <>
+      <NoLegend>
+        <BarChart
+          x={[chart.labels]}
+          y={[chart.data]}
+          horizontal={chart.direction === 'horizontal'}
+          color={['blue-france']}
+        />
+      </NoLegend>
+      <ChartTranscription
+        labels={chart.labels}
+        data={chart.data}
+        type="bar-chart"
+      />
+    </>
+  );
+}
+
+export default BarChartDisplay;

--- a/frontend/src/components/Analysis/ChartTranscription.tsx
+++ b/frontend/src/components/Analysis/ChartTranscription.tsx
@@ -1,0 +1,47 @@
+import Accordion from '@codegouvfr/react-dsfr/Accordion';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import { Array, pipe } from 'effect';
+import { match } from 'ts-pattern';
+
+interface ChartTranscriptionProps {
+  labels: string[];
+  data: number[];
+  type: 'pie-chart' | 'bar-chart';
+}
+
+function ChartTranscription(props: Readonly<ChartTranscriptionProps>) {
+  const { labels, data, type } = props;
+
+  const items = match(type)
+    .with('pie-chart', () => {
+      const total = pipe(
+        data,
+        Array.reduce(0, (acc, v) => acc + v)
+      );
+      if (total === 0) return [];
+      return pipe(
+        Array.zip(labels, data),
+        Array.map(([label, value]) => `${label} : ${Math.round((value / total) * 100)} %`)
+      );
+    })
+    .with('bar-chart', () =>
+      pipe(
+        Array.zip(labels, data),
+        Array.map(([label, value]) => `${label} : ${value}`)
+      )
+    )
+    .exhaustive();
+
+  return (
+    <Accordion label="Transcription">
+      <List>
+        {items.map((item, index) => (
+          <ListItem key={index}>{item}</ListItem>
+        ))}
+      </List>
+    </Accordion>
+  );
+}
+
+export default ChartTranscription;

--- a/frontend/src/components/Analysis/PieChartDisplay.tsx
+++ b/frontend/src/components/Analysis/PieChartDisplay.tsx
@@ -1,0 +1,39 @@
+import { PieChart } from '@codegouvfr/react-dsfr/Chart/PieChart';
+import type { PieChartDataDTO } from '@zerologementvacant/models';
+
+import ChartTranscription from './ChartTranscription';
+
+interface PieChartDisplayProps {
+  chart: PieChartDataDTO;
+}
+
+function PieChartDisplay(props: Readonly<PieChartDisplayProps>) {
+  const { chart } = props;
+
+  return (
+    <>
+      <PieChart
+        x={chart.labels}
+        y={chart.data}
+        name={chart.labels}
+        color={[
+          'blue-france',
+          'blue-cumulus',
+          'blue-ecume',
+          'green-archipel',
+          'green-bourgeon',
+          'green-emeraude',
+          'green-menthe',
+          'green-tilleul-verveine'
+        ]}
+      />
+      <ChartTranscription
+        labels={chart.labels}
+        data={chart.data}
+        type="pie-chart"
+      />
+    </>
+  );
+}
+
+export default PieChartDisplay;

--- a/frontend/src/components/Analysis/test/AnalysisCard.test.tsx
+++ b/frontend/src/components/Analysis/test/AnalysisCard.test.tsx
@@ -3,6 +3,8 @@ import { http, HttpResponse } from 'msw';
 import { Provider } from 'react-redux';
 
 import {
+  genBarChartCard,
+  genBarChartDataDTO,
   genFlatNumberCard,
   genPercentageCard,
   genPieChartCard,
@@ -100,5 +102,112 @@ describe('AnalysisCard', () => {
 
     await screen.findByText('Répartition par type');
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('renders a bar chart card without error when card type is bar-chart', async () => {
+    const barCard = genBarChartCard({ id: 80, title: 'Répartition par date de construction' });
+    const cardData = genBarChartDataDTO({
+      id: 80,
+      direction: 'vertical',
+      labels: ['1991 et apres', '1946 - 1990'],
+      data: [3200, 1800]
+    });
+    mockAPI.use(
+      http.get(
+        `${config.apiEndpoint}/dashboards/:did/cards/:cid`,
+        () => HttpResponse.json(cardData)
+      )
+    );
+
+    setup({ card: barCard, dashboardId });
+
+    await screen.findByText('Répartition par date de construction');
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('shows a transcription accordion for a pie chart', async () => {
+    const pieCard = genPieChartCard({ id: 77, title: 'Répartition par type' });
+    const cardData = genPieChartDataDTO({
+      id: 77,
+      labels: ['APPART', 'MAISON'],
+      data: [4876, 652]
+    });
+    mockAPI.use(
+      http.get(
+        `${config.apiEndpoint}/dashboards/:did/cards/:cid`,
+        () => HttpResponse.json(cardData)
+      )
+    );
+
+    setup({ card: pieCard, dashboardId });
+
+    await screen.findByText('Répartition par type');
+    expect(screen.getByRole('button', { name: /Transcription/i })).toBeInTheDocument();
+  });
+
+  it('shows percentage transcription items for a pie chart', async () => {
+    const pieCard = genPieChartCard({ id: 77, title: 'Répartition par type' });
+    // 4876 / (4876 + 652) * 100 = 88.2 → 88%
+    // 652  / (4876 + 652) * 100 = 11.8 → 12%
+    const cardData = genPieChartDataDTO({
+      id: 77,
+      labels: ['APPART', 'MAISON'],
+      data: [4876, 652]
+    });
+    mockAPI.use(
+      http.get(
+        `${config.apiEndpoint}/dashboards/:did/cards/:cid`,
+        () => HttpResponse.json(cardData)
+      )
+    );
+
+    setup({ card: pieCard, dashboardId });
+
+    await screen.findByText('Répartition par type');
+    expect(screen.getByText('APPART : 88 %')).toBeInTheDocument();
+    expect(screen.getByText('MAISON : 12 %')).toBeInTheDocument();
+  });
+
+  it('shows a transcription accordion for a bar chart', async () => {
+    const barCard = genBarChartCard({ id: 80, title: 'Répartition par date de construction' });
+    const cardData = genBarChartDataDTO({
+      id: 80,
+      direction: 'vertical',
+      labels: ['1991 et apres', '1946 - 1990'],
+      data: [3200, 1800]
+    });
+    mockAPI.use(
+      http.get(
+        `${config.apiEndpoint}/dashboards/:did/cards/:cid`,
+        () => HttpResponse.json(cardData)
+      )
+    );
+
+    setup({ card: barCard, dashboardId });
+
+    await screen.findByText('Répartition par date de construction');
+    expect(screen.getByRole('button', { name: /Transcription/i })).toBeInTheDocument();
+  });
+
+  it('shows raw value transcription items for a bar chart', async () => {
+    const barCard = genBarChartCard({ id: 80, title: 'Répartition par date de construction' });
+    const cardData = genBarChartDataDTO({
+      id: 80,
+      direction: 'vertical',
+      labels: ['1991 et apres', '1946 - 1990'],
+      data: [3200, 1800]
+    });
+    mockAPI.use(
+      http.get(
+        `${config.apiEndpoint}/dashboards/:did/cards/:cid`,
+        () => HttpResponse.json(cardData)
+      )
+    );
+
+    setup({ card: barCard, dashboardId });
+
+    await screen.findByText('Répartition par date de construction');
+    expect(screen.getByText('1991 et apres : 3200')).toBeInTheDocument();
+    expect(screen.getByText('1946 - 1990 : 1800')).toBeInTheDocument();
   });
 });

--- a/packages/models/src/DashboardDTO.ts
+++ b/packages/models/src/DashboardDTO.ts
@@ -1,6 +1,6 @@
 // packages/models/src/DashboardDTO.ts
 
-export type CardType = 'flat-number' | 'percentage' | 'pie-chart';
+export type CardType = 'flat-number' | 'percentage' | 'pie-chart' | 'bar-chart';
 
 export interface CardCommon {
   id: number;
@@ -24,7 +24,15 @@ export interface PieChartCard extends CardCommon {
   type: 'pie-chart';
 }
 
-export type DashboardCard = FlatNumberCard | PercentageCard | PieChartCard;
+export interface BarChartCard extends CardCommon {
+  type: 'bar-chart';
+}
+
+export type DashboardCard =
+  | FlatNumberCard
+  | PercentageCard
+  | PieChartCard
+  | BarChartCard;
 
 export interface Tab {
   id: number;
@@ -55,7 +63,15 @@ export interface PieChartDataDTO {
   labels: string[];
 }
 
-export type CardDataDTO = ScalarCardDataDTO | PieChartDataDTO;
+export interface BarChartDataDTO {
+  id: number;
+  type: 'bar-chart';
+  direction: 'horizontal' | 'vertical';
+  labels: string[];
+  data: number[];
+}
+
+export type CardDataDTO = ScalarCardDataDTO | PieChartDataDTO | BarChartDataDTO;
 
 export const RESOURCE_VALUES = [
   '6-utilisateurs-de-zlv-sur-votre-structure',

--- a/packages/models/src/test/fixtures.ts
+++ b/packages/models/src/test/fixtures.ts
@@ -6,6 +6,8 @@ import { MarkRequired } from 'ts-essentials';
 import type { BBox } from 'geojson';
 import { match, Pattern } from 'ts-pattern';
 import type {
+  BarChartCard,
+  BarChartDataDTO,
   DashboardCard,
   DashboardDTO,
   FlatNumberCard,
@@ -1056,6 +1058,41 @@ export function genPieChartDataDTO(
   return {
     id: faker.number.int({ min: 1, max: 9999 }),
     type: 'pie-chart',
+    labels,
+    data,
+    ...override
+  };
+}
+
+export function genBarChartCard(
+  override?: Partial<BarChartCard>
+): BarChartCard {
+  return {
+    id: faker.number.int({ min: 1, max: 9999 }),
+    type: 'bar-chart',
+    title: faker.lorem.words(3),
+    description: null,
+    decimals: 0,
+    position: { col: 0, row: 0 },
+    size: { width: 6, height: 4 },
+    ...override
+  };
+}
+
+export function genBarChartDataDTO(
+  override?: Partial<BarChartDataDTO>
+): BarChartDataDTO {
+  const series = faker.number.int({ min: 2, max: 5 });
+  const labels: string[] = [];
+  const data: number[] = [];
+  for (let i = 0; i < series; i++) {
+    labels.push(faker.word.noun());
+    data.push(faker.number.int({ min: 1, max: 10000 }));
+  }
+  return {
+    id: faker.number.int({ min: 1, max: 9999 }),
+    type: 'bar-chart',
+    direction: faker.helpers.arrayElement(['horizontal', 'vertical'] as const),
     labels,
     data,
     ...override

--- a/server/src/controllers/dashboardController.ts
+++ b/server/src/controllers/dashboardController.ts
@@ -4,6 +4,7 @@ import { constants } from 'node:http2';
 import jwt from 'jsonwebtoken';
 
 import type { CardDataDTO, DashboardDTO, Resource } from '@zerologementvacant/models';
+import type { BarChartValue, PieChartValue } from '~/services/metabase/metabase-service';
 import { RESOURCE_VALUES } from '@zerologementvacant/models';
 import DashcardMissingError from '~/errors/dashcardMissingError';
 import UnprocessableEntityError from '~/errors/unprocessableEntityError';
@@ -68,15 +69,29 @@ async function findOneCard(
     dashcard.cardId,
     queryParameters,
     dashcard.valueColumn,
-    dashcard.type
+    dashcard.type,
+    dashcard.direction
   );
 
+  if (dashcard.type === 'bar-chart' && typeof raw === 'object' && raw !== null) {
+    const barRaw = raw as BarChartValue;
+    response.status(constants.HTTP_STATUS_OK).json({
+      id: numericCid,
+      type: 'bar-chart',
+      direction: barRaw.direction,
+      labels: barRaw.labels,
+      data: barRaw.data
+    });
+    return;
+  }
+
   if (typeof raw === 'object' && raw !== null) {
+    const pieRaw = raw as PieChartValue;
     response.status(constants.HTTP_STATUS_OK).json({
       id: numericCid,
       type: 'pie-chart',
-      labels: raw.labels,
-      data: raw.data
+      labels: pieRaw.labels,
+      data: pieRaw.data
     });
     return;
   }

--- a/server/src/controllers/test/dashboard-api.test.ts
+++ b/server/src/controllers/test/dashboard-api.test.ts
@@ -185,6 +185,63 @@ const mockPieCardQueryResult = {
   status: 'completed'
 };
 
+const mockMetabaseDashboardWithBarCard = {
+  id: 13,
+  dashcards: [
+    {
+      id: 960,
+      card_id: 810,
+      dashboard_tab_id: null,
+      row: 0,
+      col: 0,
+      size_x: 6,
+      size_y: 4,
+      visualization_settings: { 'card.title': 'Répartition par date de construction' },
+      card: {
+        id: 810,
+        name: 'Répartition par date de construction',
+        display: 'bar',
+        description: null,
+        visualization_settings: {}
+      }
+    }
+  ]
+};
+
+const mockMetabaseDashboardWithRowCard = {
+  id: 13,
+  dashcards: [
+    {
+      id: 961,
+      card_id: 811,
+      dashboard_tab_id: null,
+      row: 0,
+      col: 0,
+      size_x: 6,
+      size_y: 4,
+      visualization_settings: { 'card.title': 'Répartition horizontale' },
+      card: {
+        id: 811,
+        name: 'Répartition horizontale',
+        display: 'row',
+        description: null,
+        visualization_settings: {}
+      }
+    }
+  ]
+};
+
+const mockBarCardQueryResult = {
+  data: {
+    rows: [
+      ['1991 et apres', 3200],
+      ['1946 - 1990', 1800]
+    ],
+    cols: [{ name: 'period' }, { name: 'count' }]
+  },
+  status: 'completed'
+};
+
 describe('Dashboard API', () => {
   let url: string;
 
@@ -291,6 +348,50 @@ describe('Dashboard API', () => {
       }
     });
 
+    it('returns a bar-chart card when display is "bar"', async () => {
+      nock(METABASE_URL)
+        .get('/api/dashboard/13')
+        .reply(200, mockMetabaseDashboardWithBarCard);
+
+      const response = await request(url)
+        .get('/dashboards/13-analyses')
+        .use(tokenProvider(user));
+
+      expect(response.status).toBe(constants.HTTP_STATUS_OK);
+      const body = response.body as DashboardDTO;
+      expect('cards' in body).toBe(true);
+      if ('cards' in body) {
+        expect(body.cards).toHaveLength(1);
+        expect(body.cards[0]).toMatchObject({
+          id: 960,
+          type: 'bar-chart',
+          title: 'Répartition par date de construction'
+        });
+      }
+    });
+
+    it('returns a bar-chart card when display is "row"', async () => {
+      nock(METABASE_URL)
+        .get('/api/dashboard/13')
+        .reply(200, mockMetabaseDashboardWithRowCard);
+
+      const response = await request(url)
+        .get('/dashboards/13-analyses')
+        .use(tokenProvider(user));
+
+      expect(response.status).toBe(constants.HTTP_STATUS_OK);
+      const body = response.body as DashboardDTO;
+      expect('cards' in body).toBe(true);
+      if ('cards' in body) {
+        expect(body.cards).toHaveLength(1);
+        expect(body.cards[0]).toMatchObject({
+          id: 961,
+          type: 'bar-chart',
+          title: 'Répartition horizontale'
+        });
+      }
+    });
+
     it('returns 422 for unknown slug', async () => {
       const response = await request(url)
         .get('/dashboards/unknown-slug')
@@ -357,6 +458,50 @@ describe('Dashboard API', () => {
         type: 'pie-chart',
         labels: ['APPART', 'MAISON'],
         data: [4876, 652]
+      });
+    });
+
+    it('returns BarChartDataDTO with direction "vertical" for display "bar"', async () => {
+      nock(METABASE_URL)
+        .get('/api/dashboard/13')
+        .reply(200, mockMetabaseDashboardWithBarCard);
+      nock(METABASE_URL)
+        .post('/api/dashboard/13/dashcard/960/card/810/query')
+        .reply(200, mockBarCardQueryResult);
+
+      const response = await request(url)
+        .get('/dashboards/13-analyses/cards/960')
+        .use(tokenProvider(user));
+
+      expect(response.status).toBe(constants.HTTP_STATUS_OK);
+      expect(response.body).toMatchObject({
+        id: 960,
+        type: 'bar-chart',
+        direction: 'vertical',
+        labels: ['1991 et apres', '1946 - 1990'],
+        data: [3200, 1800]
+      });
+    });
+
+    it('returns BarChartDataDTO with direction "horizontal" for display "row"', async () => {
+      nock(METABASE_URL)
+        .get('/api/dashboard/13')
+        .reply(200, mockMetabaseDashboardWithRowCard);
+      nock(METABASE_URL)
+        .post('/api/dashboard/13/dashcard/961/card/811/query')
+        .reply(200, mockBarCardQueryResult);
+
+      const response = await request(url)
+        .get('/dashboards/13-analyses/cards/961')
+        .use(tokenProvider(user));
+
+      expect(response.status).toBe(constants.HTTP_STATUS_OK);
+      expect(response.body).toMatchObject({
+        id: 961,
+        type: 'bar-chart',
+        direction: 'horizontal',
+        labels: ['1991 et apres', '1946 - 1990'],
+        data: [3200, 1800]
       });
     });
 

--- a/server/src/services/metabase/metabase-api.ts
+++ b/server/src/services/metabase/metabase-api.ts
@@ -3,6 +3,7 @@ import axios from 'axios';
 import type { CardType, DashboardCard, Tab } from '@zerologementvacant/models';
 import config from '~/infra/config';
 import type {
+  BarChartValue,
   CardValue,
   DashboardData,
   DashboardParameter,
@@ -146,6 +147,18 @@ function normalizeDashcard(dashcard: MetabaseDashcard): DashboardCard | null {
     };
   }
 
+  if (card.display === 'bar' || card.display === 'row') {
+    return {
+      id: dashcard.id,
+      type: 'bar-chart',
+      title: dashcard.visualization_settings['card.title'] ?? card.name,
+      description: card.description,
+      decimals: 0,
+      position: { col: dashcard.col, row: dashcard.row },
+      size: { width: dashcard.size_x, height: dashcard.size_y }
+    };
+  }
+
   if (card.display !== 'scalar') return null;
 
   const settings = mergeVisualizationSettings(
@@ -198,6 +211,20 @@ function findDashcardRef(
       cardId: found.card_id,
       type: 'pie-chart',
       valueColumn: null,
+      direction: null,
+      dashboardParameters: (raw.parameters ?? []).map(
+        (p): DashboardParameter => ({ id: p.id, slug: p.slug, type: p.type })
+      )
+    };
+  }
+
+  if (normalized.type === 'bar-chart') {
+    return {
+      dashcardId: found.id,
+      cardId: found.card_id,
+      type: 'bar-chart',
+      valueColumn: null,
+      direction: found.card!.display === 'bar' ? 'vertical' : 'horizontal',
       dashboardParameters: (raw.parameters ?? []).map(
         (p): DashboardParameter => ({ id: p.id, slug: p.slug, type: p.type })
       )
@@ -213,6 +240,7 @@ function findDashcardRef(
     cardId: found.card_id,
     type: normalized.type,
     valueColumn: settings['scalar.field'] ?? null,
+    direction: null,
     dashboardParameters: (raw.parameters ?? []).map(
       (p): DashboardParameter => ({ id: p.id, slug: p.slug, type: p.type })
     )
@@ -253,7 +281,8 @@ class MetabaseAPI implements MetabaseService {
     cardId: number,
     parameters: ReadonlyArray<DashboardParameter & { value: string }>,
     valueColumn: string | null,
-    cardType: CardType
+    cardType: CardType,
+    direction: 'horizontal' | 'vertical' | null
   ): Promise<CardValue> {
     const { data } = await this.http.post<MetabaseQueryResult>(
       `/api/dashboard/${dashboardId}/dashcard/${dashcardId}/card/${cardId}/query`,
@@ -262,6 +291,15 @@ class MetabaseAPI implements MetabaseService {
 
     if (cardType === 'pie-chart') {
       const result: PieChartValue = {
+        labels: data.data.rows.map((row) => String(row[0])),
+        data: data.data.rows.map((row) => Number(row[1]))
+      };
+      return result;
+    }
+
+    if (cardType === 'bar-chart') {
+      const result: BarChartValue = {
+        direction: direction!,
         labels: data.data.rows.map((row) => String(row[0])),
         data: data.data.rows.map((row) => Number(row[1]))
       };

--- a/server/src/services/metabase/metabase-api.ts
+++ b/server/src/services/metabase/metabase-api.ts
@@ -298,8 +298,11 @@ class MetabaseAPI implements MetabaseService {
     }
 
     if (cardType === 'bar-chart') {
+      if (direction === null) {
+        throw new Error('direction is required for bar-chart card type');
+      }
       const result: BarChartValue = {
-        direction: direction!,
+        direction,
         labels: data.data.rows.map((row) => String(row[0])),
         data: data.data.rows.map((row) => Number(row[1]))
       };

--- a/server/src/services/metabase/metabase-service.ts
+++ b/server/src/services/metabase/metabase-service.ts
@@ -15,11 +15,17 @@ export interface DashcardRef {
   cardId: number;
   type: CardType;
   valueColumn: string | null;
+  direction: 'horizontal' | 'vertical' | null;
   dashboardParameters: ReadonlyArray<DashboardParameter>;
 }
 
 export type PieChartValue = { labels: string[]; data: number[] };
-export type CardValue = number | PieChartValue;
+export type BarChartValue = {
+  direction: 'horizontal' | 'vertical';
+  labels: string[];
+  data: number[];
+};
+export type CardValue = number | PieChartValue | BarChartValue;
 
 export interface MetabaseService {
   getDashboard(id: number): Promise<DashboardData>;
@@ -30,6 +36,7 @@ export interface MetabaseService {
     cardId: number,
     parameters: ReadonlyArray<DashboardParameter & { value: string }>,
     valueColumn: string | null,
-    cardType: CardType
+    cardType: CardType,
+    direction: 'horizontal' | 'vertical' | null
   ): Promise<CardValue>;
 }


### PR DESCRIPTION
## Summary

- Extends the shared data model (`packages/models`) with `BarChartCard` and `BarChartDataDTO` types, including a `direction: 'horizontal' | 'vertical'` field derived from the Metabase `display` value (`'bar'` → vertical, `'row'` → horizontal)
- Detects and maps Metabase bar chart cards in the backend (`metabase-api.ts`): both `display: 'bar'` and `display: 'row'` are now handled, with `direction` resolved at the `findDashcard` level and passed through to the response
- Renders bar charts in `AnalysisCard` using the DSFR `BarChart` component, with `ts-pattern` replacing the previous ternary dispatch
- Adds a `ChartTranscription` accordion (DSFR `Accordion`) to both pie and bar charts: pie items are formatted as percentages, bar items as raw values; generated from `labels + data` so Metabase remains the single source of truth

## Test Plan

- [ ] Verify `GET /dashboards/:id` returns `type: 'bar-chart'` cards for Metabase dashboards with `display: 'bar'` or `display: 'row'`
- [ ] Verify `GET /dashboards/:did/cards/:cid` returns `BarChartDataDTO` with correct `direction`, `labels`, and `data`
- [ ] Open the Analysis page — bar charts render horizontally or vertically per Metabase configuration
- [ ] A "Transcription" accordion is visible beneath both bar charts and pie charts
- [ ] Pie chart transcription shows `label : NN %` items; bar chart shows `label : NN` items
- [ ] Existing scalar cards (flat-number, percentage) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)