### PR TITLE
fix(frontend): guard MapLibre image registration lifecycle

### DIFF
--- a/frontend/src/components/Map/BuildingStatusImages.tsx
+++ b/frontend/src/components/Map/BuildingStatusImages.tsx
@@ -1,0 +1,40 @@
+import { useMap } from 'react-map-gl/maplibre';
+
+import { useMapImages, type MapImage } from '../../hooks/useMapImage';
+
+const buildingStatusImages = [
+  {
+    id: 'square-fill-0',
+    path: '/map/square-fill-0.png'
+  },
+  {
+    id: 'square-fill-1',
+    path: '/map/square-fill-1.png'
+  },
+  {
+    id: 'square-fill-2',
+    path: '/map/square-fill-2.png'
+  },
+  {
+    id: 'square-fill-3',
+    path: '/map/square-fill-3.png'
+  },
+  {
+    id: 'square-fill-4',
+    path: '/map/square-fill-4.png'
+  },
+  {
+    id: 'square-fill-5',
+    path: '/map/square-fill-5.png'
+  }
+] satisfies ReadonlyArray<MapImage>;
+
+function BuildingStatusImages() {
+  const { current: map } = useMap();
+
+  useMapImages(map, buildingStatusImages);
+
+  return null;
+}
+
+export default BuildingStatusImages;

--- a/frontend/src/components/Map/Map.tsx
+++ b/frontend/src/components/Map/Map.tsx
@@ -12,7 +12,6 @@ import ReactiveMap, {
 } from 'react-map-gl/maplibre';
 import { useNavigate } from 'react-router';
 
-import { useMapImage } from '../../hooks/useMapImage';
 import {
   type Building,
   groupByBuilding,
@@ -25,6 +24,7 @@ import {
   type HousingWithCoordinates
 } from '../../models/Housing';
 import BuildingAside from './BuildingAside';
+import BuildingStatusImages from './BuildingStatusImages';
 import Clusters from './Clusters';
 import LayerControl from './LayerControl';
 import LegendButtonControl from './LegendButtonControl';
@@ -104,31 +104,6 @@ function Map(props: MapProps) {
   const excludedPerimeters = props.perimetersExcluded ?? [];
   const [showPerimeters, setShowPerimeters] = useState(true);
 
-  useMapImage({
-    id: 'square-fill-0',
-    path: '/map/square-fill-0.png'
-  });
-  useMapImage({
-    id: 'square-fill-1',
-    path: '/map/square-fill-1.png'
-  });
-  useMapImage({
-    id: 'square-fill-2',
-    path: '/map/square-fill-2.png'
-  });
-  useMapImage({
-    id: 'square-fill-3',
-    path: '/map/square-fill-3.png'
-  });
-  useMapImage({
-    id: 'square-fill-4',
-    path: '/map/square-fill-4.png'
-  });
-  useMapImage({
-    id: 'square-fill-5',
-    path: '/map/square-fill-5.png'
-  });
-
   useEffect(() => {
     if (map && points.length > 0) {
       if (points.length === 1) {
@@ -191,6 +166,7 @@ function Map(props: MapProps) {
             ...props.style
           }}
         >
+          <BuildingStatusImages />
           <Perimeters
             id="remaining-perimeters"
             isVisible={showPerimeters}

--- a/frontend/src/hooks/useMapImage.tsx
+++ b/frontend/src/hooks/useMapImage.tsx
@@ -1,24 +1,77 @@
 import { useEffect } from 'react';
-import { useMap } from 'react-map-gl/maplibre';
+import type { MapRef } from 'react-map-gl/maplibre';
 
-interface UseMapImageOptions {
+export interface MapImage {
   id: string;
   path: string;
 }
 
-export function useMapImage(options: UseMapImageOptions) {
-  const { housingMap: map } = useMap();
-
+export function useMapImages(
+  map: MapRef | undefined,
+  images: readonly MapImage[]
+) {
   useEffect(() => {
-    if (map && !map.hasImage(options.id)) {
-      map
-        .loadImage(options.path)
-        .then((response: any) => {
-          map.addImage(options.id, response.data, {
+    if (!map) {
+      return;
+    }
+
+    const mapRef = map;
+    let cancelled = false;
+
+    async function registerImage(image: MapImage) {
+      if (!isStyleLoaded(mapRef) || hasImage(mapRef, image.id) !== false) {
+        return;
+      }
+
+      try {
+        const response = await mapRef.loadImage(image.path);
+
+        if (
+          !cancelled &&
+          isStyleLoaded(mapRef) &&
+          hasImage(mapRef, image.id) === false
+        ) {
+          mapRef.addImage(image.id, response.data, {
             sdf: false
           });
-        })
-        .catch(console.error);
+        }
+      } catch (error) {
+        if (!cancelled && isStyleLoaded(mapRef)) {
+          console.error(error);
+        }
+      }
     }
-  }, [map, options.id, options.path]);
+
+    function registerImages() {
+      void Promise.all(images.map(registerImage));
+    }
+
+    function onStyleLoad() {
+      registerImages();
+    }
+
+    registerImages();
+    mapRef.on('style.load', onStyleLoad);
+
+    return () => {
+      cancelled = true;
+      mapRef.off('style.load', onStyleLoad);
+    };
+  }, [map, images]);
+}
+
+function isStyleLoaded(map: MapRef): boolean {
+  try {
+    return Boolean(map.isStyleLoaded());
+  } catch {
+    return false;
+  }
+}
+
+function hasImage(map: MapRef, id: string): boolean | undefined {
+  try {
+    return map.hasImage(id);
+  } catch {
+    return undefined;
+  }
 }


### PR DESCRIPTION
Cette PR corrige une race condition MapLibre qui pouvait provoquer l’erreur :
```text
Cannot read properties of undefined (reading 'getImage')
```

Le crash arrivait quand l’application quittait une page contenant une carte alors que les images custom de points bâtiment étaient encore en cours d’enregistrement. À ce moment-là, l’instance de carte pouvait encore exister côté React, mais son style MapLibre était déjà détruit ou en cours de remplacement.

### Changements
Déplace l’enregistrement des images dans un composant enfant de ReactiveMap, pour utiliser la map courante.
Ajoute une garde autour du cycle de vie du style MapLibre avant hasImage / addImage.
Annule les callbacks asynchrones après démontage.
Ré-enregistre les images sur style.load, utile aussi après changement de fond de carte.