### PR TITLE
feat(owners): make birth date field optional in owner edition forms

### DIFF
--- a/frontend/src/components/Owner/OwnerEditionModal.tsx
+++ b/frontend/src/components/Owner/OwnerEditionModal.tsx
@@ -21,14 +21,7 @@ import { useUpdateOwnerMutation } from '~/services/owner.service';
 import OwnerAddressEdition from '../OwnerAddressEdition/OwnerAddressEdition';
 
 const schema = object({
-  birthDate: string()
-    .nullable()
-    .defined()
-    .test(
-      'birth-date-required',
-      'Veuillez renseigner une date de naissance.',
-      (value) => Boolean(value)
-    ),
+  birthDate: string().nullable().defined(),
   banAddress: object({
     id: string().required(),
     label: string().required(),
@@ -222,15 +215,14 @@ function createOwnerEditionModalNext() {
 
                 <AppTextInputNext<FormSchema, 'birthDate'>
                   name="birthDate"
-                  label="Date de naissance (obligatoire)"
+                  label="Date de naissance (facultatif)"
                   hintText="Format attendu : jj/mm/aaaa"
                   nativeInputProps={{
                     type: 'date',
                     max: new Date()
                       .toISOString()
                       .substring(0, 'yyyy-mm-dd'.length),
-                    autoComplete: 'bday',
-                    'aria-required': 'true'
+                    autoComplete: 'bday'
                   }}
                   mapValue={(value) => value ?? ''}
                   contramapValue={(value) => value || null}

--- a/frontend/src/components/Owner/OwnerEditionModal.tsx
+++ b/frontend/src/components/Owner/OwnerEditionModal.tsx
@@ -215,7 +215,7 @@ function createOwnerEditionModalNext() {
 
                 <AppTextInputNext<FormSchema, 'birthDate'>
                   name="birthDate"
-                  label="Date de naissance (facultatif)"
+                  label="Date de naissance"
                   hintText="Format attendu : jj/mm/aaaa"
                   nativeInputProps={{
                     type: 'date',

--- a/frontend/src/components/Owner/OwnerFormFields.tsx
+++ b/frontend/src/components/Owner/OwnerFormFields.tsx
@@ -62,7 +62,7 @@ function OwnerFormFields(props: OwnerFormFieldsProps) {
 
       <AppTextInputNext<OwnerFormFieldsSchema, 'birthDate'>
         name="birthDate"
-        label="Date de naissance (facultatif)"
+        label="Date de naissance"
         hintText="Format attendu : jj/mm/aaaa"
         nativeInputProps={{
           type: 'date',

--- a/frontend/src/components/Owner/OwnerFormFields.tsx
+++ b/frontend/src/components/Owner/OwnerFormFields.tsx
@@ -13,14 +13,7 @@ import Icon from '~/components/ui/Icon';
 import type { Owner } from '~/models/Owner';
 
 export const OWNER_FORM_FIELD_SCHEMA = object({
-  birthDate: string()
-    .defined()
-    .nullable()
-    .test(
-      'birth-date-required',
-      'Veuillez renseigner une date de naissance.',
-      (value) => Boolean(value)
-    ),
+  birthDate: string().defined().nullable(),
   banAddress: object({
     id: string().required(),
     label: string().required(),
@@ -69,13 +62,12 @@ function OwnerFormFields(props: OwnerFormFieldsProps) {
 
       <AppTextInputNext<OwnerFormFieldsSchema, 'birthDate'>
         name="birthDate"
-        label="Date de naissance (obligatoire)"
+        label="Date de naissance (facultatif)"
         hintText="Format attendu : jj/mm/aaaa"
         nativeInputProps={{
           type: 'date',
           max: new Date().toISOString().substring(0, 'yyyy-mm-dd'.length),
-          autoComplete: 'bday',
-          'aria-required': 'true'
+          autoComplete: 'bday'
         }}
         mapValue={(value) => value ?? ''}
         contramapValue={(value) => value || null}


### PR DESCRIPTION
## Summary

- Removes the mandatory validation on the birth date field in owner edition forms
- Updates field label from "(obligatoire)" to "(facultatif)"
- Removes `aria-required` attribute from the input

Fixes: GEN-1551

## Test plan

- [ ] Open an owner edition form
- [ ] Submit the form without filling in the birth date — should succeed
- [ ] Submit the form with a birth date — should still work
- [ ] Verify the field label reads "Date de naissance (facultatif)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)