### PR TITLE
feat(map): add fullscreen control to the housing map

### DIFF
--- a/frontend/src/components/Map/FullscreenControl.tsx
+++ b/frontend/src/components/Map/FullscreenControl.tsx
@@ -1,0 +1,121 @@
+import { fr } from '@codegouvfr/react-dsfr';
+import Button from '@codegouvfr/react-dsfr/Button';
+import { styled } from '@mui/material/styles';
+import type { IControl, Map as MaplibreMap } from 'maplibre-gl';
+import { createRoot, type Root } from 'react-dom/client';
+import { useControl } from 'react-map-gl/maplibre';
+
+const hex = fr.colors.getHex({ isDark: false });
+
+// DSFR secondary buttons are transparent by default; force a white background
+// so the control stays readable above the map tiles.
+const StyledButton = styled(Button)({
+  backgroundColor: hex.decisions.background.default.grey.default
+});
+
+export interface FullscreenMapButtonProps {
+  isFullscreen: boolean;
+  onToggle(): void;
+}
+
+export function FullscreenMapButton({
+  isFullscreen,
+  onToggle
+}: Readonly<FullscreenMapButtonProps>) {
+  const label = isFullscreen
+    ? 'Quitter le plein écran'
+    : 'Afficher la carte en plein écran';
+
+  return (
+    <StyledButton
+      priority="secondary"
+      size="small"
+      iconId={
+        isFullscreen
+          ? 'ri-collapse-diagonal-2-line'
+          : 'ri-expand-diagonal-2-line'
+      }
+      // `title` drives the mouse tooltip; `aria-label` duplicates it so the
+      // accessible name is reliably exposed to touch/mobile screen readers,
+      // where `title` alone is unreliable (RGAA 7.1/7.3).
+      title={label}
+      onClick={onToggle}
+      nativeButtonProps={{ 'aria-label': label }}
+    />
+  );
+}
+
+/**
+ * A MapLibre control that toggles the map container into fullscreen using the
+ * native Fullscreen API, so the user can keep panning and zooming while the map
+ * fills the whole screen.
+ */
+class Fullscreen implements IControl {
+  private container: HTMLElement | null = null;
+  private root: Root | null = null;
+  private map: MaplibreMap | null = null;
+  private isFullscreen = false;
+
+  onAdd(map: MaplibreMap): HTMLElement {
+    this.map = map;
+    this.container = document.createElement('div');
+    this.container.className = 'maplibregl-ctrl';
+    this.root = createRoot(this.container);
+    document.addEventListener('fullscreenchange', this.handleFullscreenChange);
+    this.render();
+    return this.container;
+  }
+
+  onRemove(): void {
+    document.removeEventListener(
+      'fullscreenchange',
+      this.handleFullscreenChange
+    );
+    const root = this.root;
+    setTimeout(() => root?.unmount(), 0);
+    this.container?.remove();
+    this.container = null;
+    this.root = null;
+    this.map = null;
+  }
+
+  private readonly handleFullscreenChange = (): void => {
+    const target = this.map?.getContainer();
+    this.isFullscreen = !!target && document.fullscreenElement === target;
+    // The container changed size: let MapLibre recompute its dimensions.
+    this.map?.resize();
+    this.render();
+  };
+
+  private readonly toggle = (): void => {
+    const target = this.map?.getContainer();
+    if (!target) {
+      return;
+    }
+
+    if (document.fullscreenElement) {
+      void document.exitFullscreen();
+    } else {
+      void target.requestFullscreen();
+    }
+  };
+
+  private render(): void {
+    this.root?.render(
+      <FullscreenMapButton
+        isFullscreen={this.isFullscreen}
+        onToggle={this.toggle}
+      />
+    );
+  }
+}
+
+function FullscreenControl() {
+  const control = new Fullscreen();
+  useControl(() => control, {
+    position: 'bottom-right'
+  });
+  return null;
+}
+
+export default FullscreenControl;

