### PR TITLE
chore: share Claude Code plugins with the team

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -22,9 +22,21 @@
         "source": "github",
         "repo": "nrwl/nx-ai-agents-config"
       }
+    },
+    "claude-plugins-official": {
+      "source": {
+        "source": "github",
+        "repo": "anthropics/claude-plugins-official"
+      }
     }
   },
   "enabledPlugins": {
-    "nx@nx-claude-plugins": true
+    "nx@nx-claude-plugins": true,
+    "superpowers@claude-plugins-official": true,
+    "context7@claude-plugins-official": true,
+    "code-review@claude-plugins-official": true,
+    "figma@claude-plugins-official": true,
+    "claude-md-management@claude-plugins-official": true,
+    "skill-creator@claude-plugins-official": true
   }
 }

--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,4 +1,7 @@
 {
-  "*.{ts,tsx,js,jsx,mjs,cjs}": ["oxlint --fix", "oxfmt"],
-  "*.{json,yaml,yml,md,css,scss}": "oxfmt"
+  "*.{ts,tsx,js,jsx,mjs,cjs}": [
+    "oxlint --fix",
+    "oxfmt --no-error-on-unmatched-pattern"
+  ],
+  "*.{json,yaml,yml,md,css,scss}": "oxfmt --no-error-on-unmatched-pattern"
 }


### PR DESCRIPTION
## Summary

- Declare the `claude-plugins-official` marketplace in `.claude/settings.json` and enable `superpowers`, `context7`, `code-review`, `figma`, `claude-md-management`, `skill-creator`. Teammates get a one-time install prompt on their next Claude Code session.
- Pass `--no-error-on-unmatched-pattern` to `oxfmt` in `.lintstagedrc.json` so commits touching only dotfiles (e.g. `.claude/`) no longer fail the pre-commit hook — oxfmt silently excludes hidden directories and otherwise errors with "no target files".

## Test plan

- [ ] Open a new Claude Code session in this repo and confirm it prompts to install the six newly enabled plugins.
- [ ] Confirm the previously enabled `nx@nx-claude-plugins` plugin still loads.
- [ ] Make a no-op change inside `.claude/` and confirm the pre-commit hook now succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)