### PR TITLE
Fix/multi structure user perimeters

### DIFF
--- a/server/src/controllers/auth-controller.ts
+++ b/server/src/controllers/auth-controller.ts
@@ -114,6 +114,31 @@ async function refreshAuthorizedEstablishments(user: UserApi): Promise<void> {
             establishmentSiren: est.siren,
             hasCommitment: ceremaUser.hasCommitment
           });
+
+          if (ceremaUser.perimeter) {
+            const perimeter = ceremaUser.perimeter;
+            await userPerimeterRepository.upsert({
+              userId: user.id,
+              establishmentId: est.id,
+              geoCodes: perimeter.comm || [],
+              departments: perimeter.dep || [],
+              regions: perimeter.reg || [],
+              epci: perimeter.epci || [],
+              frEntiere: perimeter.fr_entiere || false,
+              updatedAt: new Date().toJSON()
+            });
+
+            logger.info('User perimeter saved from Portail DF', {
+              userId: user.id,
+              email: user.email,
+              establishmentId: est.id,
+              frEntiere: perimeter.fr_entiere,
+              communesCount: perimeter.comm?.length || 0,
+              departmentsCount: perimeter.dep?.length || 0,
+              regionsCount: perimeter.reg?.length || 0,
+              epciCount: perimeter.epci?.length || 0
+            });
+          }
         } else {
           logger.warn(
             'Access rights verification failed for establishment at login',
@@ -208,43 +233,7 @@ async function refreshAuthorizedEstablishments(user: UserApi): Promise<void> {
       });
     }
 