--- a/frontend/src/components/Map/Map.tsx
+++ b/frontend/src/components/Map/Map.tsx
@@ -26,6 +26,7 @@ import {
 import BuildingAside from './BuildingAside';
 import BuildingStatusImages from './BuildingStatusImages';
 import Clusters from './Clusters';
+import FullscreenControl from './FullscreenControl';
 import LayerControl from './LayerControl';
 import LegendButtonControl from './LegendButtonControl';
 import MapControls from './MapControls';
@@ -224,6 +225,7 @@ function Map(props: MapProps) {
             showZoom
             visualizePitch={false}
           />
+          <FullscreenControl />
         </ReactiveMap>
       </MapWrapper>
 

--- a/frontend/src/components/Map/test/FullscreenControl.test.tsx
+++ b/frontend/src/components/Map/test/FullscreenControl.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { FullscreenMapButton } from '../FullscreenControl';
+
+describe('FullscreenMapButton', () => {
+  const user = userEvent.setup();
+
+  it('should display the expand icon when not in fullscreen', () => {
+    render(<FullscreenMapButton isFullscreen={false} onToggle={vi.fn()} />);
+
+    const button = screen.getByRole('button', {
+      name: 'Afficher la carte en plein écran'
+    });
+
+    expect(button).toHaveClass('ri-expand-diagonal-2-line');
+    expect(button).toHaveAttribute(
+      'aria-label',
+      'Afficher la carte en plein écran'
+    );
+  });
+
+  it('should display the collapse icon when in fullscreen', () => {
+    render(<FullscreenMapButton isFullscreen onToggle={vi.fn()} />);
+
+    const button = screen.getByRole('button', {
+      name: 'Quitter le plein écran'
+    });
+
+    expect(button).toHaveClass('ri-collapse-diagonal-2-line');
+    expect(button).toHaveAttribute('aria-label', 'Quitter le plein écran');
+  });
+
+  it('should call onToggle when clicked', async () => {
+    const onToggle = vi.fn();
+    render(<FullscreenMapButton isFullscreen={false} onToggle={onToggle} />);
+
+    await user.click(
+      screen.getByRole('button', { name: 'Afficher la carte en plein écran' })
+    );
+
+    expect(onToggle).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## What

Adds a **fullscreen button** to the map. Because it lives in the shared `Map` component (`frontend/src/components/Map/Map.tsx`), it shows up on **both** maps that use it:

- the housing list map — *parc de logements* (`HousingListMap.tsx`)
- the housing detail map — *fiche logement*, section « Localisation » (`HousingTab.tsx`)

Clicking it puts the map into native fullscreen and keeps it fully interactive (pan / zoom); clicking again (or pressing `Échap`) exits.

## Design

Matches the requested spec:
- Position: **bottom-right**
- DSFR `Button` `priority="secondary"`, `size="small"`, forced **white background** (`fr.colors.getHex().decisions.background.default.grey.default`)
- Icon: remixicon **`ri-expand-diagonal-2-line`** (DSFR-recommended), swapping to **`ri-collapse-diagonal-2-line`** while fullscreen

## How

New `FullscreenControl.tsx`:
- `FullscreenMapButton` — presentational, testable DSFR button (icon + label depend on `isFullscreen`)
- `Fullscreen implements IControl` — uses the native **Fullscreen API** on `map.getContainer()`, registered at `bottom-right` via `useControl`, and calls `map.resize()` on `fullscreenchange` so MapLibre recomputes its size

## Accessibility (RGAA)

Icon-only button, so the accessible name matters:
- DSFR `IconOnly` variant requires a `title` (enforced at type level)
- mirrored with a dynamic **`aria-label`** for reliable exposure to touch/mobile screen readers (RGAA 7.1 / 7.3)
- the label changes with state (« Afficher la carte en plein écran » ⇄ « Quitter le plein écran »), so state is announced without redundant `aria-pressed`

## Tests

- 3 unit tests for `FullscreenMapButton` (expand icon + label, collapse icon + label, `onToggle` on click, plus `aria-label` assertions) — all green
- Frontend typecheck clean
- Verified end-to-end on a local env (button renders on both maps over seeded data)

## Files
- `frontend/src/components/Map/FullscreenControl.tsx` (new)
- `frontend/src/components/Map/test/FullscreenControl.test.tsx` (new)
- `frontend/src/components/Map/Map.tsx` (render `<FullscreenControl />`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)