### PR TITLE
fix(establishments): enable intercommunality filter for DDT and departmental structures

### DIFF
--- a/packages/models/src/EstablishmentDTO.ts
+++ b/packages/models/src/EstablishmentDTO.ts
@@ -26,7 +26,16 @@ export function isChild(geoCodes: ReadonlySet<string>) {
 export function isDepartmentalEstablishment(
   establishment: Pick<EstablishmentDTO, 'kind'>
 ): boolean {
-  const departments: ReadonlyArray<EstablishmentKind> = ['DEP', 'REG', 'TOM'];
+  const departments: ReadonlyArray<EstablishmentKind> = [
+    'DEP',
+    'REG',
+    'TOM',
+    'CTU',
+    'PETR',
+    'SDED',
+    'SDER',
+    'SIVOM'
+  ];
   return departments.includes(establishment.kind);
 }
 

--- a/packages/models/src/EstablishmentKind.ts
+++ b/packages/models/src/EstablishmentKind.ts
@@ -6,11 +6,16 @@ export const ESTABLISHMENT_KIND_VALUES = [
   'CC', // Communauté de Communes
   'COM', // Commune
   'COM-TOM', // Commune d'Outre-Mer
+  'CTU', // Collectivité Territoriale Unique
   'CU', // Communauté Urbaine
   'DEP', // Département
   'EPT', // Établissement Public Territorial
   'METRO', // Métropole
+  'PETR', // Pôle d'Équilibre Territorial et Rural
   'REG', // Région
+  'SDED', // Service déconcentré de l'État à compétence (inter)départementale
+  'SDER', // Service déconcentré de l'État à compétence (inter)régionale
+  'SIVOM', // Syndicat Intercommunal à Vocation Multiple
   'TOM' // Territoire d'Outre-Mer
 ] as const;
 
@@ -20,21 +25,26 @@ const ESTABLISHMENT_KIND_ORDER: Record<EstablishmentKind, number> = {
   // Regional level
   REG: 1, // Région
   TOM: 2, // Territoire d'Outre-Mer
+  SDER: 3, // Service déconcentré de l'État à compétence (inter)régionale
+  CTU: 4, // Collectivité Territoriale Unique
 
   // Departmental level
-  DEP: 3, // Département
+  DEP: 5, // Département
+  SDED: 6, // Service déconcentré de l'État à compétence (inter)départementale
 
   // Intercommunal level (from largest to smallest)
-  METRO: 4, // Métropole
-  CU: 5, // Communauté Urbaine
-  CA: 6, // Communauté d'Agglomération
-  CC: 7, // Communauté de Communes
-  EPT: 8, // Établissement Public Territorial
+  METRO: 7, // Métropole
+  CU: 8, // Communauté Urbaine
+  CA: 9, // Communauté d'Agglomération
+  CC: 10, // Communauté de Communes
+  EPT: 11, // Établissement Public Territorial
+  PETR: 12, // Pôle d'Équilibre Territorial et Rural
+  SIVOM: 13, // Syndicat Intercommunal à Vocation Multiple
 
   // Municipal level
-  COM: 9, // Commune
-  'COM-TOM': 10, // Commune d'Outre-Mer
-  ARR: 11 // Arrondissement
+  COM: 14, // Commune
+  'COM-TOM': 15, // Commune d'Outre-Mer
+  ARR: 16 // Arrondissement
 };
 export const byKindDesc = Order.mapInput(
   Order.number,


### PR DESCRIPTION
## Contexte

Le filtre "intercommunalité" était grisé pour les DDT (et autres structures de niveau départemental et au-dessus) suite à la MEP du nouveau schéma des établissements qui a introduit de nouveaux types (`kind`) non présents dans le modèle front.

Ticket : GEN-1492

## Changements

**`packages/models/src/EstablishmentKind.ts`**
- Ajout des nouveaux kinds : `CTU`, `PETR`, `SDED`, `SDER`, `SIVOM`
- Mise à jour de `ESTABLISHMENT_KIND_ORDER` avec l'ordre hiérarchique correct

**`packages/models/src/EstablishmentDTO.ts`**
- Mise à jour de `isDepartmentalEstablishment` pour inclure les nouvelles structures départementales (`CTU`, `PETR`, `SDED`, `SDER`, `SIVOM`)
- Ces structures voient maintenant le filtre intercommunalité actif (conformément au tableau du ticket)

## Comment tester

1. Se connecter avec un compte DDT (ex : DDT du Gers)
2. Aller sur la liste des logements
3. Vérifier que le filtre "intercommunalité" est actif (non grisé)

## Points d'attention

- `PETR` et `SIVOM` sont classés au niveau intercommunal dans l'ordre hiérarchique mais ont accès au filtre interco (comportement voulu selon le ticket)
- `isIntercommunalityEstablishment` n'a pas été modifié — ces nouveaux kinds ne sont pas des intercommunalités elles-mêmes