### PR TITLE
feat(analytics): sync CEREMA Portail DF LOVAC users monthly and surface unregistered ones

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -3,8 +3,16 @@ fileignoreconfig:
   checksum: 5b3a281c32a6fab83c8385a64a45faddcac10f226b8daa85bdbf6a29d6b062a8
 - filename: README.md
   checksum: e9453f34a422b94f243daf56302141d9fc22cddf802423f64da72cee91c407d2
+- filename: analytics/dagster/src/assets/dwh/ingest/ingest_cerema_lovac_users_asset.py
+  checksum: 37f1b166a3faf6cb78b7591b6f7031aa110e05e8aeb90b3b222ee22bf71f9713
 - filename: analytics/dagster/src/assets/dwh/ingest/ingest_postgres_asset.py
   checksum: b379fbb88e46511c62682abf4cb422e730c4210f6dadc9d5ca648dfd68ff8f88
+- filename: analytics/dagster/src/config.py
+  checksum: 8f99243a8283bb0b5ea0f6513647557274a5da958684e68a9dc3b86b44974a5b
+- filename: analytics/dbt/models/marts/production/marts_production_cerema_lovac_users_unregistered.sql
+  checksum: 4f5752352d75a7a4f9504cb7f1495c2a2cec6725942a34fa7f572feef03436a0
+- filename: analytics/dbt/models/staging/external/cerema/stg_external_cerema_lovac_users.sql
+  checksum: e6ccfed9e9dd6d2b53f3f00eb89a1cb574e516736d7f2122e53c2f820b2f81f9
 - filename: analytics/dagster/src/assets/populate_edited_owners_ban_addresses.py
   checksum: c3a27f2457d2c1cd5f01ef1940c78bc40f8dedb0aff7a5edbc0d1b1e5000f5d3
 - filename: analytics/dagster/src/assets/populate_housings_ban_addresses.py

--- a/analytics/dagster/DATA_SOURCES_CATALOG.md
+++ b/analytics/dagster/DATA_SOURCES_CATALOG.md
@@ -25,6 +25,7 @@ This document catalogs all external data sources to be integrated into the Zero 
 |--------|------|-------------|-----|-----------|-------|
 | 🟢 | LOVAC | Logements vacants (2019-2025) | S3 Internal | CSV | Already implemented via S3 |
 | 🟢 | Fichiers Fonciers | Fichiers fonciers (2019-2024) | S3 Internal | CSV | Already implemented via S3 |
+| 🟢 | LOVAC users (Portail DF) | Users belonging to a structure with LOVAC access | Portail DF API | JSON | Monthly sync; auth via `CEREMA_USERNAME`/`CEREMA_PASSWORD` → `/api/token/` |
 | 🔴 | DV3F | Demandes de Valeurs Foncières | TBD | TBD | Large dataset, may need special handling |
 | ⚠️ | Prix immobiliers | Evolution des prix immobiliers par commune (2010-2021) | TBD | XLSX | Files: dv3f_prix_volumes_communes_20XX.xlsx |
 | ⚠️ | Consommation d'espace | Consommation d'espace (2009-2022) | TBD | CSV | |