-    // Save user perimeter from Portail DF for filtering
-    // Use the perimeter from the user's current establishment
-    if (user.establishmentId) {
-      const currentEstablishment = knownEstablishments.find(
-        (est) => est.id === user.establishmentId
-      );
-      if (currentEstablishment) {
-        const currentCeremaUser = ceremaUsersWithCommitment.find(
-          (cu) =>
-            cu.establishmentSiren === currentEstablishment.siren ||
-            cu.establishmentSiren === '*'
-        );
-
-        if (currentCeremaUser?.perimeter) {
-          const perimeter = currentCeremaUser.perimeter;
-          await userPerimeterRepository.upsert({
-            userId: user.id,
-            geoCodes: perimeter.comm || [],
-            departments: perimeter.dep || [],
-            regions: perimeter.reg || [],
-            epci: perimeter.epci || [],
-            frEntiere: perimeter.fr_entiere || false,
-            updatedAt: new Date().toJSON()
-          });
-
-          logger.info('User perimeter saved from Portail DF', {
-            userId: user.id,
-            email: user.email,
-            frEntiere: perimeter.fr_entiere,
-            communesCount: perimeter.comm?.length || 0,
-            departmentsCount: perimeter.dep?.length || 0,
-            regionsCount: perimeter.reg?.length || 0,
-            epciCount: perimeter.epci?.length || 0
-          });
-        }
-      }
-    }
+    // User perimeters are saved per establishment while validating rights above.
   } catch (error) {
     // Log error but don't fail login
     logger.error('Failed to refresh authorized establishments at login', {
@@ -400,7 +389,10 @@ async function signInToEstablishment(
   // ADMIN and VISITOR users have no restriction (effectiveGeoCodes = undefined)
   let effectiveGeoCodes: string[] | undefined;
   if (user.role !== UserRole.ADMIN && user.role !== UserRole.VISITOR) {
-    const userPerimeter = await userPerimeterRepository.get(user.id);
+    const userPerimeter = await userPerimeterRepository.get(
+      user.id,
+      establishment.id
+    );
     effectiveGeoCodes = await filterGeoCodesByPerimeter(
       establishment.geoCodes,
       userPerimeter,
@@ -457,13 +449,14 @@ async function changeEstablishment(request: Request, response: Response) {
   }
 
   // Update user's current establishment
-  await userRepository.update({
+  const updatedUser = {
     ...user,
     establishmentId,
     updatedAt: new Date().toJSON()
-  });
+  };
+  await userRepository.update(updatedUser);
 
-  await signInToEstablishment(user, establishmentId, response);
+  await signInToEstablishment(updatedUser, establishmentId, response);
 }
 
 async function get(request: Request, response: Response) {

--- a/server/src/controllers/test/auth-controller.test.ts
+++ b/server/src/controllers/test/auth-controller.test.ts
@@ -61,8 +61,10 @@ import {
   formatResetLinkApi,
   ResetLinks
 } from '~/repositories/resetLinkRepository';
+import { UsersEstablishments } from '~/repositories/user-establishment-repository';
 import { toUserDBO, Users } from '~/repositories/userRepository';
 import userRepository from '~/repositories/userRepository';
+import ceremaService from '~/services/ceremaService';
 import {
   genEstablishmentApi,
   genNumber,
@@ -327,6 +329,78 @@ describe('Account controller', () => {
 
       expect(status).toBe(constants.HTTP_STATUS_OK);
       expect(body).toStrictEqual(toUserAccountDTO(user));
+    });
+  });
+
+  describe('Change establishment', () => {
+    it('should use the target establishment perimeter for multi-structure users', async () => {
+      const sourceEstablishment = genEstablishmentApi();
+      const targetEstablishment = genEstablishmentApi();
+      const multiStructureUser: UserApi = {
+        ...genUserApi(sourceEstablishment.id),
+        role: UserRole.USUAL
+      };
+      await Establishments().insert(
+        [sourceEstablishment, targetEstablishment].map(formatEstablishmentApi)
+      );
+      await Users().insert(toUserDBO(multiStructureUser));
+      await UsersEstablishments().insert([
+        {
+          user_id: multiStructureUser.id,
+          establishment_id: sourceEstablishment.id,
+          establishment_siren: sourceEstablishment.siren,
+          has_commitment: true
+        },
+        {
+          user_id: multiStructureUser.id,
+          establishment_id: targetEstablishment.id,
+          establishment_siren: targetEstablishment.siren,
+          has_commitment: true
+        }
+      ]);
+      const consultUsers = vi
+        .spyOn(ceremaService, 'consultUsers')
+        .mockResolvedValue([
+          {
+            email: multiStructureUser.email,
+            establishmentSiren: sourceEstablishment.siren,
+            hasAccount: true,
+            hasCommitment: true,
+            perimeter: {
+              perimetre_id: 1,
+              origine: 'test',
+              fr_entiere: false,
+              reg: [],
+              dep: [],
+              epci: [sourceEstablishment.siren],
+              comm: []
+            }
+          },
+          {
+            email: multiStructureUser.email,
+            establishmentSiren: targetEstablishment.siren,
+            hasAccount: true,
+            hasCommitment: true,
+            perimeter: {
+              perimetre_id: 2,
+              origine: 'test',
+              fr_entiere: false,
+              reg: [],
+              dep: [],
+              epci: [targetEstablishment.siren],
+              comm: []
+            }
+          }
+        ]);
+
+      const { body, status } = await request(url)
+        .get(`/account/establishments/${targetEstablishment.id}`)
+        .use(tokenProvider(multiStructureUser));
+
+      expect(status).toBe(constants.HTTP_STATUS_OK);
+      expect(body.user.establishmentId).toBe(targetEstablishment.id);
+      expect(body.effectiveGeoCodes).toBeUndefined();
+      consultUsers.mockRestore();
     });
   });
 

--- a/server/src/controllers/test/user-api.test.ts
+++ b/server/src/controllers/test/user-api.test.ts
@@ -51,8 +51,8 @@ import {
   formatProspectApi,
   Prospects
 } from '~/repositories/prospectRepository';
-import { toUserDBO, Users, USERS_TABLE } from '~/repositories/userRepository';
 import { UsersEstablishments } from '~/repositories/user-establishment-repository';
+import { toUserDBO, Users, USERS_TABLE } from '~/repositories/userRepository';
 import ceremaService from '~/services/ceremaService';
 import { TEST_ACCOUNTS } from '~/services/ceremaService/consultUserService';
 import {

--- a/server/src/controllers/test/user-api.test.ts
+++ b/server/src/controllers/test/user-api.test.ts
@@ -52,6 +52,7 @@ import {
   Prospects
 } from '~/repositories/prospectRepository';
 import { toUserDBO, Users, USERS_TABLE } from '~/repositories/userRepository';
+import { UsersEstablishments } from '~/repositories/user-establishment-repository';
 import ceremaService from '~/services/ceremaService';
 import { TEST_ACCOUNTS } from '~/services/ceremaService/consultUserService';
 import {
@@ -122,6 +123,30 @@ describe('User API', () => {
           (user) => user.establishmentId === establishment.id
         );
       });
+
+      it('should return users attached through multi-structure memberships', async () => {
+        const otherEstablishment = genEstablishmentApi();
+        const multiStructureUser = genUserApi(otherEstablishment.id);
+        await Establishments().insert(
+          formatEstablishmentApi(otherEstablishment)
+        );
+        await Users().insert(toUserDBO(multiStructureUser));
+        await UsersEstablishments().insert({
+          user_id: multiStructureUser.id,
+          establishment_id: establishment.id,
+          establishment_siren: establishment.siren,
+          has_commitment: true
+        });
+
+        const { body, status } = await request(url)
+          .get(route)
+          .use(tokenProvider(user));
+
+        expect(status).toBe(constants.HTTP_STATUS_OK);
+        expect(body).toSatisfyAny(
+          (user: UserDTO) => user.id === multiStructureUser.id
+        );
+      });
     });
 
     describe('As an authenticated admin', () => {
@@ -147,6 +172,19 @@ describe('User API', () => {
       });
 
       it('should filter by establishment', async () => {
+        const otherEstablishment = genEstablishmentApi();
+        const multiStructureUser = genUserApi(otherEstablishment.id);
+        await Establishments().insert(
+          formatEstablishmentApi(otherEstablishment)
+        );
+        await Users().insert(toUserDBO(multiStructureUser));
+        await UsersEstablishments().insert({
+          user_id: multiStructureUser.id,
+          establishment_id: establishment.id,
+          establishment_siren: establishment.siren,
+          has_commitment: true
+        });
+
         const { body, status } = await request(url)
           .get(route)
           .query({ establishments: [establishment.id] })
@@ -154,8 +192,8 @@ describe('User API', () => {
 
         expect(status).toBe(constants.HTTP_STATUS_OK);
         expect(body.length).toBeGreaterThan(0);
-        expect(body).toSatisfyAll<UserDTO>(
-          (user) => user.establishmentId === establishment.id
+        expect(body).toSatisfyAny(
+          (user: UserDTO) => user.id === multiStructureUser.id
         );
       });
     });

--- a/server/src/infra/database/migrations/20260623000000_user-perimeters-add-establishment-id.ts
+++ b/server/src/infra/database/migrations/20260623000000_user-perimeters-add-establishment-id.ts
@@ -1,0 +1,46 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('user_perimeters', (table) => {
+    table.uuid('establishment_id').nullable();
+  });
+
+  await knex.raw(`
+    UPDATE user_perimeters
+    SET establishment_id = users.establishment_id
+    FROM users
+    WHERE user_perimeters.user_id = users.id
+  `);
+
+  await knex('user_perimeters').whereNull('establishment_id').delete();
+
+  await knex.schema.alterTable('user_perimeters', (table) => {
+    table.dropPrimary();
+    table.uuid('establishment_id').notNullable().alter();
+    table
+      .foreign('establishment_id')
+      .references('id')
+      .inTable('establishments')
+      .onUpdate('CASCADE')
+      .onDelete('CASCADE');
+    table.primary(['user_id', 'establishment_id']);
+    table.index(['establishment_id']);
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`
+    DELETE FROM user_perimeters kept
+    USING user_perimeters removed
+    WHERE kept.user_id = removed.user_id
+    AND kept.ctid < removed.ctid
+  `);
+
+  await knex.schema.alterTable('user_perimeters', (table) => {
+    table.dropPrimary();
+    table.dropIndex(['establishment_id']);
+    table.dropForeign(['establishment_id']);
+    table.dropColumn('establishment_id');
+    table.primary(['user_id']);
+  });
+}

--- a/server/src/middlewares/auth.ts
+++ b/server/src/middlewares/auth.ts
@@ -64,7 +64,7 @@ export function userCheck(options?: CheckOptions) {
     const [user, establishment, userPerimeter] = await Promise.all([
       getUser(request.auth.userId),
       getEstablishment(request.auth.establishmentId),
-      getUserPerimeter(request.auth.userId)
+      getUserPerimeter(request.auth.userId, request.auth.establishmentId)
     ]);
     if (!user) {
       // Should never happen

--- a/server/src/models/UserPerimeterApi.ts
+++ b/server/src/models/UserPerimeterApi.ts
@@ -21,6 +21,7 @@ export interface PerimeterShape {
  */
 export interface UserPerimeterApi extends PerimeterShape {
   userId: string;
+  establishmentId: string;
   updatedAt: string;
 }
 

--- a/server/src/repositories/test/userPerimeterRepository.test.ts
+++ b/server/src/repositories/test/userPerimeterRepository.test.ts
@@ -1,0 +1,55 @@
+import {
+  Establishments,
+  formatEstablishmentApi
+} from '~/repositories/establishmentRepository';
+import userPerimeterRepository from '~/repositories/userPerimeterRepository';
+import { toUserDBO, Users } from '~/repositories/userRepository';
+import {
+  genEstablishmentApi,
+  genUserApi
+} from '~/test/testFixtures';
+
+describe('User perimeter repository', () => {
+  it('stores one perimeter per user and establishment', async () => {
+    const establishment = genEstablishmentApi();
+    const anotherEstablishment = genEstablishmentApi();
+    const user = genUserApi(establishment.id);
+    await Establishments().insert(
+      [establishment, anotherEstablishment].map(formatEstablishmentApi)
+    );
+    await Users().insert(toUserDBO(user));
+
+    await userPerimeterRepository.upsert({
+      userId: user.id,
+      establishmentId: establishment.id,
+      geoCodes: [],
+      departments: [],
+      regions: [],
+      epci: [establishment.siren],
+      frEntiere: false,
+      updatedAt: new Date().toJSON()
+    });
+    await userPerimeterRepository.upsert({
+      userId: user.id,
+      establishmentId: anotherEstablishment.id,
+      geoCodes: [],
+      departments: [],
+      regions: [],
+      epci: [anotherEstablishment.siren],
+      frEntiere: false,
+      updatedAt: new Date().toJSON()
+    });
+
+    const perimeter = await userPerimeterRepository.get(
+      user.id,
+      establishment.id
+    );
+    const anotherPerimeter = await userPerimeterRepository.get(
+      user.id,
+      anotherEstablishment.id
+    );
+
+    expect(perimeter?.epci).toStrictEqual([establishment.siren]);
+    expect(anotherPerimeter?.epci).toStrictEqual([anotherEstablishment.siren]);
+  });
+});

--- a/server/src/repositories/test/userPerimeterRepository.test.ts
+++ b/server/src/repositories/test/userPerimeterRepository.test.ts
@@ -4,10 +4,7 @@ import {
 } from '~/repositories/establishmentRepository';
 import userPerimeterRepository from '~/repositories/userPerimeterRepository';
 import { toUserDBO, Users } from '~/repositories/userRepository';
-import {
-  genEstablishmentApi,
-  genUserApi
-} from '~/test/testFixtures';
+import { genEstablishmentApi, genUserApi } from '~/test/testFixtures';
 
 describe('User perimeter repository', () => {
   it('stores one perimeter per user and establishment', async () => {

--- a/server/src/repositories/userPerimeterRepository.ts
+++ b/server/src/repositories/userPerimeterRepository.ts
@@ -7,38 +7,55 @@ export const UserPerimeters = (transaction = db) =>
   transaction<UserPerimeterDBO>(userPerimeterTable);
 
 async function upsert(perimeter: UserPerimeterApi): Promise<void> {
-  logger.debug('Upsert user perimeter', { userId: perimeter.userId });
+  logger.debug('Upsert user perimeter', {
+    userId: perimeter.userId,
+    establishmentId: perimeter.establishmentId
+  });
 
   const dbo = toUserPerimeterDBO(perimeter);
 
-  await UserPerimeters().insert(dbo).onConflict('user_id').merge({
-    geo_codes: dbo.geo_codes,
-    departments: dbo.departments,
-    regions: dbo.regions,
-    epci: dbo.epci,
-    fr_entiere: dbo.fr_entiere,
-    updated_at: dbo.updated_at
-  });
+  await UserPerimeters()
+    .insert(dbo)
+    .onConflict(['user_id', 'establishment_id'])
+    .merge({
+      geo_codes: dbo.geo_codes,
+      departments: dbo.departments,
+      regions: dbo.regions,
+      epci: dbo.epci,
+      fr_entiere: dbo.fr_entiere,
+      updated_at: dbo.updated_at
+    });
 }
 
-async function get(userId: string): Promise<UserPerimeterApi | null> {
-  logger.debug('Get user perimeter', { userId });
+async function get(
+  userId: string,
+  establishmentId: string
+): Promise<UserPerimeterApi | null> {
+  logger.debug('Get user perimeter', { userId, establishmentId });
 
   const perimeter = await UserPerimeters()
     .select()
-    .where('user_id', userId)
+    .where({ user_id: userId, establishment_id: establishmentId })
     .first();
 
   return perimeter ? fromUserPerimeterDBO(perimeter) : null;
 }
 
-async function remove(userId: string): Promise<void> {
-  logger.debug('Remove user perimeter', { userId });
-  await UserPerimeters().where('user_id', userId).delete();
+async function remove(userId: string, establishmentId?: string): Promise<void> {
+  logger.debug('Remove user perimeter', { userId, establishmentId });
+  await UserPerimeters()
+    .where('user_id', userId)
+    .modify((query) => {
+      if (establishmentId) {
+        query.where('establishment_id', establishmentId);
+      }
+    })
+    .delete();
 }
 
 export interface UserPerimeterDBO {
   user_id: string;
+  establishment_id: string;
   geo_codes: string[];
   departments: string[];
   regions: string[];
@@ -51,6 +68,7 @@ export const fromUserPerimeterDBO = (
   dbo: UserPerimeterDBO
 ): UserPerimeterApi => ({
   userId: dbo.user_id,
+  establishmentId: dbo.establishment_id,
   geoCodes: dbo.geo_codes || [],
   departments: dbo.departments || [],
   regions: dbo.regions || [],
@@ -63,6 +81,7 @@ export const toUserPerimeterDBO = (
   api: UserPerimeterApi
 ): UserPerimeterDBO => ({
   user_id: api.userId,
+  establishment_id: api.establishmentId,
   geo_codes: api.geoCodes,
   departments: api.departments,
   regions: api.regions,

--- a/server/src/repositories/userRepository.ts
+++ b/server/src/repositories/userRepository.ts
@@ -5,6 +5,7 @@ import db, { notDeleted } from '~/infra/database';
 import { logger } from '~/infra/logger';
 import { PaginationApi, paginationQuery } from '~/models/PaginationApi';
 import { UserApi } from '~/models/UserApi';
+import { USERS_ESTABLISHMENTS_TABLE } from './user-establishment-repository';
 
 export const USERS_TABLE = 'users';
 
@@ -64,10 +65,22 @@ interface FindOptions {
 
 async function find(opts?: FindOptions): Promise<UserApi[]> {
   const users: UserDBO[] = await db<UserDBO>(USERS_TABLE)
+    .select(`${USERS_TABLE}.*`)
     .where(notDeleted)
     .modify((builder) => {
       if (opts?.filters?.establishments?.length) {
-        builder.whereIn('establishment_id', opts.filters.establishments);
+        builder
+          .join(
+            USERS_ESTABLISHMENTS_TABLE,
+            `${USERS_ESTABLISHMENTS_TABLE}.user_id`,
+            `${USERS_TABLE}.id`
+          )
+          .whereIn(
+            `${USERS_ESTABLISHMENTS_TABLE}.establishment_id`,
+            opts.filters.establishments
+          )
+          .where(`${USERS_ESTABLISHMENTS_TABLE}.has_commitment`, true)
+          .distinct(`${USERS_TABLE}.id`);
       }
     })
     // TODO: flexible sort
@@ -84,7 +97,17 @@ interface CountOptions {
 function filter(filters?: UserFilters) {
   return (builder: Knex.QueryBuilder<UserDBO>) => {
     if (filters?.establishments?.length) {
-      builder.whereIn('establishment_id', filters.establishments);
+      builder
+        .join(
+          USERS_ESTABLISHMENTS_TABLE,
+          `${USERS_ESTABLISHMENTS_TABLE}.user_id`,
+          `${USERS_TABLE}.id`
+        )
+        .whereIn(
+          `${USERS_ESTABLISHMENTS_TABLE}.establishment_id`,
+          filters.establishments
+        )
+        .where(`${USERS_ESTABLISHMENTS_TABLE}.has_commitment`, true);
     }
   };
 }
@@ -93,7 +116,7 @@ async function count(opts?: CountOptions): Promise<number> {
   const result = await db<UserDBO>(USERS_TABLE)
     .where(notDeleted)
     .modify(filter(opts?.filters))
-    .count('id')
+    .countDistinct(`${USERS_TABLE}.id`)
     .first();
 
   return Number(result?.count);

--- a/server/src/repositories/userRepository.ts
+++ b/server/src/repositories/userRepository.ts
@@ -5,6 +5,7 @@ import db, { notDeleted } from '~/infra/database';
 import { logger } from '~/infra/logger';
 import { PaginationApi, paginationQuery } from '~/models/PaginationApi';
 import { UserApi } from '~/models/UserApi';
+
 import { USERS_ESTABLISHMENTS_TABLE } from './user-establishment-repository';
 
 export const USERS_TABLE = 'users';

--- a/server/src/repositories/userRepository.ts
+++ b/server/src/repositories/userRepository.ts
@@ -70,20 +70,10 @@ async function find(opts?: FindOptions): Promise<UserApi[]> {
     .where(notDeleted)
     .modify((builder) => {
       if (opts?.filters?.establishments?.length) {
-        builder
-          .join(
-            USERS_ESTABLISHMENTS_TABLE,
-            `${USERS_ESTABLISHMENTS_TABLE}.user_id`,
-            `${USERS_TABLE}.id`
-          )
-          .whereIn(
-            `${USERS_ESTABLISHMENTS_TABLE}.establishment_id`,
-            opts.filters.establishments
-          )
-          .where(`${USERS_ESTABLISHMENTS_TABLE}.has_commitment`, true)
-          .distinct(`${USERS_TABLE}.id`);
+        builder.distinct(`${USERS_TABLE}.id`);
       }
     })
+    .modify(filter(opts?.filters))
     // TODO: flexible sort
     .orderBy(['last_name', 'first_name'])
     .modify(paginationQuery(opts?.pagination));
@@ -97,18 +87,20 @@ interface CountOptions {
 
 function filter(filters?: UserFilters) {
   return (builder: Knex.QueryBuilder<UserDBO>) => {
-    if (filters?.establishments?.length) {
-      builder
-        .join(
-          USERS_ESTABLISHMENTS_TABLE,
+    const establishmentIds = filters?.establishments;
+    if (establishmentIds?.length) {
+      builder.join(USERS_ESTABLISHMENTS_TABLE, function () {
+        this.on(
           `${USERS_ESTABLISHMENTS_TABLE}.user_id`,
+          '=',
           `${USERS_TABLE}.id`
         )
-        .whereIn(
-          `${USERS_ESTABLISHMENTS_TABLE}.establishment_id`,
-          filters.establishments
-        )
-        .where(`${USERS_ESTABLISHMENTS_TABLE}.has_commitment`, true);
+          .onIn(
+            `${USERS_ESTABLISHMENTS_TABLE}.establishment_id`,
+            establishmentIds
+          )
+          .andOnVal(`${USERS_ESTABLISHMENTS_TABLE}.has_commitment`, true);
+      });
     }
   };
 }


### PR DESCRIPTION
Ce correctif adresse deux problèmes liés aux utilisateurs multi-structures.

Jusqu’ici, ZLV savait rattacher un utilisateur à plusieurs structures via `users_establishments`, mais certaines lectures restaient basées sur `users.establishment_id`, qui ne représente que la structure courante.

## Ce qui change

- La liste des utilisateurs rattachés à une structure filtre maintenant via `users_establishments`.
- Les périmètres utilisateur sont désormais stockés par couple `(user_id, establishment_id)`.
- Au login / switch de structure, ZLV sauvegarde et relit le périmètre correspondant à la structure active.
- La réponse du switch retourne le `user.establishmentId` mis à jour.

## Pourquoi

Cerema retourne un même utilisateur avec plusieurs structures, groupes et périmètres distincts. Avant, ZLV ne stockait qu’un seul périmètre par utilisateur, ce qui pouvait appliquer le périmètre d’une structure à une autre et produire une liste de logements vide.

## Validation

- `yarn nx typecheck server`
- Tests ciblés sur la liste utilisateurs multi-structures
- Tests ciblés sur le switch avec périmètre par établissement