### PR TITLE
perf: cache Metabase responses on the Analysis page

### DIFF
--- a/docs/superpowers/plans/2026-06-09-analysis-page-cache.md
+++ b/docs/superpowers/plans/2026-06-09-analysis-page-cache.md
@@ -1,0 +1,996 @@
+# Analysis Page Cache Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Cache Metabase API responses in-process on the backend (TTL: 1h) and bump RTK Query's `keepUnusedDataFor` so the Analysis page reloads fast and Metabase isn't hit redundantly.
+
+**Architecture:** Refactor `metabase-api.ts` to expose a single `fetchDashboardRaw` step that both `getDashboard` and `findDashcard` consume. Wrap the `MetabaseService` interface with a `CachedMetabaseService` that holds two `@isaacs/ttlcache` instances — one keyed by `dashboardId`, one keyed by `${dashboardId}:${dashcardId}:${cardId}:${establishmentId}`. Caches store the *promise* so concurrent callers coalesce; rejected promises are evicted so the next caller retries. Replace the singleton export with the cached wrapper; the only consumer (`dashboardController`) needs no changes.
+
+**Tech Stack:** TypeScript, `@isaacs/ttlcache`, Vitest (with fake timers), Express, RTK Query.
+
+**Spec reference:** `docs/superpowers/specs/2026-06-09-analysis-page-cache-design.md`
+
+---
+
+### Task 1: Add `@isaacs/ttlcache` dependency
+
+**Files:**
+- Modify: `server/package.json`
+
+- [ ] **Step 1: Add the dependency**
+
+Run from repo root:
+
+```bash
+yarn workspace @zerologementvacant/server add @isaacs/ttlcache
+```
+
+Expected: `@isaacs/ttlcache` added to `server/package.json` `dependencies`, `yarn.lock` updated.
+
+- [ ] **Step 2: Verify install**
+
+Run:
+
+```bash
+yarn workspace @zerologementvacant/server why @isaacs/ttlcache
+```
+
+Expected: prints a tree showing `@isaacs/ttlcache@<version>`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/package.json yarn.lock
+git commit -m "chore(server): add @isaacs/ttlcache dependency"
+```
+
+---
+
+### Task 2: Extract `fetchDashboardRaw` in `metabase-api.ts`
+
+The current `getDashboard` and `findDashcard` each call `GET /api/dashboard/:id` independently. Extract that fetch into a shared method exposed on the `MetabaseService` interface so it can be cached once.
+
+**Files:**
+- Modify: `server/src/services/metabase/metabase-service.ts`
+- Modify: `server/src/services/metabase/metabase-api.ts`
+
+- [ ] **Step 1: Move `MetabaseDashboardRaw` and its supporting types to the service module**
+
+The Raw types currently live in `metabase-api.ts` (lines 25–83). Move them verbatim into `server/src/services/metabase/metabase-service.ts`, just above `DashboardData`. Cut from `metabase-api.ts`, paste into `metabase-service.ts`, and prefix each with `export`:
+
+```ts
+// Raw payload returned by `GET /api/dashboard/:id`. Exposed on the service
+// contract so wrappers (cache, instrumentation) can hold the raw payload before
+// normalization.
+export interface MetabaseColumnSettings {
+  number_style?: string;
+  decimals?: number;
+  suffix?: string;
+  column_title?: string;
+}
+
+export interface MetabaseVisualizationSettings {
+  'number.style'?: string;
+  'scalar.decimals'?: number;
+  'scalar.field'?: string;
+  'table.columns'?: Array<{ name: string; enabled: boolean }>;
+  'graph.dimensions'?: string[];
+  'graph.metrics'?: string[];
+  column_settings?: Record<string, MetabaseColumnSettings>;
+}
+
+export interface MetabaseCard {
+  id: number;
+  name: string;
+  display: string;
+  description: string | null;
+  visualization_settings: MetabaseVisualizationSettings;
+}
+
+export interface MetabaseDashcardVisualizationSettings {
+  'card.title'?: string | null;
+  'number.style'?: string;
+  'scalar.field'?: string;
+  'table.columns'?: Array<{ name: string; enabled: boolean }>;
+  'graph.dimensions'?: string[];
+  'graph.metrics'?: string[];
+  column_settings?: Record<string, MetabaseColumnSettings>;
+}
+
+export interface MetabaseDashcard {
+  id: number;
+  card_id: number | null;
+  dashboard_tab_id: number | null;
+  row: number;
+  col: number;
+  size_x: number;
+  size_y: number;
+  visualization_settings: MetabaseDashcardVisualizationSettings;
+  card: MetabaseCard | null;
+}
+
+export interface MetabaseTab {
+  id: number;
+  name: string;
+  position: number;
+}
+
+export interface MetabaseDashboardRaw {
+  id: number;
+  tabs?: MetabaseTab[];
+  dashcards: MetabaseDashcard[];
+  parameters?: Array<{ id: string; slug: string; type: string }>;
+}
+
+export interface MetabaseCol {
+  name: string;
+  display_name?: string;
+  base_type?: string;
+}
+
+export interface MetabaseQueryResult {
+  data: { rows: unknown[][]; cols: MetabaseCol[] };
+}
+```
+
+In `metabase-api.ts`, import these from `./metabase-service` instead of redefining them locally.
+
+- [ ] **Step 2: Add `fetchDashboardRaw` to the `MetabaseService` interface**
+
+In `server/src/services/metabase/metabase-service.ts`, update the `MetabaseService` interface — add the method as the **first** entry:
+
+```ts
+export interface MetabaseService {
+  fetchDashboardRaw(id: number): Promise<MetabaseDashboardRaw>;
+  getDashboard(id: number): Promise<DashboardData>;
+  findDashcard(dashboardId: number, dashcardId: number): Promise<DashcardRef | null>;
+  getCardValue(
+    dashboardId: number,
+    dashcardId: number,
+    cardId: number,
+    parameters: ReadonlyArray<DashboardParameter & { value: string }>,
+    valueColumn: string | null,
+    labelColumn: string | null,
+    cardType: CardType,
+    direction: 'horizontal' | 'vertical' | null,
+    format: 'number' | 'percent',
+    decimals: number,
+    tableColumns: ReadonlyArray<TableColumnRef> | null
+  ): Promise<CardValue>;
+}
+```
+
+- [ ] **Step 3: Refactor `MetabaseAPI` to use `fetchDashboardRaw` internally**
+
+In `server/src/services/metabase/metabase-api.ts`:
+
+1. The Metabase-prefixed type definitions (`MetabaseColumnSettings`, `MetabaseVisualizationSettings`, `MetabaseCard`, `MetabaseDashcardVisualizationSettings`, `MetabaseDashcard`, `MetabaseTab`, `MetabaseDashboardRaw`, `MetabaseCol`, `MetabaseQueryResult`) — all of lines ~25–93 — were moved out in Step 1. Delete them here.
+2. Add all of those names to the imports from `./metabase-service`.
+3. Replace the existing `getDashboard` and `findDashcard` methods with:
+
+```ts
+async fetchDashboardRaw(id: number): Promise<MetabaseDashboardRaw> {
+  const { data } = await this.http.get<MetabaseDashboardRaw>(
+    `/api/dashboard/${id}`
+  );
+  return data;
+}
+
+async getDashboard(id: number): Promise<DashboardData> {
+  return normalizeDashboard(await this.fetchDashboardRaw(id));
+}
+
+async findDashcard(
+  dashboardId: number,
+  dashcardId: number
+): Promise<DashcardRef | null> {
+  return findDashcardRef(await this.fetchDashboardRaw(dashboardId), dashcardId);
+}
+```
+
+- [ ] **Step 4: Export the normalization helpers**
+
+The cache wrapper (Task 4) needs `normalizeDashboard` and `findDashcardRef`. In `server/src/services/metabase/metabase-api.ts`, add `export` to both declarations:
+
+```ts
+export function normalizeDashboard(raw: MetabaseDashboardRaw): DashboardData {
+```
+
+```ts
+export function findDashcardRef(
+  raw: MetabaseDashboardRaw,
+  dashcardId: number
+): DashcardRef | null {
+```
+
+- [ ] **Step 5: Typecheck and run the existing controller tests**
+
+Run from repo root:
+
+```bash
+yarn nx typecheck server
+yarn nx test server -- dashboard-api
+```
+
+Expected: typecheck passes; all 24+ tests in `dashboard-api.test.ts` still pass without modification. If anything fails, the refactor changed behavior — fix before continuing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/src/services/metabase/
+git commit -m "refactor(server): share fetchDashboardRaw between getDashboard and findDashcard"
+```
+
+---
+
+### Task 3: Add cache config to `infra/config.ts`
+
+Two env vars driving the cache behavior. Both default to safe production values; tests will override `ttlMs` to a small number via fake timers (no env override needed in tests).
+
+**Files:**
+- Modify: `server/src/infra/config.ts`
+
+- [ ] **Step 1: Extend the `metabase` schema and parser**
+
+In `server/src/infra/config.ts`:
+
+1. In the `metabase` block of `configSchema` (around line 157), add the two fields:
+
+```ts
+metabase: z.object({
+  domain: z.url().nullable().default('http://localhost:4000'),
+  token: z.string().default('example-token'),
+  apiToken: z.string().default('example-api-token'),
+  cacheTtlMs: z.coerce.number().int().min(0).default(60 * 60 * 1000),
+  cacheMaxEntries: z.coerce.number().int().min(1).default(10_000)
+}),
+```
+
+2. In the env-binding object (around line 303), wire the env vars:
+
+```ts
+metabase: {
+  domain: env('METABASE_DOMAIN'),
+  token: env('METABASE_TOKEN'),
+  apiToken: env('METABASE_API_TOKEN'),
+  cacheTtlMs: env('METABASE_CACHE_TTL_MS'),
+  cacheMaxEntries: env('METABASE_CACHE_MAX_ENTRIES')
+},
+```
+
+3. Extend the final cast at the bottom of the file (around line 337):
+
+```ts
+metabase: {
+  domain: string;
+  token: string;
+  apiToken: string;
+  cacheTtlMs: number;
+  cacheMaxEntries: number;
+};
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run:
+
+```bash
+yarn nx typecheck server
+```
+
+Expected: passes.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/src/infra/config.ts
+git commit -m "feat(server): add metabase cache TTL and max-entries config"
+```
+
+---
+
+### Task 4: Build `metabase-cache.ts` (TDD)
+
+A `CachedMetabaseService` that implements `MetabaseService`, holds two `@isaacs/ttlcache` instances, caches promises (coalescing), and evicts rejected promises.
+
+**Files:**
+- Create: `server/src/services/metabase/metabase-cache.ts`
+- Create: `server/src/services/metabase/test/metabase-cache.test.ts`
+
+- [ ] **Step 1: Create the test file with imports and a fake-service builder**
+
+`server/src/services/metabase/test/metabase-cache.test.ts`:
+
+```ts
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type {
+  CardValue,
+  DashboardData,
+  DashcardRef,
+  MetabaseDashboardRaw,
+  MetabaseService
+} from '../metabase-service';
+import { createCachedMetabaseService } from '../metabase-cache';
+
+function genRaw(id: number): MetabaseDashboardRaw {
+  return {
+    id,
+    dashcards: [
+      {
+        id: 100,
+        card_id: 200,
+        dashboard_tab_id: null,
+        row: 0,
+        col: 0,
+        size_x: 6,
+        size_y: 3,
+        visualization_settings: {},
+        card: {
+          id: 200,
+          name: 'fake',
+          display: 'scalar',
+          description: null,
+          visualization_settings: {}
+        }
+      }
+    ],
+    parameters: []
+  };
+}
+
+function genDashcardRef(): DashcardRef {
+  return {
+    dashcardId: 100,
+    cardId: 200,
+    type: 'flat-number',
+    valueColumn: null,
+    labelColumn: null,
+    direction: null,
+    format: 'number',
+    decimals: 0,
+    tableColumns: null,
+    dashboardParameters: []
+  };
+}
+
+interface FakeService extends MetabaseService {
+  calls: {
+    fetchDashboardRaw: number;
+    getDashboard: number;
+    findDashcard: number;
+    getCardValue: number;
+  };
+}
+
+function genFakeService(overrides: Partial<MetabaseService> = {}): FakeService {
+  const calls = {
+    fetchDashboardRaw: 0,
+    getDashboard: 0,
+    findDashcard: 0,
+    getCardValue: 0
+  };
+  const inner: FakeService = {
+    calls,
+    fetchDashboardRaw: vi.fn(async (id: number) => {
+      calls.fetchDashboardRaw++;
+      return genRaw(id);
+    }),
+    getDashboard: vi.fn(async () => {
+      calls.getDashboard++;
+      return { cards: [] } as DashboardData;
+    }),
+    findDashcard: vi.fn(async () => {
+      calls.findDashcard++;
+      return genDashcardRef();
+    }),
+    getCardValue: vi.fn(async () => {
+      calls.getCardValue++;
+      return 42 as CardValue;
+    }),
+    ...overrides
+  };
+  return inner;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+```
+
+- [ ] **Step 2: Write the first failing test — TTL hit caches `fetchDashboardRaw`**
+
+Append to the test file:
+
+```ts
+describe('CachedMetabaseService.fetchDashboardRaw', () => {
+  it('returns cached value on second call within TTL', async () => {
+    const inner = genFakeService();
+    const cached = createCachedMetabaseService(inner, {
+      ttlMs: 60_000,
+      max: 100
+    });
+
+    await cached.fetchDashboardRaw(13);
+    await cached.fetchDashboardRaw(13);
+
+    expect(inner.calls.fetchDashboardRaw).toBe(1);
+  });
+});
+```
+
+- [ ] **Step 3: Run the test → expect FAIL ("cannot find module")**
+
+Run:
+
+```bash
+yarn nx test server -- metabase-cache
+```
+
+Expected: FAIL with `Failed to load url ../metabase-cache` or similar — module does not exist yet.
+
+- [ ] **Step 4: Implement minimal `metabase-cache.ts`**
+
+Create `server/src/services/metabase/metabase-cache.ts`:
+
+```ts
+import TTLCache from '@isaacs/ttlcache';
+
+import {
+  findDashcardRef,
+  normalizeDashboard
+} from './metabase-api';
+import type {
+  CardValue,
+  DashboardData,
+  DashboardParameter,
+  DashcardRef,
+  MetabaseDashboardRaw,
+  MetabaseService,
+  TableColumnRef
+} from './metabase-service';
+import type { CardType, TableColumnMeta } from '@zerologementvacant/models';
+
+export interface CacheOptions {
+  ttlMs: number;
+  max: number;
+}
+
+async function cached<K, V>(
+  store: TTLCache<K, Promise<V>>,
+  key: K,
+  fetch: () => Promise<V>
+): Promise<V> {
+  const existing = store.get(key);
+  if (existing) return existing;
+  const promise = fetch().catch((err) => {
+    store.delete(key);
+    throw err;
+  });
+  store.set(key, promise);
+  return promise;
+}
+
+function cardKey(
+  dashboardId: number,
+  dashcardId: number,
+  cardId: number,
+  establishmentId: string
+): string {
+  return `${dashboardId}:${dashcardId}:${cardId}:${establishmentId}`;
+}
+
+class CachedMetabaseService implements MetabaseService {
+  private readonly dashboardCache: TTLCache<number, Promise<MetabaseDashboardRaw>>;
+  private readonly cardCache: TTLCache<string, Promise<CardValue>>;
+
+  constructor(
+    private readonly inner: MetabaseService,
+    opts: CacheOptions
+  ) {
+    this.dashboardCache = new TTLCache({ ttl: opts.ttlMs, max: opts.max });
+    this.cardCache = new TTLCache({ ttl: opts.ttlMs, max: opts.max });
+  }
+
+  fetchDashboardRaw(id: number): Promise<MetabaseDashboardRaw> {
+    return cached(this.dashboardCache, id, () =>
+      this.inner.fetchDashboardRaw(id)
+    );
+  }
+
+  async getDashboard(id: number): Promise<DashboardData> {
+    return normalizeDashboard(await this.fetchDashboardRaw(id));
+  }
+
+  async findDashcard(
+    dashboardId: number,
+    dashcardId: number
+  ): Promise<DashcardRef | null> {
+    return findDashcardRef(
+      await this.fetchDashboardRaw(dashboardId),
+      dashcardId
+    );
+  }
+
+  getCardValue(
+    dashboardId: number,
+    dashcardId: number,
+    cardId: number,
+    parameters: ReadonlyArray<DashboardParameter & { value: string }>,
+    valueColumn: string | null,
+    labelColumn: string | null,
+    cardType: CardType,
+    direction: 'horizontal' | 'vertical' | null,
+    format: 'number' | 'percent',
+    decimals: number,
+    tableColumns: ReadonlyArray<TableColumnRef> | null
+  ): Promise<CardValue> {
+    const establishmentId =
+      parameters.find((p) => p.slug === 'id')?.value ?? 'anonymous';
+    const key = cardKey(dashboardId, dashcardId, cardId, establishmentId);
+    return cached(this.cardCache, key, () =>
+      this.inner.getCardValue(
+        dashboardId,
+        dashcardId,
+        cardId,
+        parameters,
+        valueColumn,
+        labelColumn,
+        cardType,
+        direction,
+        format,
+        decimals,
+        tableColumns
+      )
+    );
+  }
+
+  clear(): void {
+    this.dashboardCache.clear();
+    this.cardCache.clear();
+  }
+}
+
+export function createCachedMetabaseService(
+  inner: MetabaseService,
+  opts: CacheOptions
+): MetabaseService & { clear: () => void } {
+  return new CachedMetabaseService(inner, opts);
+}
+
+// Re-export so callers can import the type from the module they actually use.
+export type { TableColumnMeta };
+```
+
+- [ ] **Step 5: Run the test → expect PASS**
+
+Run:
+
+```bash
+yarn nx test server -- metabase-cache
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Add the TTL-expiry test**
+
+Append to the `describe('CachedMetabaseService.fetchDashboardRaw', …)` block:
+
+```ts
+  it('re-fetches after TTL expiry', async () => {
+    const inner = genFakeService();
+    const cached = createCachedMetabaseService(inner, {
+      ttlMs: 60_000,
+      max: 100
+    });
+
+    await cached.fetchDashboardRaw(13);
+    vi.advanceTimersByTime(60_001);
+    await cached.fetchDashboardRaw(13);
+
+    expect(inner.calls.fetchDashboardRaw).toBe(2);
+  });
+```
+
+Run:
+
+```bash
+yarn nx test server -- metabase-cache
+```
+
+Expected: PASS (TTLCache's `ttl` option uses the wall clock; fake timers control it).
+
+- [ ] **Step 7: Add the coalescing test**
+
+Append:
+
+```ts
+  it('coalesces concurrent calls into one underlying fetch', async () => {
+    let resolveInner: ((v: MetabaseDashboardRaw) => void) | undefined;
+    const innerPromise = new Promise<MetabaseDashboardRaw>((resolve) => {
+      resolveInner = resolve;
+    });
+    const inner = genFakeService({
+      fetchDashboardRaw: vi.fn(() => innerPromise)
+    });
+    const cached = createCachedMetabaseService(inner, {
+      ttlMs: 60_000,
+      max: 100
+    });
+
+    const [a, b, c] = [
+      cached.fetchDashboardRaw(13),
+      cached.fetchDashboardRaw(13),
+      cached.fetchDashboardRaw(13)
+    ];
+    resolveInner!(genRaw(13));
+    await Promise.all([a, b, c]);
+
+    expect(inner.fetchDashboardRaw).toHaveBeenCalledTimes(1);
+  });
+```
+
+Run → PASS.
+
+- [ ] **Step 8: Add the rejection-cleanup test**
+
+Append:
+
+```ts
+  it('removes the cached promise on rejection so the next call retries', async () => {
+    let attempt = 0;
+    const inner = genFakeService({
+      fetchDashboardRaw: vi.fn(async (id: number) => {
+        attempt++;
+        if (attempt === 1) throw new Error('boom');
+        return genRaw(id);
+      })
+    });
+    const cached = createCachedMetabaseService(inner, {
+      ttlMs: 60_000,
+      max: 100
+    });
+
+    await expect(cached.fetchDashboardRaw(13)).rejects.toThrow('boom');
+    await expect(cached.fetchDashboardRaw(13)).resolves.toMatchObject({
+      id: 13
+    });
+
+    expect(inner.fetchDashboardRaw).toHaveBeenCalledTimes(2);
+  });
+```
+
+Run → PASS.
+
+- [ ] **Step 9: Add tests for `getCardValue` cache scoped by establishment**
+
+Append (new `describe` block at file end):
+
+```ts
+describe('CachedMetabaseService.getCardValue', () => {
+  it('caches per (dashboard, dashcard, card, establishment)', async () => {
+    const inner = genFakeService();
+    const cached = createCachedMetabaseService(inner, {
+      ttlMs: 60_000,
+      max: 100
+    });
+    const params = [{ id: 'p1', slug: 'id', type: 'category', value: 'est-1' }];
+
+    await cached.getCardValue(
+      13, 100, 200, params, null, null, 'flat-number', null, 'number', 0, null
+    );
+    await cached.getCardValue(
+      13, 100, 200, params, null, null, 'flat-number', null, 'number', 0, null
+    );
+
+    expect(inner.getCardValue).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not share cache entries across establishments', async () => {
+    const inner = genFakeService();
+    const cached = createCachedMetabaseService(inner, {
+      ttlMs: 60_000,
+      max: 100
+    });
+    const p1 = [{ id: 'p1', slug: 'id', type: 'category', value: 'est-1' }];
+    const p2 = [{ id: 'p1', slug: 'id', type: 'category', value: 'est-2' }];
+
+    await cached.getCardValue(
+      13, 100, 200, p1, null, null, 'flat-number', null, 'number', 0, null
+    );
+    await cached.getCardValue(
+      13, 100, 200, p2, null, null, 'flat-number', null, 'number', 0, null
+    );
+
+    expect(inner.getCardValue).toHaveBeenCalledTimes(2);
+  });
+});
+```
+
+Run → PASS.
+
+- [ ] **Step 10: Add test for `getDashboard` and `findDashcard` sharing the cached raw fetch**
+
+Append:
+
+```ts
+describe('CachedMetabaseService — shared raw fetch', () => {
+  it('runs one fetchDashboardRaw for getDashboard + findDashcard on the same id', async () => {
+    const inner = genFakeService();
+    const cached = createCachedMetabaseService(inner, {
+      ttlMs: 60_000,
+      max: 100
+    });
+
+    await cached.getDashboard(13);
+    await cached.findDashcard(13, 100);
+
+    expect(inner.fetchDashboardRaw).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+Run → PASS.
+
+- [ ] **Step 11: Add `clear()` test**
+
+Append:
+
+```ts
+describe('CachedMetabaseService.clear', () => {
+  it('drops all cached entries', async () => {
+    const inner = genFakeService();
+    const cached = createCachedMetabaseService(inner, {
+      ttlMs: 60_000,
+      max: 100
+    });
+
+    await cached.fetchDashboardRaw(13);
+    cached.clear();
+    await cached.fetchDashboardRaw(13);
+
+    expect(inner.fetchDashboardRaw).toHaveBeenCalledTimes(2);
+  });
+});
+```
+
+Run → PASS.
+
+- [ ] **Step 12: Final test run + typecheck**
+
+Run:
+
+```bash
+yarn nx test server -- metabase-cache
+yarn nx typecheck server
+```
+
+Expected: all 7 tests pass, typecheck clean.
+
+- [ ] **Step 13: Commit**
+
+```bash
+git add server/src/services/metabase/metabase-cache.ts server/src/services/metabase/test/metabase-cache.test.ts
+git commit -m "feat(server): add CachedMetabaseService with TTL and promise coalescing"
+```
+
+---
+
+### Task 5: Wire the cache into the exported singleton
+
+Replace the singleton at the bottom of `metabase-api.ts` with the cached wrapper. The controller's import stays the same.
+
+**Files:**
+- Modify: `server/src/services/metabase/metabase-api.ts`
+- Modify: `server/src/controllers/test/dashboard-api.test.ts`
+
+- [ ] **Step 1: Wrap the singleton with the cache**
+
+In `server/src/services/metabase/metabase-api.ts`, replace the final exports at the bottom (lines ~554–562) with:
+
+```ts
+export function createMetabaseAPI(opts: MetabaseAPIOptions): MetabaseService {
+  return new MetabaseAPI(opts);
+}
+
+import { createCachedMetabaseService } from './metabase-cache';
+
+const baseMetabaseAPI = createMetabaseAPI({
+  domain: config.metabase.domain,
+  apiToken: config.metabase.apiToken
+});
+
+export const metabaseAPI = createCachedMetabaseService(baseMetabaseAPI, {
+  ttlMs: config.metabase.cacheTtlMs,
+  max: config.metabase.cacheMaxEntries
+});
+```
+
+Note: this creates a circular-ish import — `metabase-api.ts` imports from `metabase-cache.ts` which imports `normalizeDashboard`/`findDashcardRef` from `metabase-api.ts`. Node handles this fine because the wrapper only uses those at call time, not at module-load time. If the typecheck flags it, move the `import { createCachedMetabaseService }` to the top of the file with the other imports.
+
+- [ ] **Step 2: Typecheck**
+
+Run:
+
+```bash
+yarn nx typecheck server
+```
+
+Expected: passes. If a circular-import warning appears, move the `import` line up.
+
+- [ ] **Step 3: Run dashboard-api tests — they will now fail because the cache persists across tests**
+
+Run:
+
+```bash
+yarn nx test server -- dashboard-api
+```
+
+Expected: at least some tests FAIL with the second invocation of the same dashboard ID returning stale data (the first nock mock was consumed; the cached promise returns it again for the second test).
+
+If by luck all tests already pass (each uses unique IDs), proceed to Step 5 and skip Step 4.
+
+- [ ] **Step 4: Clear the cache between dashboard-api tests**
+
+In `server/src/controllers/test/dashboard-api.test.ts`:
+
+1. Add to the imports near the top:
+
+```ts
+import { metabaseAPI } from '~/services/metabase/metabase-api';
+```
+
+2. Add an `afterEach` inside the top-level `describe('Dashboard API', …)` block (immediately after the existing `beforeAll`/`afterEach` setup, around line 449):
+
+```ts
+afterEach(() => {
+  // Cached MetabaseService keeps promises alive across tests. Without this,
+  // a cached response from one test leaks into the next.
+  (metabaseAPI as unknown as { clear: () => void }).clear();
+});
+```
+
+(The cast is needed because the `MetabaseService` interface doesn't declare `clear` — only the cached wrapper does.)
+
+- [ ] **Step 5: Run dashboard-api tests again**
+
+Run:
+
+```bash
+yarn nx test server -- dashboard-api
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/src/services/metabase/metabase-api.ts server/src/controllers/test/dashboard-api.test.ts
+git commit -m "feat(server): cache metabase responses on the exported singleton"
+```
+
+---
+
+### Task 6: Bump RTK Query `keepUnusedDataFor` on the Analysis page endpoints
+
+**Files:**
+- Modify: `frontend/src/services/dashboard.service.ts`
+
+- [ ] **Step 1: Add `keepUnusedDataFor` to the two endpoints used by `AnalysisViewNext`**
+
+Replace the body of `dashboardApi` in `frontend/src/services/dashboard.service.ts` with:
+
+```ts
+const ONE_HOUR_SECONDS = 60 * 60;
+
+export const dashboardApi = zlvApi.injectEndpoints({
+  endpoints: (builder) => ({
+    findOneDashboard: builder.query<DashboardDTO, FindOneOptions>({
+      query: (opts) => `dashboards/${opts.id}`,
+      providesTags: (_result, _error, arg) => [{ type: 'Stats', id: arg.id }]
+    }),
+    findOneDashboardNext: builder.query<DashboardDTO, FindOneOptions>({
+      query: (opts) => `dashboards/${opts.id}`,
+      keepUnusedDataFor: ONE_HOUR_SECONDS,
+      providesTags: (_result, _error, arg) => [
+        { type: 'Stats', id: `next-${arg.id}` }
+      ]
+    }),
+    findOneCard: builder.query<CardDataDTO, FindOneCardOptions>({
+      query: (opts) => `dashboards/${opts.did}/cards/${opts.cid}`,
+      keepUnusedDataFor: ONE_HOUR_SECONDS,
+      providesTags: (_result, _error, arg) => [
+        { type: 'Stats', id: `${arg.did}-card-${arg.cid}` }
+      ]
+    })
+  })
+});
+```
+
+Note: legacy `findOneDashboard` is intentionally left untouched (it backs the old `AnalysisView`).
+
+- [ ] **Step 2: Typecheck + run frontend tests**
+
+Run:
+
+```bash
+yarn nx typecheck frontend
+yarn nx test frontend -- AnalysisViewNext
+```
+
+Expected: typecheck clean, AnalysisViewNext tests still pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/services/dashboard.service.ts
+git commit -m "feat(front): keep analysis dashboard data for 1h in RTK Query cache"
+```
+
+---
+
+### Task 7: Manual verification
+
+- [ ] **Step 1: Start the stack**
+
+Run in three terminals (or use `wt`'s post-start tasks):
+
+```bash
+docker compose -f .docker/docker-compose.yml up -d
+yarn workspace @zerologementvacant/server dev
+yarn workspace @zerologementvacant/front dev
+```
+
+- [ ] **Step 2: Tail backend logs and capture Metabase traffic**
+
+In the server log, watch for outbound HTTP calls to `${METABASE_DOMAIN}/api/dashboard/...`. If logs don't surface axios calls, set `LOG_LEVEL=debug` in `server/.env` or temporarily add a one-line console.log inside `MetabaseAPI.fetchDashboardRaw`.
+
+- [ ] **Step 3: First load**
+
+Open <http://localhost:3000>, log in, navigate to the Analysis page (resource `13-analyses`).
+
+Expected logs: 1× `fetchDashboardRaw(13)` and N× `getCardValue` (one per card).
+
+- [ ] **Step 4: Hard reload (Ctrl+Shift+R) within the TTL window**
+
+Expected logs: **no new outbound Metabase calls** — the backend cache serves everything.
+
+- [ ] **Step 5: Confirm RTK Query keeps the data after navigation**
+
+Navigate to `/parc-de-logements`, then back to the Analysis page (soft navigation, no reload).
+
+Expected: page renders instantly with no network calls visible in DevTools → Network tab (RTK Query serves from store).
+
+- [ ] **Step 6: Confirm TTL re-fetch behavior (optional, slow)**
+
+Either wait an hour, or temporarily start the server with `METABASE_CACHE_TTL_MS=5000`, reload after 6 seconds. Expected: one fresh `fetchDashboardRaw` call after the TTL elapses.
+
+- [ ] **Step 7: Push the branch and open a PR**
+
+```bash
+git push -u origin perf/analysis-page-cache
+gh pr create --title "perf: cache Metabase responses on the Analysis page" --body "$(cat <<'EOF'
+## Summary
+- Backend in-process TTL cache (1h, `@isaacs/ttlcache`) for Metabase dashboard layouts and card values, keyed per-establishment for card values.
+- Refactored `metabase-api.ts` so `getDashboard` and `findDashcard` share a single `fetchDashboardRaw` step — the cached path now covers both.
+- Bumped RTK Query `keepUnusedDataFor` to 1h on the two `AnalysisViewNext` endpoints (legacy `findOneDashboard` untouched).
+- New `METABASE_CACHE_TTL_MS` (default 3 600 000) and `METABASE_CACHE_MAX_ENTRIES` (default 10 000) env vars.
+
+## Test plan
+- [ ] `yarn nx test server -- metabase-cache` — 7 unit tests pass
+- [ ] `yarn nx test server -- dashboard-api` — existing controller tests still pass
+- [ ] `yarn nx typecheck server frontend` — clean
+- [ ] Manual: hard-reload Analysis page; backend logs show no second-call Metabase traffic within TTL
+- [ ] Manual: navigate away and back within an hour; no network requests from the browser
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+gh pr edit "$(gh pr view --json number -q .number)" --add-label perf --add-assignee "@me"
+```
+
+Expected: PR URL printed. Confirm the `perf` label exists (`gh label list | grep perf`); if not, pick the closest existing label.

--- a/docs/superpowers/specs/2026-06-09-analysis-page-cache-design.md
+++ b/docs/superpowers/specs/2026-06-09-analysis-page-cache-design.md
@@ -1,0 +1,162 @@
+# Analysis Page Cache — Design
+
+## Problem
+
+The new "Analyse du parc vacant" page (`AnalysisViewNext`) reloads slowly and
+hammers the Metabase backend, which is not deployed for scale. Each page load
+with N cards triggers ~`1 + 2N` Metabase API calls:
+
+- 1 call for the dashboard layout (`GET /api/dashboard/:id`)
+- For every card: 1 dashboard re-fetch (inside `findDashcard`) + 1 card query
+
+There is no shared cache today. Every reload from every user re-runs every query.
+
+## Goals
+
+- Cut Metabase calls per page load and share results across users of the same
+  establishment.
+- Improve perceived reload speed for the Analysis page.
+
+## Non-goals
+
+- Cross-process cache (Redis): out of scope, defer until horizontal scale forces it.
+- HTTP `Cache-Control` headers: defer; backend cache covers both goals.
+- Replacing `memoizee` in `auth.ts`: separate concern, separate PR.
+
+## Approach
+
+Two changes, composable:
+
+1. **Backend in-process TTL cache** in front of the Metabase service. Solves
+   "Metabase load" and "slow F5 reload" (first user pays; everyone else hits cache).
+2. **Bump RTK Query `keepUnusedDataFor`** to 1 hour. Solves
+   "navigating back to the page within a session is instant".
+
+Daily-refresh data justifies a 1-hour TTL across both layers.
+
+## Architecture
+
+### Backend (`server/src/services/metabase/`)
+
+New dependency: `@isaacs/ttlcache` (TTL-primary, FIFO eviction, no LRU overhead).
+
+#### Refactor `metabase-api.ts`
+
+Extract the raw fetch so it's shared between dashboard and dashcard reads:
+
+```ts
+// Private to MetabaseAPI
+async fetchDashboardRaw(id: number): Promise<MetabaseDashboardRaw> {
+  const { data } = await this.http.get(`/api/dashboard/${id}`);
+  return data;
+}
+
+async getDashboard(id: number): Promise<DashboardData> {
+  return normalizeDashboard(await this.fetchDashboardRaw(id));
+}
+
+async findDashcard(dashboardId: number, dashcardId: number): Promise<DashcardRef | null> {
+  return findDashcardRef(await this.fetchDashboardRaw(dashboardId), dashcardId);
+}
+```
+
+After this refactor, caching `fetchDashboardRaw` deduplicates dashboard +
+dashcard reads automatically.
+
+#### New `metabase-cache.ts`
+
+Wraps a `MetabaseService` with two TTL caches:
+
+- **Dashboard cache**: `TTLCache<number, Promise<MetabaseDashboardRaw>>`
+  keyed by `dashboardId`. Shared across all establishments (dashboard layout
+  doesn't depend on the tenant).
+- **Card-value cache**: `TTLCache<string, Promise<CardValue>>` keyed by
+  `${dashboardId}:${dashcardId}:${cardId}:${establishmentId}`. Per-tenant.
+
+Both caches **store the promise**, not the resolved value, which gives us free
+request coalescing — when 12 cards mount at once on a cold cache, the
+dashboard fetch fires once. On rejection, the entry is deleted so the next
+caller retries instead of replaying the error for 1h.
+
+```ts
+async function cached<K, V>(
+  cache: TTLCache<K, Promise<V>>,
+  key: K,
+  fetch: () => Promise<V>
+): Promise<V> {
+  const existing = cache.get(key);
+  if (existing) return existing;
+  const promise = fetch().catch((err) => {
+    cache.delete(key);
+    throw err;
+  });
+  cache.set(key, promise);
+  return promise;
+}
+```
+
+#### Config
+
+Two new env vars in `server/src/infra/config.ts`:
+
+- `METABASE_CACHE_TTL_MS` — default `3_600_000` (1h)
+- `METABASE_CACHE_MAX_ENTRIES` — default `10_000` (safety cap, never expected to hit)
+
+The exported `metabaseAPI` singleton is wrapped with the cache layer.
+
+### Frontend (`frontend/src/services/dashboard.service.ts`)
+
+Bump `keepUnusedDataFor` on the two endpoints used by `AnalysisViewNext`:
+
+```ts
+findOneDashboardNext: builder.query<DashboardDTO, FindOneOptions>({
+  query: (opts) => `dashboards/${opts.id}`,
+  keepUnusedDataFor: 60 * 60,
+  providesTags: …
+}),
+findOneCard: builder.query<CardDataDTO, FindOneCardOptions>({
+  query: (opts) => `dashboards/${opts.did}/cards/${opts.cid}`,
+  keepUnusedDataFor: 60 * 60,
+  providesTags: …
+}),
+```
+
+The legacy `findOneDashboard` endpoint (used by the old `AnalysisView`) is left
+untouched.
+
+## Implementation order (TDD)
+
+1. Add `@isaacs/ttlcache` to `server` workspace.
+2. Refactor `metabase-api.ts` to extract `fetchDashboardRaw`. Existing tests
+   must still pass.
+3. Write tests for `metabase-cache.ts`:
+   - TTL expiry triggers a re-fetch
+   - Concurrent calls share one underlying fetch (coalescing)
+   - Rejected promise is removed from cache so the next call retries
+   - `max` cap evicts in FIFO order
+4. Implement `metabase-cache.ts`.
+5. Wire the cache wrapper into the exported `metabaseAPI` singleton.
+6. Bump `keepUnusedDataFor` in `dashboard.service.ts`.
+7. Manual verification: load `/parc-vacant/analyses/13-analyses`, reload, check
+   Metabase isn't hit twice within the TTL.
+
+## Risks & trade-offs
+
+- **Staleness after PM edits a dashboard.** Up to 1h delay. Acceptable —
+  warehouse refreshes daily; PM edits are infrequent and not time-sensitive.
+  If this becomes a pain point, add a `POST /admin/cache/metabase` flush endpoint.
+- **Per-pod cache.** Multi-instance deployments give each pod its own cache;
+  redeploys clear everything. Fine at current scale.
+- **Promise-coalescing rejection.** If the cached promise rejects, all
+  concurrent callers see the same error. They get the same outcome they would
+  have without the cache; the next call after rejection re-fetches.
+- **Memory bound.** `max: 10_000` × ~5 KB ≈ 50 MB worst case. In practice
+  closer to a few MB.
+
+## Verification
+
+- New: `server/src/services/metabase/test/metabase-cache.test.ts`
+- Existing controller tests in `server/src/controllers/test/dashboard-api.test.ts`
+  must continue to pass without modification.
+- Manual: reload the Analysis page twice within the TTL; second load should
+  produce no outbound Metabase traffic from the backend logs.

--- a/frontend/src/services/dashboard.service.ts
+++ b/frontend/src/services/dashboard.service.ts
@@ -14,6 +14,8 @@ interface FindOneCardOptions {
   cid: number;
 }
 
+const ONE_HOUR_SECONDS = 60 * 60;
+
 export const dashboardApi = zlvApi.injectEndpoints({
   endpoints: (builder) => ({
     findOneDashboard: builder.query<DashboardDTO, FindOneOptions>({
@@ -22,12 +24,14 @@ export const dashboardApi = zlvApi.injectEndpoints({
     }),
     findOneDashboardNext: builder.query<DashboardDTO, FindOneOptions>({
       query: (opts) => `dashboards/${opts.id}`,
+      keepUnusedDataFor: ONE_HOUR_SECONDS,
       providesTags: (_result, _error, arg) => [
         { type: 'Stats', id: `next-${arg.id}` }
       ]
     }),
     findOneCard: builder.query<CardDataDTO, FindOneCardOptions>({
       query: (opts) => `dashboards/${opts.did}/cards/${opts.cid}`,
+      keepUnusedDataFor: ONE_HOUR_SECONDS,
       providesTags: (_result, _error, arg) => [
         { type: 'Stats', id: `${arg.did}-card-${arg.cid}` }
       ]

--- a/server/.env.example
+++ b/server/.env.example
@@ -76,6 +76,8 @@ REDIS_URL=redis://localhost:6379
 METABASE_DOMAIN=https://stats.zlv.beta.gouv.fr
 METABASE_TOKEN=METABASE_TOKEN
 METABASE_API_TOKEN=METABASE_API_TOKEN
+METABASE_CACHE_MAX_ENTRIES=
+METABASE_CACHE_TTL_MS=
 
 # BAN (Base Adresse Nationale) API
 BAN_API_ENDPOINT=https://api-adresse.data.gouv.fr

--- a/server/package.json
+++ b/server/package.json
@@ -18,6 +18,7 @@
     "@faker-js/faker": "8.4.1",
     "@getbrevo/brevo": "1.0.1",
     "@godaddy/terminus": "4.12.1",
+    "@isaacs/ttlcache": "^2.1.5",
     "@scalar/express-api-reference": "0.9.14",
     "@sendinblue/client": "3.3.1",
     "@sentry/integrations": "7.120.4",

--- a/server/package.json
+++ b/server/package.json
@@ -18,7 +18,7 @@
     "@faker-js/faker": "8.4.1",
     "@getbrevo/brevo": "1.0.1",
     "@godaddy/terminus": "4.12.1",
-    "@isaacs/ttlcache": "^2.1.5",
+    "@isaacs/ttlcache": "2.1.5",
     "@scalar/express-api-reference": "0.9.14",
     "@sendinblue/client": "3.3.1",
     "@sentry/integrations": "7.120.4",

--- a/server/src/controllers/test/dashboard-api.test.ts
+++ b/server/src/controllers/test/dashboard-api.test.ts
@@ -11,6 +11,7 @@ import {
   formatEstablishmentApi
 } from '~/repositories/establishmentRepository';
 import { toUserDBO, Users } from '~/repositories/userRepository';
+import { metabaseAPI } from '~/services/metabase/metabase-api';
 import { genEstablishmentApi, genUserApi } from '../../test/testFixtures';
 import { tokenProvider } from '../../test/testUtils';
 
@@ -456,6 +457,12 @@ describe('Dashboard API', () => {
 
   afterEach(() => {
     nock.cleanAll();
+  });
+
+  afterEach(() => {
+    // Cached MetabaseService keeps promises alive across tests. Without this,
+    // a cached response from one test leaks into the next.
+    (metabaseAPI as unknown as { clear: () => void }).clear();
   });
 
   describe('GET /dashboards/:id', () => {

--- a/server/src/infra/config.ts
+++ b/server/src/infra/config.ts
@@ -157,7 +157,9 @@ export const configSchema = z.object({
   metabase: z.object({
     domain: z.url().nullable().default('http://localhost:4000'),
     token: z.string().default('example-token'),
-    apiToken: z.string().default('example-api-token')
+    apiToken: z.string().default('example-api-token'),
+    cacheTtlMs: z.coerce.number().int().min(0).default(60 * 60 * 1000),
+    cacheMaxEntries: z.coerce.number().int().min(1).default(10_000)
   }),
   rateLimit: z.object({
     max: z.coerce.number().int().default(10_000)
@@ -303,7 +305,9 @@ const config = configSchema.parse({
   metabase: {
     domain: env('METABASE_DOMAIN'),
     token: env('METABASE_TOKEN'),
-    apiToken: env('METABASE_API_TOKEN')
+    apiToken: env('METABASE_API_TOKEN'),
+    cacheTtlMs: env('METABASE_CACHE_TTL_MS'),
+    cacheMaxEntries: env('METABASE_CACHE_MAX_ENTRIES')
   },
   rateLimit: {
     max: env('RATE_LIMIT_MAX')
@@ -334,5 +338,5 @@ const config = configSchema.parse({
 // - metabase.token / apiToken typed as string (required in production; null only in dev)
 export default config as Omit<Config, 'auth' | 'metabase'> & {
   auth: Omit<Config['auth'], 'expiresIn'> & { expiresIn: StringValue };
-  metabase: { domain: string; token: string; apiToken: string };
+  metabase: { domain: string; token: string; apiToken: string; cacheTtlMs: number; cacheMaxEntries: number };
 };

--- a/server/src/services/metabase/metabase-api.ts
+++ b/server/src/services/metabase/metabase-api.ts
@@ -14,83 +14,17 @@ import type {
   DashboardParameter,
   DashcardRef,
   LineChartValue,
+  MetabaseColumnSettings,
+  MetabaseDashboardRaw,
+  MetabaseDashcard,
+  MetabaseDashcardVisualizationSettings,
+  MetabaseQueryResult,
   MetabaseService,
+  MetabaseVisualizationSettings,
   PieChartValue,
   TableColumnRef,
   TableValue
 } from './metabase-service';
-
-// ─── Metabase internal types (minimal subset) ─────────────────────────────────
-
-interface MetabaseColumnSettings {
-  number_style?: string;
-  decimals?: number;
-  suffix?: string;
-  column_title?: string;
-}
-
-interface MetabaseVisualizationSettings {
-  'number.style'?: string;
-  'scalar.decimals'?: number;
-  'scalar.field'?: string;
-  'table.columns'?: Array<{ name: string; enabled: boolean }>;
-  'graph.dimensions'?: string[];
-  'graph.metrics'?: string[];
-  column_settings?: Record<string, MetabaseColumnSettings>;
-}
-
-interface MetabaseCard {
-  id: number;
-  name: string;
-  display: string;
-  description: string | null;
-  visualization_settings: MetabaseVisualizationSettings;
-}
-
-interface MetabaseDashcardVisualizationSettings {
-  'card.title'?: string | null;
-  'number.style'?: string;
-  'scalar.field'?: string;
-  'table.columns'?: Array<{ name: string; enabled: boolean }>;
-  'graph.dimensions'?: string[];
-  'graph.metrics'?: string[];
-  column_settings?: Record<string, MetabaseColumnSettings>;
-}
-
-interface MetabaseDashcard {
-  id: number;
-  card_id: number | null;
-  dashboard_tab_id: number | null;
-  row: number;
-  col: number;
-  size_x: number;
-  size_y: number;
-  visualization_settings: MetabaseDashcardVisualizationSettings;
-  card: MetabaseCard | null;
-}
-
-interface MetabaseTab {
-  id: number;
-  name: string;
-  position: number;
-}
-
-interface MetabaseDashboardRaw {
-  id: number;
-  tabs?: MetabaseTab[];
-  dashcards: MetabaseDashcard[];
-  parameters?: Array<{ id: string; slug: string; type: string }>;
-}
-
-interface MetabaseCol {
-  name: string;
-  display_name?: string;
-  base_type?: string;
-}
-
-interface MetabaseQueryResult {
-  data: { rows: unknown[][]; cols: MetabaseCol[] };
-}
 
 // ─── Normalization helpers ─────────────────────────────────────────────────────
 
@@ -294,7 +228,7 @@ function normalizeDashcard(dashcard: MetabaseDashcard): DashboardCard | null {
   };
 }
 
-function normalizeDashboard(raw: MetabaseDashboardRaw): DashboardData {
+export function normalizeDashboard(raw: MetabaseDashboardRaw): DashboardData {
   if (raw.tabs && raw.tabs.length > 0) {
     const sortedTabs = [...raw.tabs].sort((a, b) => a.position - b.position);
     const tabs: Tab[] = sortedTabs.map((tab) => ({
@@ -314,7 +248,7 @@ function normalizeDashboard(raw: MetabaseDashboardRaw): DashboardData {
   };
 }
 
-function findDashcardRef(
+export function findDashcardRef(
   raw: MetabaseDashboardRaw,
   dashcardId: number
 ): DashcardRef | null {
@@ -445,14 +379,22 @@ class MetabaseAPI implements MetabaseService {
     });
   }
 
-  async getDashboard(id: number): Promise<DashboardData> {
-    const { data } = await this.http.get<MetabaseDashboardRaw>(`/api/dashboard/${id}`);
-    return normalizeDashboard(data);
+  async fetchDashboardRaw(id: number): Promise<MetabaseDashboardRaw> {
+    const { data } = await this.http.get<MetabaseDashboardRaw>(
+      `/api/dashboard/${id}`
+    );
+    return data;
   }
 
-  async findDashcard(dashboardId: number, dashcardId: number): Promise<DashcardRef | null> {
-    const { data } = await this.http.get<MetabaseDashboardRaw>(`/api/dashboard/${dashboardId}`);
-    return findDashcardRef(data, dashcardId);
+  async getDashboard(id: number): Promise<DashboardData> {
+    return normalizeDashboard(await this.fetchDashboardRaw(id));
+  }
+
+  async findDashcard(
+    dashboardId: number,
+    dashcardId: number
+  ): Promise<DashcardRef | null> {
+    return findDashcardRef(await this.fetchDashboardRaw(dashboardId), dashcardId);
   }
 
   async getCardValue(

--- a/server/src/services/metabase/metabase-api.ts
+++ b/server/src/services/metabase/metabase-api.ts
@@ -2,11 +2,15 @@ import axios from 'axios';
 
 import type {
   CardType,
-  DashboardCard,
-  Tab,
   TableColumnMeta
 } from '@zerologementvacant/models';
 import config from '~/infra/config';
+import { createCachedMetabaseService } from './metabase-cache';
+import {
+  findDashcardRef,
+  normalizeBaseType,
+  normalizeDashboard
+} from './metabase-normalize';
 import type {
   BarChartValue,
   CardValue,
@@ -14,322 +18,13 @@ import type {
   DashboardParameter,
   DashcardRef,
   LineChartValue,
-  MetabaseColumnSettings,
   MetabaseDashboardRaw,
-  MetabaseDashcard,
-  MetabaseDashcardVisualizationSettings,
   MetabaseQueryResult,
   MetabaseService,
-  MetabaseVisualizationSettings,
   PieChartValue,
   TableColumnRef,
   TableValue
 } from './metabase-service';
-
-// ─── Normalization helpers ─────────────────────────────────────────────────────
-
-function mergeVisualizationSettings(
-  card: MetabaseVisualizationSettings,
-  dashcard: MetabaseDashcardVisualizationSettings
-): MetabaseVisualizationSettings {
-  return {
-    ...card,
-    ...(dashcard['number.style'] !== undefined && { 'number.style': dashcard['number.style'] }),
-    ...(dashcard['scalar.field'] !== undefined && { 'scalar.field': dashcard['scalar.field'] }),
-    ...(dashcard['table.columns'] !== undefined && {
-      'table.columns': dashcard['table.columns']
-    }),
-    ...(dashcard['graph.dimensions'] !== undefined && {
-      'graph.dimensions': dashcard['graph.dimensions']
-    }),
-    ...(dashcard['graph.metrics'] !== undefined && {
-      'graph.metrics': dashcard['graph.metrics']
-    }),
-    column_settings: { ...(card.column_settings ?? {}), ...(dashcard.column_settings ?? {}) }
-  };
-}
-
-// Returns column settings for the active display column.
-// For multi-column scalar cards, scalar.field identifies which column is shown.
-// Falls back to the first enabled table column when scalar.field is absent.
-function activeColumnSettings(
-  settings: MetabaseVisualizationSettings
-): MetabaseColumnSettings | undefined {
-  const scalarField = settings['scalar.field'];
-  if (scalarField !== undefined) {
-    return settings.column_settings?.[JSON.stringify(['name', scalarField])];
-  }
-  const activeCol = (settings['table.columns'] ?? []).find((c) => c.enabled);
-  if (!activeCol) return undefined;
-  return settings.column_settings?.[JSON.stringify(['name', activeCol.name])];
-}
-
-function resolveAxisColumns(
-  settings: MetabaseVisualizationSettings
-): { labelColumn: string | null; valueColumn: string | null } {
-  return {
-    labelColumn: settings['graph.dimensions']?.[0] ?? null,
-    valueColumn: settings['graph.metrics']?.[0] ?? null
-  };
-}
-
-function detectColumnFormat(
-  settings: MetabaseVisualizationSettings,
-  columnName: string | null
-): { format: 'number' | 'percent'; decimals: number } {
-  if (columnName === null) return { format: 'number', decimals: 0 };
-  const col = settings.column_settings?.[JSON.stringify(['name', columnName])];
-  if (!col) return { format: 'number', decimals: 0 };
-  const isPercent = col.suffix?.includes('%') === true || col.number_style === 'percent';
-  return {
-    format: isPercent ? 'percent' : 'number',
-    decimals: col.decimals ?? 0
-  };
-}
-
-function detectCardType(
-  settings: MetabaseVisualizationSettings
-): 'flat-number' | 'percentage' {
-  if (settings['number.style'] === 'percent') return 'percentage';
-  const col = activeColumnSettings(settings);
-  if (col) {
-    return col.suffix?.includes('%') || col.number_style === 'percent'
-      ? 'percentage'
-      : 'flat-number';
-  }
-  // When table.columns is explicitly configured but no specific field is active,
-  // the column_settings are table-layout overrides — not scalar format signals.
-  if (settings['table.columns'] !== undefined) return 'flat-number';
-  const hasPercent = Object.values(settings.column_settings ?? {}).some(
-    (c) => c.number_style === 'percent' || c.suffix?.includes('%')
-  );
-  return hasPercent ? 'percentage' : 'flat-number';
-}
-
-function detectDecimals(settings: MetabaseVisualizationSettings): number {
-  if (settings['scalar.decimals'] !== undefined) return settings['scalar.decimals'];
-  const col = activeColumnSettings(settings);
-  return col?.decimals ?? 0;
-}
-
-function normalizeBaseType(
-  metabaseType: string | undefined
-): TableColumnMeta['baseType'] {
-  if (!metabaseType) return 'unknown';
-  if (/Integer|Decimal|Float|Number/.test(metabaseType)) return 'number';
-  if (/Date|Time/.test(metabaseType)) return 'date';
-  if (metabaseType.endsWith('Boolean')) return 'boolean';
-  if (metabaseType.endsWith('Text') || metabaseType.endsWith('String')) {
-    return 'string';
-  }
-  return 'unknown';
-}
-
-// Returns the PM-curated column names in display order. Returns null when no
-// `table.columns` is configured (callers fall back to query columns).
-function resolveVisibleColumnNames(
-  settings: MetabaseVisualizationSettings
-): string[] | null {
-  const tableColumns = settings['table.columns'];
-  if (!tableColumns || tableColumns.length === 0) return null;
-  return tableColumns.filter((c) => c.enabled).map((c) => c.name);
-}
-
-function buildTableColumnRefs(
-  settings: MetabaseVisualizationSettings
-): TableColumnRef[] {
-  const names = resolveVisibleColumnNames(settings);
-  if (names === null) return []; // sentinel: use all query cols
-  return names.map((name) => {
-    const colSettings =
-      settings.column_settings?.[JSON.stringify(['name', name])];
-    return {
-      name,
-      ...(colSettings?.column_title !== undefined && {
-        columnTitle: colSettings.column_title
-      }),
-      ...(colSettings?.decimals !== undefined && {
-        decimals: colSettings.decimals
-      }),
-      ...(colSettings?.suffix !== undefined && { suffix: colSettings.suffix }),
-      ...(colSettings?.number_style !== undefined && {
-        numberStyle: colSettings.number_style
-      })
-    };
-  });
-}
-
-function normalizeDashcard(dashcard: MetabaseDashcard): DashboardCard | null {
-  if (dashcard.card === null) return null;
-  const { card } = dashcard;
-
-  if (card.display === 'pie') {
-    return {
-      id: dashcard.id,
-      type: 'pie-chart',
-      title: dashcard.visualization_settings['card.title'] ?? card.name,
-      description: card.description,
-      decimals: 0,
-      position: { col: dashcard.col, row: dashcard.row },
-      size: { width: dashcard.size_x, height: dashcard.size_y }
-    };
-  }
-
-  if (card.display === 'bar' || card.display === 'row') {
-    return {
-      id: dashcard.id,
-      type: 'bar-chart',
-      title: dashcard.visualization_settings['card.title'] ?? card.name,
-      description: card.description,
-      decimals: 0,
-      position: { col: dashcard.col, row: dashcard.row },
-      size: { width: dashcard.size_x, height: dashcard.size_y }
-    };
-  }
-
-  if (card.display === 'table') {
-    return {
-      id: dashcard.id,
-      type: 'table',
-      title: dashcard.visualization_settings['card.title'] ?? card.name,
-      description: card.description,
-      decimals: 0,
-      position: { col: dashcard.col, row: dashcard.row },
-      size: { width: dashcard.size_x, height: dashcard.size_y }
-    };
-  }
-
-  if (card.display === 'line') {
-    return {
-      id: dashcard.id,
-      type: 'line-chart',
-      title: dashcard.visualization_settings['card.title'] ?? card.name,
-      description: card.description,
-      decimals: 0,
-      position: { col: dashcard.col, row: dashcard.row },
-      size: { width: dashcard.size_x, height: dashcard.size_y }
-    };
-  }
-
-  if (card.display !== 'scalar') return null;
-
-  const settings = mergeVisualizationSettings(
-    card.visualization_settings,
-    dashcard.visualization_settings
-  );
-  return {
-    id: dashcard.id,
-    type: detectCardType(settings),
-    title: dashcard.visualization_settings['card.title'] ?? card.name,
-    description: card.description,
-    decimals: detectDecimals(settings),
-    position: { col: dashcard.col, row: dashcard.row },
-    size: { width: dashcard.size_x, height: dashcard.size_y }
-  };
-}
-
-export function normalizeDashboard(raw: MetabaseDashboardRaw): DashboardData {
-  if (raw.tabs && raw.tabs.length > 0) {
-    const sortedTabs = [...raw.tabs].sort((a, b) => a.position - b.position);
-    const tabs: Tab[] = sortedTabs.map((tab) => ({
-      id: tab.id,
-      title: tab.name,
-      cards: raw.dashcards
-        .filter((dc) => dc.dashboard_tab_id === tab.id)
-        .map(normalizeDashcard)
-        .filter((c): c is DashboardCard => c !== null)
-    }));
-    return { tabs };
-  }
-  return {
-    cards: raw.dashcards
-      .map(normalizeDashcard)
-      .filter((c): c is DashboardCard => c !== null)
-  };
-}
-
-export function findDashcardRef(
-  raw: MetabaseDashboardRaw,
-  dashcardId: number
-): DashcardRef | null {
-  const found = raw.dashcards.find((dc) => dc.id === dashcardId);
-  if (!found || found.card_id === null) return null;
-  const normalized = normalizeDashcard(found);
-  if (!normalized) return null;
-
-  const settings = mergeVisualizationSettings(
-    found.card!.visualization_settings,
-    found.visualization_settings
-  );
-  const dashboardParameters = (raw.parameters ?? []).map(
-    (p): DashboardParameter => ({ id: p.id, slug: p.slug, type: p.type })
-  );
-
-  if (normalized.type === 'pie-chart') {
-    return {
-      dashcardId: found.id,
-      cardId: found.card_id,
-      type: 'pie-chart',
-      valueColumn: null,
-      labelColumn: null,
-      direction: null,
-      format: 'number',
-      decimals: 0,
-      tableColumns: null,
-      dashboardParameters
-    };
-  }
-
-  if (normalized.type === 'bar-chart' || normalized.type === 'line-chart') {
-    const { labelColumn, valueColumn } = resolveAxisColumns(settings);
-    const { format, decimals } = detectColumnFormat(settings, valueColumn);
-    return {
-      dashcardId: found.id,
-      cardId: found.card_id,
-      type: normalized.type,
-      valueColumn,
-      labelColumn,
-      direction:
-        normalized.type === 'bar-chart'
-          ? found.card!.display === 'bar'
-            ? 'vertical'
-            : 'horizontal'
-          : null,
-      format,
-      decimals,
-      tableColumns: null,
-      dashboardParameters
-    };
-  }
-
-  if (normalized.type === 'table') {
-    return {
-      dashcardId: found.id,
-      cardId: found.card_id,
-      type: 'table',
-      valueColumn: null,
-      labelColumn: null,
-      direction: null,
-      format: 'number',
-      decimals: 0,
-      tableColumns: buildTableColumnRefs(settings),
-      dashboardParameters
-    };
-  }
-
-  return {
-    dashcardId: found.id,
-    cardId: found.card_id,
-    type: normalized.type,
-    valueColumn: settings['scalar.field'] ?? null,
-    labelColumn: null,
-    direction: null,
-    format: 'number',
-    decimals: 0,
-    tableColumns: null,
-    dashboardParameters
-  };
-}
 
 // Percent-formatted columns are stored as display values (e.g. 1.79 for 1.79%)
 // in Metabase. We divide by 100 here so the response shape matches the scalar
@@ -497,7 +192,12 @@ export function createMetabaseAPI(opts: MetabaseAPIOptions): MetabaseService {
   return new MetabaseAPI(opts);
 }
 
-export const metabaseAPI = createMetabaseAPI({
+const baseMetabaseAPI = createMetabaseAPI({
   domain: config.metabase.domain,
   apiToken: config.metabase.apiToken
+});
+
+export const metabaseAPI = createCachedMetabaseService(baseMetabaseAPI, {
+  ttlMs: config.metabase.cacheTtlMs,
+  max: config.metabase.cacheMaxEntries
 });

--- a/server/src/services/metabase/metabase-cache.ts
+++ b/server/src/services/metabase/metabase-cache.ts
@@ -1,0 +1,126 @@
+import { TTLCache } from '@isaacs/ttlcache';
+
+import {
+  findDashcardRef,
+  normalizeDashboard
+} from './metabase-api';
+import type {
+  CardValue,
+  DashboardData,
+  DashboardParameter,
+  DashcardRef,
+  MetabaseDashboardRaw,
+  MetabaseService,
+  TableColumnRef
+} from './metabase-service';
+import type { CardType, TableColumnMeta } from '@zerologementvacant/models';
+
+export interface CacheOptions {
+  ttlMs: number;
+  max: number;
+}
+
+async function cached<K, V>(
+  store: TTLCache<K, Promise<V>>,
+  key: K,
+  fetch: () => Promise<V>
+): Promise<V> {
+  const existing = store.get(key);
+  if (existing) return existing;
+  const promise = fetch().catch((err) => {
+    store.delete(key);
+    throw err;
+  });
+  store.set(key, promise);
+  return promise;
+}
+
+function cardKey(
+  dashboardId: number,
+  dashcardId: number,
+  cardId: number,
+  establishmentId: string
+): string {
+  return `${dashboardId}:${dashcardId}:${cardId}:${establishmentId}`;
+}
+
+class CachedMetabaseService implements MetabaseService {
+  private readonly dashboardCache: TTLCache<number, Promise<MetabaseDashboardRaw>>;
+  private readonly cardCache: TTLCache<string, Promise<CardValue>>;
+
+  constructor(
+    private readonly inner: MetabaseService,
+    opts: CacheOptions
+  ) {
+    this.dashboardCache = new TTLCache({ ttl: opts.ttlMs, max: opts.max });
+    this.cardCache = new TTLCache({ ttl: opts.ttlMs, max: opts.max });
+  }
+
+  fetchDashboardRaw(id: number): Promise<MetabaseDashboardRaw> {
+    return cached(this.dashboardCache, id, () =>
+      this.inner.fetchDashboardRaw(id)
+    );
+  }
+
+  async getDashboard(id: number): Promise<DashboardData> {
+    return normalizeDashboard(await this.fetchDashboardRaw(id));
+  }
+
+  async findDashcard(
+    dashboardId: number,
+    dashcardId: number
+  ): Promise<DashcardRef | null> {
+    return findDashcardRef(
+      await this.fetchDashboardRaw(dashboardId),
+      dashcardId
+    );
+  }
+
+  getCardValue(
+    dashboardId: number,
+    dashcardId: number,
+    cardId: number,
+    parameters: ReadonlyArray<DashboardParameter & { value: string }>,
+    valueColumn: string | null,
+    labelColumn: string | null,
+    cardType: CardType,
+    direction: 'horizontal' | 'vertical' | null,
+    format: 'number' | 'percent',
+    decimals: number,
+    tableColumns: ReadonlyArray<TableColumnRef> | null
+  ): Promise<CardValue> {
+    const establishmentId =
+      parameters.find((p) => p.slug === 'id')?.value ?? 'anonymous';
+    const key = cardKey(dashboardId, dashcardId, cardId, establishmentId);
+    return cached(this.cardCache, key, () =>
+      this.inner.getCardValue(
+        dashboardId,
+        dashcardId,
+        cardId,
+        parameters,
+        valueColumn,
+        labelColumn,
+        cardType,
+        direction,
+        format,
+        decimals,
+        tableColumns
+      )
+    );
+  }
+
+  clear(): void {
+    this.dashboardCache.clear();
+    this.cardCache.clear();
+  }
+}
+
+export function createCachedMetabaseService(
+  inner: MetabaseService,
+  opts: CacheOptions
+): MetabaseService & { clear: () => void } {
+  return new CachedMetabaseService(inner, opts);
+}
+
+// Re-export so callers can import the type from the module they actually use.
+export type { TableColumnMeta };

--- a/server/src/services/metabase/metabase-cache.ts
+++ b/server/src/services/metabase/metabase-cache.ts
@@ -13,7 +13,7 @@ import type {
   MetabaseService,
   TableColumnRef
 } from './metabase-service';
-import type { CardType, TableColumnMeta } from '@zerologementvacant/models';
+import type { CardType } from '@zerologementvacant/models';
 
 export interface CacheOptions {
   ttlMs: number;
@@ -26,7 +26,7 @@ async function cached<K, V>(
   fetch: () => Promise<V>
 ): Promise<V> {
   const existing = store.get(key);
-  if (existing) return existing;
+  if (existing !== undefined) return existing;
   const promise = fetch().catch((err) => {
     store.delete(key);
     throw err;
@@ -121,6 +121,3 @@ export function createCachedMetabaseService(
 ): MetabaseService & { clear: () => void } {
   return new CachedMetabaseService(inner, opts);
 }
-
-// Re-export so callers can import the type from the module they actually use.
-export type { TableColumnMeta };

--- a/server/src/services/metabase/metabase-cache.ts
+++ b/server/src/services/metabase/metabase-cache.ts
@@ -3,7 +3,7 @@ import { TTLCache } from '@isaacs/ttlcache';
 import {
   findDashcardRef,
   normalizeDashboard
-} from './metabase-api';
+} from './metabase-normalize';
 import type {
   CardValue,
   DashboardData,

--- a/server/src/services/metabase/metabase-normalize.ts
+++ b/server/src/services/metabase/metabase-normalize.ts
@@ -1,0 +1,319 @@
+import type {
+  DashboardCard,
+  Tab,
+  TableColumnMeta
+} from '@zerologementvacant/models';
+import type {
+  DashboardData,
+  DashboardParameter,
+  DashcardRef,
+  MetabaseColumnSettings,
+  MetabaseDashboardRaw,
+  MetabaseDashcard,
+  MetabaseDashcardVisualizationSettings,
+  MetabaseVisualizationSettings,
+  TableColumnRef
+} from './metabase-service';
+
+function mergeVisualizationSettings(
+  card: MetabaseVisualizationSettings,
+  dashcard: MetabaseDashcardVisualizationSettings
+): MetabaseVisualizationSettings {
+  return {
+    ...card,
+    ...(dashcard['number.style'] !== undefined && { 'number.style': dashcard['number.style'] }),
+    ...(dashcard['scalar.field'] !== undefined && { 'scalar.field': dashcard['scalar.field'] }),
+    ...(dashcard['table.columns'] !== undefined && {
+      'table.columns': dashcard['table.columns']
+    }),
+    ...(dashcard['graph.dimensions'] !== undefined && {
+      'graph.dimensions': dashcard['graph.dimensions']
+    }),
+    ...(dashcard['graph.metrics'] !== undefined && {
+      'graph.metrics': dashcard['graph.metrics']
+    }),
+    column_settings: { ...(card.column_settings ?? {}), ...(dashcard.column_settings ?? {}) }
+  };
+}
+
+// Returns column settings for the active display column.
+// For multi-column scalar cards, scalar.field identifies which column is shown.
+// Falls back to the first enabled table column when scalar.field is absent.
+function activeColumnSettings(
+  settings: MetabaseVisualizationSettings
+): MetabaseColumnSettings | undefined {
+  const scalarField = settings['scalar.field'];
+  if (scalarField !== undefined) {
+    return settings.column_settings?.[JSON.stringify(['name', scalarField])];
+  }
+  const activeCol = (settings['table.columns'] ?? []).find((c) => c.enabled);
+  if (!activeCol) return undefined;
+  return settings.column_settings?.[JSON.stringify(['name', activeCol.name])];
+}
+
+function resolveAxisColumns(
+  settings: MetabaseVisualizationSettings
+): { labelColumn: string | null; valueColumn: string | null } {
+  return {
+    labelColumn: settings['graph.dimensions']?.[0] ?? null,
+    valueColumn: settings['graph.metrics']?.[0] ?? null
+  };
+}
+
+function detectColumnFormat(
+  settings: MetabaseVisualizationSettings,
+  columnName: string | null
+): { format: 'number' | 'percent'; decimals: number } {
+  if (columnName === null) return { format: 'number', decimals: 0 };
+  const col = settings.column_settings?.[JSON.stringify(['name', columnName])];
+  if (!col) return { format: 'number', decimals: 0 };
+  const isPercent = col.suffix?.includes('%') === true || col.number_style === 'percent';
+  return {
+    format: isPercent ? 'percent' : 'number',
+    decimals: col.decimals ?? 0
+  };
+}
+
+function detectCardType(
+  settings: MetabaseVisualizationSettings
+): 'flat-number' | 'percentage' {
+  if (settings['number.style'] === 'percent') return 'percentage';
+  const col = activeColumnSettings(settings);
+  if (col) {
+    return col.suffix?.includes('%') || col.number_style === 'percent'
+      ? 'percentage'
+      : 'flat-number';
+  }
+  // When table.columns is explicitly configured but no specific field is active,
+  // the column_settings are table-layout overrides — not scalar format signals.
+  if (settings['table.columns'] !== undefined) return 'flat-number';
+  const hasPercent = Object.values(settings.column_settings ?? {}).some(
+    (c) => c.number_style === 'percent' || c.suffix?.includes('%')
+  );
+  return hasPercent ? 'percentage' : 'flat-number';
+}
+
+function detectDecimals(settings: MetabaseVisualizationSettings): number {
+  if (settings['scalar.decimals'] !== undefined) return settings['scalar.decimals'];
+  const col = activeColumnSettings(settings);
+  return col?.decimals ?? 0;
+}
+
+export function normalizeBaseType(
+  metabaseType: string | undefined
+): TableColumnMeta['baseType'] {
+  if (!metabaseType) return 'unknown';
+  if (/Integer|Decimal|Float|Number/.test(metabaseType)) return 'number';
+  if (/Date|Time/.test(metabaseType)) return 'date';
+  if (metabaseType.endsWith('Boolean')) return 'boolean';
+  if (metabaseType.endsWith('Text') || metabaseType.endsWith('String')) {
+    return 'string';
+  }
+  return 'unknown';
+}
+
+// Returns the PM-curated column names in display order. Returns null when no
+// `table.columns` is configured (callers fall back to query columns).
+function resolveVisibleColumnNames(
+  settings: MetabaseVisualizationSettings
+): string[] | null {
+  const tableColumns = settings['table.columns'];
+  if (!tableColumns || tableColumns.length === 0) return null;
+  return tableColumns.filter((c) => c.enabled).map((c) => c.name);
+}
+
+function buildTableColumnRefs(
+  settings: MetabaseVisualizationSettings
+): TableColumnRef[] {
+  const names = resolveVisibleColumnNames(settings);
+  if (names === null) return []; // sentinel: use all query cols
+  return names.map((name) => {
+    const colSettings =
+      settings.column_settings?.[JSON.stringify(['name', name])];
+    return {
+      name,
+      ...(colSettings?.column_title !== undefined && {
+        columnTitle: colSettings.column_title
+      }),
+      ...(colSettings?.decimals !== undefined && {
+        decimals: colSettings.decimals
+      }),
+      ...(colSettings?.suffix !== undefined && { suffix: colSettings.suffix }),
+      ...(colSettings?.number_style !== undefined && {
+        numberStyle: colSettings.number_style
+      })
+    };
+  });
+}
+
+function normalizeDashcard(dashcard: MetabaseDashcard): DashboardCard | null {
+  if (dashcard.card === null) return null;
+  const { card } = dashcard;
+
+  if (card.display === 'pie') {
+    return {
+      id: dashcard.id,
+      type: 'pie-chart',
+      title: dashcard.visualization_settings['card.title'] ?? card.name,
+      description: card.description,
+      decimals: 0,
+      position: { col: dashcard.col, row: dashcard.row },
+      size: { width: dashcard.size_x, height: dashcard.size_y }
+    };
+  }
+
+  if (card.display === 'bar' || card.display === 'row') {
+    return {
+      id: dashcard.id,
+      type: 'bar-chart',
+      title: dashcard.visualization_settings['card.title'] ?? card.name,
+      description: card.description,
+      decimals: 0,
+      position: { col: dashcard.col, row: dashcard.row },
+      size: { width: dashcard.size_x, height: dashcard.size_y }
+    };
+  }
+
+  if (card.display === 'table') {
+    return {
+      id: dashcard.id,
+      type: 'table',
+      title: dashcard.visualization_settings['card.title'] ?? card.name,
+      description: card.description,
+      decimals: 0,
+      position: { col: dashcard.col, row: dashcard.row },
+      size: { width: dashcard.size_x, height: dashcard.size_y }
+    };
+  }
+
+  if (card.display === 'line') {
+    return {
+      id: dashcard.id,
+      type: 'line-chart',
+      title: dashcard.visualization_settings['card.title'] ?? card.name,
+      description: card.description,
+      decimals: 0,
+      position: { col: dashcard.col, row: dashcard.row },
+      size: { width: dashcard.size_x, height: dashcard.size_y }
+    };
+  }
+
+  if (card.display !== 'scalar') return null;
+
+  const settings = mergeVisualizationSettings(
+    card.visualization_settings,
+    dashcard.visualization_settings
+  );
+  return {
+    id: dashcard.id,
+    type: detectCardType(settings),
+    title: dashcard.visualization_settings['card.title'] ?? card.name,
+    description: card.description,
+    decimals: detectDecimals(settings),
+    position: { col: dashcard.col, row: dashcard.row },
+    size: { width: dashcard.size_x, height: dashcard.size_y }
+  };
+}
+
+export function normalizeDashboard(raw: MetabaseDashboardRaw): DashboardData {
+  if (raw.tabs && raw.tabs.length > 0) {
+    const sortedTabs = [...raw.tabs].sort((a, b) => a.position - b.position);
+    const tabs: Tab[] = sortedTabs.map((tab) => ({
+      id: tab.id,
+      title: tab.name,
+      cards: raw.dashcards
+        .filter((dc) => dc.dashboard_tab_id === tab.id)
+        .map(normalizeDashcard)
+        .filter((c): c is DashboardCard => c !== null)
+    }));
+    return { tabs };
+  }
+  return {
+    cards: raw.dashcards
+      .map(normalizeDashcard)
+      .filter((c): c is DashboardCard => c !== null)
+  };
+}
+
+export function findDashcardRef(
+  raw: MetabaseDashboardRaw,
+  dashcardId: number
+): DashcardRef | null {
+  const found = raw.dashcards.find((dc) => dc.id === dashcardId);
+  if (!found || found.card_id === null) return null;
+  const normalized = normalizeDashcard(found);
+  if (!normalized) return null;
+
+  const settings = mergeVisualizationSettings(
+    found.card!.visualization_settings,
+    found.visualization_settings
+  );
+  const dashboardParameters = (raw.parameters ?? []).map(
+    (p): DashboardParameter => ({ id: p.id, slug: p.slug, type: p.type })
+  );
+
+  if (normalized.type === 'pie-chart') {
+    return {
+      dashcardId: found.id,
+      cardId: found.card_id,
+      type: 'pie-chart',
+      valueColumn: null,
+      labelColumn: null,
+      direction: null,
+      format: 'number',
+      decimals: 0,
+      tableColumns: null,
+      dashboardParameters
+    };
+  }
+
+  if (normalized.type === 'bar-chart' || normalized.type === 'line-chart') {
+    const { labelColumn, valueColumn } = resolveAxisColumns(settings);
+    const { format, decimals } = detectColumnFormat(settings, valueColumn);
+    return {
+      dashcardId: found.id,
+      cardId: found.card_id,
+      type: normalized.type,
+      valueColumn,
+      labelColumn,
+      direction:
+        normalized.type === 'bar-chart'
+          ? found.card!.display === 'bar'
+            ? 'vertical'
+            : 'horizontal'
+          : null,
+      format,
+      decimals,
+      tableColumns: null,
+      dashboardParameters
+    };
+  }
+
+  if (normalized.type === 'table') {
+    return {
+      dashcardId: found.id,
+      cardId: found.card_id,
+      type: 'table',
+      valueColumn: null,
+      labelColumn: null,
+      direction: null,
+      format: 'number',
+      decimals: 0,
+      tableColumns: buildTableColumnRefs(settings),
+      dashboardParameters
+    };
+  }
+
+  return {
+    dashcardId: found.id,
+    cardId: found.card_id,
+    type: normalized.type,
+    valueColumn: settings['scalar.field'] ?? null,
+    labelColumn: null,
+    direction: null,
+    format: 'number',
+    decimals: 0,
+    tableColumns: null,
+    dashboardParameters
+  };
+}

--- a/server/src/services/metabase/metabase-service.ts
+++ b/server/src/services/metabase/metabase-service.ts
@@ -5,6 +5,79 @@ import type {
   TableColumnMeta
 } from '@zerologementvacant/models';
 
+// Raw payload returned by `GET /api/dashboard/:id`. Exposed on the service
+// contract so wrappers (cache, instrumentation) can hold the raw payload before
+// normalization.
+export interface MetabaseColumnSettings {
+  number_style?: string;
+  decimals?: number;
+  suffix?: string;
+  column_title?: string;
+}
+
+export interface MetabaseVisualizationSettings {
+  'number.style'?: string;
+  'scalar.decimals'?: number;
+  'scalar.field'?: string;
+  'table.columns'?: Array<{ name: string; enabled: boolean }>;
+  'graph.dimensions'?: string[];
+  'graph.metrics'?: string[];
+  column_settings?: Record<string, MetabaseColumnSettings>;
+}
+
+export interface MetabaseCard {
+  id: number;
+  name: string;
+  display: string;
+  description: string | null;
+  visualization_settings: MetabaseVisualizationSettings;
+}
+
+export interface MetabaseDashcardVisualizationSettings {
+  'card.title'?: string | null;
+  'number.style'?: string;
+  'scalar.field'?: string;
+  'table.columns'?: Array<{ name: string; enabled: boolean }>;
+  'graph.dimensions'?: string[];
+  'graph.metrics'?: string[];
+  column_settings?: Record<string, MetabaseColumnSettings>;
+}
+
+export interface MetabaseDashcard {
+  id: number;
+  card_id: number | null;
+  dashboard_tab_id: number | null;
+  row: number;
+  col: number;
+  size_x: number;
+  size_y: number;
+  visualization_settings: MetabaseDashcardVisualizationSettings;
+  card: MetabaseCard | null;
+}
+
+export interface MetabaseTab {
+  id: number;
+  name: string;
+  position: number;
+}
+
+export interface MetabaseDashboardRaw {
+  id: number;
+  tabs?: MetabaseTab[];
+  dashcards: MetabaseDashcard[];
+  parameters?: Array<{ id: string; slug: string; type: string }>;
+}
+
+export interface MetabaseCol {
+  name: string;
+  display_name?: string;
+  base_type?: string;
+}
+
+export interface MetabaseQueryResult {
+  data: { rows: unknown[][]; cols: MetabaseCol[] };
+}
+
 export type DashboardData =
   | { tabs: ReadonlyArray<Tab> }
   | { cards: ReadonlyArray<DashboardCard> };
@@ -65,6 +138,7 @@ export type CardValue =
   | TableValue;
 
 export interface MetabaseService {
+  fetchDashboardRaw(id: number): Promise<MetabaseDashboardRaw>;
   getDashboard(id: number): Promise<DashboardData>;
   findDashcard(dashboardId: number, dashcardId: number): Promise<DashcardRef | null>;
   getCardValue(

--- a/server/src/services/metabase/test/metabase-cache.test.ts
+++ b/server/src/services/metabase/test/metabase-cache.test.ts
@@ -1,0 +1,247 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type {
+  CardValue,
+  DashboardData,
+  DashcardRef,
+  MetabaseDashboardRaw,
+  MetabaseService
+} from '../metabase-service';
+import { createCachedMetabaseService } from '../metabase-cache';
+
+function genRaw(id: number): MetabaseDashboardRaw {
+  return {
+    id,
+    dashcards: [
+      {
+        id: 100,
+        card_id: 200,
+        dashboard_tab_id: null,
+        row: 0,
+        col: 0,
+        size_x: 6,
+        size_y: 3,
+        visualization_settings: {},
+        card: {
+          id: 200,
+          name: 'fake',
+          display: 'scalar',
+          description: null,
+          visualization_settings: {}
+        }
+      }
+    ],
+    parameters: []
+  };
+}
+
+function genDashcardRef(): DashcardRef {
+  return {
+    dashcardId: 100,
+    cardId: 200,
+    type: 'flat-number',
+    valueColumn: null,
+    labelColumn: null,
+    direction: null,
+    format: 'number',
+    decimals: 0,
+    tableColumns: null,
+    dashboardParameters: []
+  };
+}
+
+interface FakeService extends MetabaseService {
+  calls: {
+    fetchDashboardRaw: number;
+    getDashboard: number;
+    findDashcard: number;
+    getCardValue: number;
+  };
+}
+
+function genFakeService(overrides: Partial<MetabaseService> = {}): FakeService {
+  const calls = {
+    fetchDashboardRaw: 0,
+    getDashboard: 0,
+    findDashcard: 0,
+    getCardValue: 0
+  };
+  const inner: FakeService = {
+    calls,
+    fetchDashboardRaw: vi.fn(async (id: number) => {
+      calls.fetchDashboardRaw++;
+      return genRaw(id);
+    }),
+    getDashboard: vi.fn(async () => {
+      calls.getDashboard++;
+      return { cards: [] } as DashboardData;
+    }),
+    findDashcard: vi.fn(async () => {
+      calls.findDashcard++;
+      return genDashcardRef();
+    }),
+    getCardValue: vi.fn(async () => {
+      calls.getCardValue++;
+      return 42 as CardValue;
+    }),
+    ...overrides
+  };
+  return inner;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('CachedMetabaseService.fetchDashboardRaw', () => {
+  it('returns cached value on second call within TTL', async () => {
+    const inner = genFakeService();
+    const cached = createCachedMetabaseService(inner, {
+      ttlMs: 60_000,
+      max: 100
+    });
+
+    await cached.fetchDashboardRaw(13);
+    await cached.fetchDashboardRaw(13);
+
+    expect(inner.calls.fetchDashboardRaw).toBe(1);
+  });
+
+  it('re-fetches after TTL expiry', async () => {
+    // Real timers + a short TTL: TTLCache reads from a `performance` ref
+    // captured at module load, so Vitest fake timers cannot move its clock.
+    // 50ms TTL with a 250ms wait gives a 5× margin to stay reliable on busy CI.
+    vi.useRealTimers();
+    const inner = genFakeService();
+    const cached = createCachedMetabaseService(inner, {
+      ttlMs: 50,
+      max: 100
+    });
+
+    await cached.fetchDashboardRaw(13);
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    await cached.fetchDashboardRaw(13);
+
+    expect(inner.calls.fetchDashboardRaw).toBe(2);
+  });
+
+  it('coalesces concurrent calls into one underlying fetch', async () => {
+    let resolveInner: ((v: MetabaseDashboardRaw) => void) | undefined;
+    const innerPromise = new Promise<MetabaseDashboardRaw>((resolve) => {
+      resolveInner = resolve;
+    });
+    const inner = genFakeService({
+      fetchDashboardRaw: vi.fn(() => innerPromise)
+    });
+    const cached = createCachedMetabaseService(inner, {
+      ttlMs: 60_000,
+      max: 100
+    });
+
+    const [a, b, c] = [
+      cached.fetchDashboardRaw(13),
+      cached.fetchDashboardRaw(13),
+      cached.fetchDashboardRaw(13)
+    ];
+    resolveInner!(genRaw(13));
+    await Promise.all([a, b, c]);
+
+    expect(inner.fetchDashboardRaw).toHaveBeenCalledTimes(1);
+  });
+
+  it('removes the cached promise on rejection so the next call retries', async () => {
+    let attempt = 0;
+    const inner = genFakeService({
+      fetchDashboardRaw: vi.fn(async (id: number) => {
+        attempt++;
+        if (attempt === 1) throw new Error('boom');
+        return genRaw(id);
+      })
+    });
+    const cached = createCachedMetabaseService(inner, {
+      ttlMs: 60_000,
+      max: 100
+    });
+
+    await expect(cached.fetchDashboardRaw(13)).rejects.toThrow('boom');
+    await expect(cached.fetchDashboardRaw(13)).resolves.toMatchObject({
+      id: 13
+    });
+
+    expect(inner.fetchDashboardRaw).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('CachedMetabaseService.getCardValue', () => {
+  it('caches per (dashboard, dashcard, card, establishment)', async () => {
+    const inner = genFakeService();
+    const cached = createCachedMetabaseService(inner, {
+      ttlMs: 60_000,
+      max: 100
+    });
+    const params = [{ id: 'p1', slug: 'id', type: 'category', value: 'est-1' }];
+
+    await cached.getCardValue(
+      13, 100, 200, params, null, null, 'flat-number', null, 'number', 0, null
+    );
+    await cached.getCardValue(
+      13, 100, 200, params, null, null, 'flat-number', null, 'number', 0, null
+    );
+
+    expect(inner.getCardValue).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not share cache entries across establishments', async () => {
+    const inner = genFakeService();
+    const cached = createCachedMetabaseService(inner, {
+      ttlMs: 60_000,
+      max: 100
+    });
+    const p1 = [{ id: 'p1', slug: 'id', type: 'category', value: 'est-1' }];
+    const p2 = [{ id: 'p1', slug: 'id', type: 'category', value: 'est-2' }];
+
+    await cached.getCardValue(
+      13, 100, 200, p1, null, null, 'flat-number', null, 'number', 0, null
+    );
+    await cached.getCardValue(
+      13, 100, 200, p2, null, null, 'flat-number', null, 'number', 0, null
+    );
+
+    expect(inner.getCardValue).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('CachedMetabaseService — shared raw fetch', () => {
+  it('runs one fetchDashboardRaw for getDashboard + findDashcard on the same id', async () => {
+    const inner = genFakeService();
+    const cached = createCachedMetabaseService(inner, {
+      ttlMs: 60_000,
+      max: 100
+    });
+
+    await cached.getDashboard(13);
+    await cached.findDashcard(13, 100);
+
+    expect(inner.fetchDashboardRaw).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('CachedMetabaseService.clear', () => {
+  it('drops all cached entries', async () => {
+    const inner = genFakeService();
+    const cached = createCachedMetabaseService(inner, {
+      ttlMs: 60_000,
+      max: 100
+    });
+
+    await cached.fetchDashboardRaw(13);
+    cached.clear();
+    await cached.fetchDashboardRaw(13);
+
+    expect(inner.fetchDashboardRaw).toHaveBeenCalledTimes(2);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3648,6 +3648,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@isaacs/ttlcache@npm:^2.1.5":
+  version: 2.1.5
+  resolution: "@isaacs/ttlcache@npm:2.1.5"
+  checksum: 10c0/6a5e3e868e916e43bf7f25d2dbd50861c6aec1aea9349b2a87bf348fb12efa2bfa8cb2e94dc83a7b6287071c18efff7123c9cbb7d0da1f311330c7bd0b2351bf
+  languageName: node
+  linkType: hard
+
 "@jest/diff-sequences@npm:30.0.1":
   version: 30.0.1
   resolution: "@jest/diff-sequences@npm:30.0.1"
@@ -11525,6 +11532,7 @@ __metadata:
     "@fast-check/vitest": "npm:0.4.1"
     "@getbrevo/brevo": "npm:1.0.1"
     "@godaddy/terminus": "npm:4.12.1"
+    "@isaacs/ttlcache": "npm:^2.1.5"
     "@scalar/express-api-reference": "npm:0.9.14"
     "@sendinblue/client": "npm:3.3.1"
     "@sentry/integrations": "npm:7.120.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3648,7 +3648,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@isaacs/ttlcache@npm:^2.1.5":
+"@isaacs/ttlcache@npm:2.1.5":
   version: 2.1.5
   resolution: "@isaacs/ttlcache@npm:2.1.5"
   checksum: 10c0/6a5e3e868e916e43bf7f25d2dbd50861c6aec1aea9349b2a87bf348fb12efa2bfa8cb2e94dc83a7b6287071c18efff7123c9cbb7d0da1f311330c7bd0b2351bf
@@ -11532,7 +11532,7 @@ __metadata:
     "@fast-check/vitest": "npm:0.4.1"
     "@getbrevo/brevo": "npm:1.0.1"
     "@godaddy/terminus": "npm:4.12.1"
-    "@isaacs/ttlcache": "npm:^2.1.5"
+    "@isaacs/ttlcache": "npm:2.1.5"
     "@scalar/express-api-reference": "npm:0.9.14"
     "@sendinblue/client": "npm:3.3.1"
     "@sentry/integrations": "npm:7.120.4"


### PR DESCRIPTION
## Summary

The new Analysis page (`AnalysisViewNext`, resource `13-analyses`) re-runs every Metabase query on every reload, for every user. For a dashboard with N cards, each page load triggered `1 + 2N` Metabase calls (one dashboard layout fetch, plus a redundant layout fetch + a card query per card). Metabase isn't deployed for that load and the page felt slow.

This PR introduces a two-layer cache:

- **Backend in-process TTL cache** (`@isaacs/ttlcache`) on the exported Metabase service singleton. Two caches:
  - Dashboard layout, keyed by `dashboardId`, shared across all establishments.
  - Card value, keyed by `${dashboardId}:${dashcardId}:${cardId}:${establishmentId}`, per-tenant.
  - Both caches store the **promise**, not the resolved value — so when 12 cards mount at once on a cold cache, only one Metabase call fires (coalescing). On rejection, the cached entry is dropped so the next caller retries.
  - TTL: 1 hour by default (`METABASE_CACHE_TTL_MS`). Max entries: 10 000 (`METABASE_CACHE_MAX_ENTRIES`).
- **Frontend RTK Query** `keepUnusedDataFor: 60 * 60` on `findOneDashboardNext` and `findOneCard` — so navigating away and back within an hour is instant. Legacy `findOneDashboard` is untouched.

Along the way:

- `metabase-api.ts` was refactored so `getDashboard` and `findDashcard` both consume a shared `fetchDashboardRaw(id)`. After caching, both methods share a single fetch per dashboard.
- The Metabase-prefixed raw types (`MetabaseDashboardRaw`, etc.) moved from `metabase-api.ts` into `metabase-service.ts` — they're now part of the service contract.
- Pure normalization helpers (`normalizeDashboard`, `findDashcardRef`, `normalizeBaseType`) moved into a new `metabase-normalize.ts` so the dependency graph stays acyclic: `metabase-api → metabase-cache → metabase-normalize`.

Spec: `docs/superpowers/specs/2026-06-09-analysis-page-cache-design.md`
Plan: `docs/superpowers/plans/2026-06-09-analysis-page-cache.md`

## Test plan

Automated (already passing on this branch):

- [x] `yarn nx test server -- metabase-cache` — 8 tests covering TTL hit, TTL expiry, coalescing, rejection cleanup, per-establishment scoping, shared raw fetch, `clear()`.
- [x] `yarn nx test server -- dashboard-api` — 22 existing controller tests (now wrapped in an `afterEach` cache clear) still green.
- [x] `yarn nx typecheck server` and `yarn nx typecheck frontend` clean.

Manual (please verify before merge):

- [ ] Start the stack locally, log in, open the Analysis page (`/parc-vacant/analyses/13-analyses`).
- [ ] Check the backend Metabase request count on first load: 1 dashboard fetch + N card queries.
- [ ] Hard reload (Ctrl/Cmd+Shift+R) within an hour — backend logs should show **no** new Metabase calls.
- [ ] Navigate away (e.g. `/parc-de-logements`) and back to the Analysis page — DevTools Network tab should show **no** requests to `/api/dashboards/...`.
- [ ] Optional TTL re-fetch check: temporarily set `METABASE_CACHE_TTL_MS=5000`, reload after 6 s — one fresh fetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)