--- a/analytics/dagster/src/assets/dwh/ingest/ingest_cerema_lovac_users_asset.py
+++ b/analytics/dagster/src/assets/dwh/ingest/ingest_cerema_lovac_users_asset.py
@@ -1,0 +1,189 @@
+"""
+Dagster asset to ingest CEREMA Portail DF LOVAC users into the warehouse.
+
+Fetches every user belonging to a structure that has LOVAC access, by
+authenticating against the Portail DF token endpoint and walking the
+paginated `structures` + `utilisateurs` endpoints.
+
+The result is materialized as `external.cerema_lovac_users_raw` on MotherDuck,
+ready to be consumed by dbt staging models.
+"""
+
+import time
+from typing import Any
+
+import pandas as pd
+import requests
+from dagster import AssetExecutionContext, MaterializeResult, RetryPolicy, asset
+from dagster_duckdb import DuckDBResource
+
+from ....config import Config
+
+TABLE_NAME = "external.cerema_lovac_users_raw"
+PAGE_SLEEP_SECONDS = 0.3
+REQUEST_TIMEOUT_SECONDS = 60
+
+
+def _clean_url(url: str) -> str:
+    """Upgrade HTTP→HTTPS and strip the `#`/`%23` corruption that Portail DF
+    introduces on `next` page links after a redirect."""
+    if not url:
+        return url
+    if url.startswith("http://portaildf.cerema.fr"):
+        url = url.replace("http://", "https://", 1)
+    url = url.replace("/%23?", "/?").replace("/%23", "/")
+    url = url.replace("%23?", "?").replace("#?", "?")
+    return url.replace("%23", "").replace("#", "")
+
+
+def _fetch_access_token(context: AssetExecutionContext) -> str:
+    """Exchange username + password for a short-lived access token."""
+    if not Config.CEREMA_USERNAME or not Config.CEREMA_PASSWORD:
+        raise ValueError(
+            "CEREMA_USERNAME and CEREMA_PASSWORD must be set in the environment."
+        )
+
+    token_url = f"{Config.CEREMA_API_BASE_URL.rstrip('/')}/token/"
+    context.log.info(f"Authenticating against {token_url}")
+    response = requests.post(
+        token_url,
+        json={
+            "username": Config.CEREMA_USERNAME,
+            "password": Config.CEREMA_PASSWORD,
+        },
+        timeout=REQUEST_TIMEOUT_SECONDS,
+    )
+    response.raise_for_status()
+    access_token = response.json().get("access")
+    if not access_token:
+        raise ValueError("Portail DF token endpoint did not return an access token.")
+    return access_token
+
+
+def _fetch_all_pages(
+    session: requests.Session,
+    base_url: str,
+    endpoint: str,
+    context: AssetExecutionContext,
+) -> list[dict[str, Any]]:
+    """Walk every page of a paginated Portail DF endpoint."""
+    results: list[dict[str, Any]] = []
+    url: str | None = f"{base_url}/{endpoint}"
+    page = 1
+    while url:
+        response = session.get(url, timeout=REQUEST_TIMEOUT_SECONDS)
+        response.raise_for_status()
+        payload = response.json()
+        results.extend(payload.get("results", []))
+        next_url = payload.get("next")
+        url = _clean_url(next_url) if next_url else None
+        context.log.debug(f"{endpoint}: fetched page {page}, running total {len(results)}")
+        page += 1
+        time.sleep(PAGE_SLEEP_SECONDS)
+    context.log.info(f"{endpoint}: {len(results)} items fetched across {page - 1} pages")
+    return results
+
+
+def _build_lovac_users(
+    structures: list[dict[str, Any]],
+    users: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Filter to structures with LOVAC access (acces_lovac date set), then
+    join users on their structure id. Matches the legacy script's shape so the
+    downstream mart can keep its filter on `structure_acces_lovac`."""
+    lovac_structures: dict[Any, dict[str, Any]] = {}
+    for structure in structures:
+        if structure.get("acces_lovac") is None:
+            continue
+        struct_id = structure.get("id_structure") or structure.get("id")
+        if struct_id is None:
+            continue
+        lovac_structures[struct_id] = {
+            "raison_sociale": structure.get("raison_sociale", ""),
+            "siret": structure.get("siret", ""),
+            "niveau_acces": structure.get("niveau_acces", ""),
+            "acces_lovac": structure.get("acces_lovac"),
+        }
+
+    lovac_users: list[dict[str, Any]] = []
+    for user in users:
+        structure_ref = user.get("structure")
+        if isinstance(structure_ref, dict):
+            structure_id = structure_ref.get("id_structure") or structure_ref.get("id")
+        else:
+            structure_id = structure_ref
+        if structure_id is None or structure_id not in lovac_structures:
+            continue
+        structure = lovac_structures[structure_id]
+        lovac_users.append({
+            "email": user.get("email", ""),
+            "id_user": user.get("id_user", ""),
+            "exterieur": user.get("exterieur", False),
+            "gestionnaire": user.get("gestionnaire", False),
+            "date_rattachement": user.get("date_rattachement"),
+            "date_expiration": user.get("date_expiration"),
+            "cgu_valide": user.get("cgu_valide"),
+            "structure_id": structure_id,
+            "structure_raison_sociale": structure["raison_sociale"],
+            "structure_siret": structure["siret"],
+            "structure_niveau_acces": structure["niveau_acces"],
+            "structure_acces_lovac": structure["acces_lovac"],
+        })
+    return lovac_users
+
+
+@asset(
+    name="raw_cerema_lovac_users_raw",
+    deps=["setup_external_schema"],
+    group_name="cerema",
+    compute_kind="duckdb",
+    description=(
+        "Users belonging to a Portail DF structure with LOVAC access. "
+        "Sourced from CEREMA Portail DF API; refreshed monthly."
+    ),
+    retry_policy=RetryPolicy(
+        max_retries=Config.DAGSTER_RETRY_MAX_ATTEMPS,
+        delay=Config.DAGSTER_RETRY_DELAY,
+    ),
+)
+def raw_cerema_lovac_users_raw(
+    context: AssetExecutionContext, duckdb: DuckDBResource
+) -> MaterializeResult:
+    access_token = _fetch_access_token(context)
+    base_url = Config.CEREMA_API_BASE_URL.rstrip("/")
+
+    session = requests.Session()
+    session.headers.update({
+        "Authorization": f"Bearer {access_token}",
+        "Accept": "application/json",
+    })
+
+    structures = _fetch_all_pages(session, base_url, "structures", context)
+    users = _fetch_all_pages(session, base_url, "utilisateurs", context)
+    lovac_users = _build_lovac_users(structures, users)
+
+    if not lovac_users:
+        context.log.warning("No LOVAC users found — leaving the existing table untouched.")
+        return MaterializeResult(metadata={"row_count": 0})
+
+    dataframe = pd.DataFrame(lovac_users)
+
+    with duckdb.get_connection() as connection:
+        connection.register("lovac_users_df", dataframe)
+        connection.execute(
+            f"CREATE OR REPLACE TABLE {TABLE_NAME} AS SELECT * FROM lovac_users_df"
+        )
+        connection.unregister("lovac_users_df")
+        row_count = connection.execute(
+            f"SELECT COUNT(*) FROM {TABLE_NAME}"
+        ).fetchone()[0]
+
+    context.log.info(f"Loaded {row_count} rows into {TABLE_NAME}")
+    return MaterializeResult(
+        metadata={
+            "table": TABLE_NAME,
+            "row_count": row_count,
+            "structures_total": len(structures),
+            "users_total": len(users),
+        }
+    )

--- a/analytics/dagster/src/config.py
+++ b/analytics/dagster/src/config.py
@@ -95,7 +95,8 @@ production_tables = [
     "marts_production_groups",
     "marts_production_users",
     "marts_production_campaigns",
-    "marts_production_events"
+    "marts_production_events",
+    "marts_production_cerema_lovac_users_unregistered"
 ]
 
 join_tables = [

--- a/analytics/dagster/src/config.py
+++ b/analytics/dagster/src/config.py
@@ -24,6 +24,10 @@ class Config:
     CLEVER_TOKEN = os.environ.get("CLEVER_TOKEN")
     CLEVER_SECRET = os.environ.get("CLEVER_SECRET")
 
+    CEREMA_API_BASE_URL = os.environ.get("CEREMA_API_BASE_URL", "https://portaildf.cerema.fr/api")
+    CEREMA_USERNAME = os.environ.get("CEREMA_USERNAME")
+    CEREMA_PASSWORD = os.environ.get("CEREMA_PASSWORD")
+
     DUCKDB_MEMORY_LIMIT = os.environ.get("DUCKDB_MEMORY_LIMIT")
     DUCKDB_THREAD_NUMBER = os.environ.get("DUCKDB_THREAD_NUMBER", 4)
     METABASE_APP_ID = os.environ.get("METABASE_APP_ID")

--- a/analytics/dagster/src/definitions.py
+++ b/analytics/dagster/src/definitions.py
@@ -128,7 +128,8 @@ cerema_lovac_users_monthly_job = define_asset_job(
 cerema_lovac_users_monthly_schedule = ScheduleDefinition(
     job=cerema_lovac_users_monthly_job,
     cron_schedule="@monthly",
-    description="Monthly sync of LOVAC users from CEREMA Portail DF (first day of each month, 00:00 UTC).",
+    default_status=DefaultScheduleStatus.STOPPED,
+    description="Monthly sync of LOVAC users from CEREMA Portail DF (first day of each month, 00:00 UTC). Starts STOPPED — enable via Dagster UI after backfill validation.",
 )
 
 # Load definitions with assets, resources, and schedule
@@ -136,6 +137,7 @@ defs = Definitions(
     assets=[
         sync_owners_ban_addresses,
         sync_housings_ban_addresses,
+        raw_cerema_lovac_users_raw,
         *dwh_assets,  # This already includes setup_external_schema and import_all_external_sources
         *dbt_analytics_assets,
         *clever_assets_assets,

--- a/analytics/dagster/src/definitions.py
+++ b/analytics/dagster/src/definitions.py
@@ -37,6 +37,9 @@ from .assets.dwh.ingest.ingest_external_sources_asset import (
     setup_external_schema,
     import_all_external_sources,
 )
+from .assets.dwh.ingest.ingest_cerema_lovac_users_asset import (
+    raw_cerema_lovac_users_raw,
+)
 from .assets.dwh.ingest.queries.external_sources_config import EXTERNAL_SOURCES
 from .assets.dwh.checks.ff_table_exists import check_ff_lovac_on_duckdb
 from .assets.dwh.upload.upload_ff_db_to_cellar import upload_ff_to_s3
@@ -112,6 +115,22 @@ ban_daily_sync_schedule = ScheduleDefinition(
     description="Daily BAN sync at 03:00 UTC. Starts STOPPED — enable via Dagster UI after backfill validation.",
 )
 
+cerema_lovac_users_monthly_job = define_asset_job(
+    name="cerema_lovac_users_monthly_sync",
+    selection=AssetSelection.assets(
+        "setup_duckdb",
+        setup_external_schema,
+        raw_cerema_lovac_users_raw,
+    ),
+    description="Monthly refresh of CEREMA Portail DF LOVAC users.",
+)
+
+cerema_lovac_users_monthly_schedule = ScheduleDefinition(
+    job=cerema_lovac_users_monthly_job,
+    cron_schedule="@monthly",
+    description="Monthly sync of LOVAC users from CEREMA Portail DF (first day of each month, 00:00 UTC).",
+)
+
 # Load definitions with assets, resources, and schedule
 defs = Definitions(
     assets=[
@@ -140,9 +159,11 @@ defs = Definitions(
         daily_refresh_schedule,
         yearly_external_sources_refresh_schedule,
         ban_daily_sync_schedule,
+        cerema_lovac_users_monthly_schedule,
     ],
     jobs=[
         yearly_update_all_external_sources_job,
         ban_daily_sync_job,
+        cerema_lovac_users_monthly_job,
     ],
 )

--- a/analytics/dbt/models/marts/production/marts_production_cerema_lovac_users_unregistered.sql
+++ b/analytics/dbt/models/marts/production/marts_production_cerema_lovac_users_unregistered.sql
@@ -1,0 +1,10 @@
+{{ config(materialized='table') }}
+
+select *
+from {{ ref('stg_external_cerema_lovac_users') }}
+where email not in (
+    select email
+    from {{ ref('int_production_users') }}
+    where email is not null
+)
+  and structure_acces_lovac is not null

--- a/analytics/dbt/models/marts/production/schema.yml
+++ b/analytics/dbt/models/marts/production/schema.yml
@@ -684,6 +684,23 @@ models:
       - name: street_address
         description: "Adresse de rue"
 
+  - name: marts_production_cerema_lovac_users_unregistered
+    description: "LOVAC users from CEREMA Portail DF who do not yet have an account in ZLV — onboarding gap list refreshed monthly via Dagster."
+    columns:
+      - name: email
+        description: "Email of the LOVAC user from Portail DF. Unique within this mart since each user appears at most once in the source."
+        tests:
+          - unique
+          - not_null
+      - name: structure_acces_lovac
+        description: "Date the user's structure was granted LOVAC access."
+        tests:
+          - not_null
+      - name: structure_siret
+        description: "SIRET of the user's Portail DF structure — useful to map to the corresponding ZLV establishment."
+      - name: structure_raison_sociale
+        description: "Raison sociale of the user's Portail DF structure."
+
   - name: marts_production_users
     description: "Table des utilisateurs avec informations sur leurs établissements de rattachement"
     columns:

--- a/analytics/dbt/models/staging/external/cerema/schemas.yml
+++ b/analytics/dbt/models/staging/external/cerema/schemas.yml
@@ -6,4 +6,14 @@ models:
   - name: stg_external_cerema_prix_volumes_appartements
   - name: stg_external_cerema_prix_volumes_bati
   - name: stg_external_cerema_prix_volumes_maisons
-    
+  - name: stg_external_cerema_lovac_users
+    description: "LOVAC users from CEREMA Portail DF — every active user belonging to a structure that has LOVAC access. Refreshed monthly."
+    columns:
+      - name: email
+        description: "User email; the join key against ZLV's production.users."
+        tests:
+          - not_null
+      - name: structure_acces_lovac
+        description: "Date on which the user's structure was granted LOVAC access. Always set in this staging table because the upstream script pre-filters to LOVAC-enabled structures."
+        tests:
+          - not_null

--- a/analytics/dbt/models/staging/external/cerema/sources.yml
+++ b/analytics/dbt/models/staging/external/cerema/sources.yml
@@ -113,3 +113,14 @@ sources:
       - name: cerema_prix_volumes_2013_communes_ensemble_des_appartements_raw
         description: "Prix volumes 2013 communes - Ensemble des appartements"
 
+      # Portail DF — LOVAC users
+      - name: cerema_lovac_users_raw
+        description: "Users belonging to a Portail DF structure with LOVAC access, fetched monthly from the Portail DF API."
+        meta:
+          dagster_asset_key: raw_cerema_lovac_users_raw
+        columns:
+          - name: email
+            description: "User email — the join key against the ZLV users table."
+            tests:
+              - not_null
+

--- a/analytics/dbt/models/staging/external/cerema/stg_external_cerema_lovac_users.sql
+++ b/analytics/dbt/models/staging/external/cerema/stg_external_cerema_lovac_users.sql
@@ -1,0 +1,25 @@
+{{ config(materialized='view') }}
+
+with source as (
+    select * from {{ source('external_cerema', 'cerema_lovac_users_raw') }}
+),
+
+renamed as (
+    select
+        email,
+        id_user,
+        exterieur,
+        gestionnaire,
+        cast(date_rattachement as date) as date_rattachement,
+        cast(date_expiration as date) as date_expiration,
+        cgu_valide,
+        structure_id,
+        structure_raison_sociale,
+        structure_siret,
+        structure_niveau_acces,
+        cast(structure_acces_lovac as date) as structure_acces_lovac,
+        current_timestamp as _loaded_at
+    from source
+)
+
+select * from renamed


### PR DESCRIPTION
## Summary

- **New Dagster asset** (`raw_cerema_lovac_users_raw`) that authenticates against the CEREMA Portail DF API (`/api/token/`), fetches every user belonging to a structure with LOVAC access, and writes the result to `external.cerema_lovac_users_raw` on MotherDuck.
- **Monthly schedule** (`cerema_lovac_users_monthly_sync`) refreshes the bronze table on the 1st of each month.
- **New dbt mart** (`marts_production_cerema_lovac_users_unregistered`) joins the bronze table against `int_production_users` to surface every LOVAC user from Portail DF who does not yet have a ZLV account — the recurring onboarding gap list.
- Staging view `stg_external_cerema_lovac_users` typed with date casts + `_loaded_at`, plus `not_null` / `unique` tests on email at both staging and mart layers.
- `DATA_SOURCES_CATALOG.md` entry added.

## How it fits

Bronze (Dagster → `external.cerema_lovac_users_raw`) → bronze view (`stg_external_cerema_lovac_users`) → gold mart (`marts_production_cerema_lovac_users_unregistered`). Skipped the intermediate/silver layer because the join is a single `NOT IN` and matches the pattern of the existing `marts_production_users` etc.

## Env vars to add on Clever Cloud

- `CEREMA_USERNAME`
- `CEREMA_PASSWORD`
- `CEREMA_API_BASE_URL` (optional — defaults to `https://portaildf.cerema.fr/api`)

## Test plan

- [x] Set the env vars in Clever Cloud
- [ ] Materialize `raw_cerema_lovac_users_raw` once manually from the Dagster UI and confirm row count looks right
- [ ] Run `dbt run --select +marts_production_cerema_lovac_users_unregistered` and inspect a sample
- [ ] Confirm the monthly schedule is registered and enabled in the Dagster UI
- [ ] Surface the mart in Metabase as the onboarding follow-up list

🤖 Generated with [Claude Code](https://claude.com/claude-code)