### PR TITLE
Fix/sync cerema suspension causes

### DIFF
--- a/clevercloud/README.md
+++ b/clevercloud/README.md
@@ -2,7 +2,7 @@
 
 ## Configuration Files
 
-- **`cron.json`**: Periodic task scheduling (Cerema sync every 30 minutes)
+- **`cron.json`**: Periodic task scheduling
 - **`post_build.sh`**: Automatic Python dependencies installation after Node.js build
 - **`README.md`**: This file
 
@@ -14,9 +14,33 @@ This project uses Clever Cloud's cron system to schedule periodic tasks.
 
 The `cron.json` file defines scheduled tasks:
 
+- **Monthly logs export**: On the first day of each month at 03:00
+  - Command: `$ROOT/server/src/scripts/logs/export-monthly-logs.sh`
+  - Frequency: `0 3 1 * *`
+
+There is no active Clever Cloud cron for Cerema rights synchronization anymore.
+The former `cerema-sync.sh` cron was removed when Cerema rights checks moved to
+the application login flow. Users and establishments are refreshed from Portail
+DF when a user logs in or creates an account.
+
+The Python scripts under `server/src/scripts/perimeters-portaildf/` are kept for
+manual audits, exports, and troubleshooting. They are not scheduled by
+`clevercloud/cron.json`.
+
+### Deprecated Cerema Cron
+
+The former Cerema DF Portal synchronization cron is documented here for
+historical context only:
+
 - **Cerema DF Portal Synchronization**: Every 30 minutes
   - Command: `/app/server/src/scripts/perimeters-portaildf/cerema-sync.sh`
-  - Frequency: `*/30 * * * *` (every 30 minutes)
+  - Frequency: `*/30 * * * *`
+  - Status: removed from `clevercloud/cron.json`
+  - Replacement: Portail DF rights checks during login/account creation
+
+Do not re-enable this cron unless the product explicitly needs background rights
+synchronization again. In that case, the cron and scripts should be reviewed
+against the current login-based synchronization logic first.
 
 ### Prerequisites
 
@@ -79,10 +103,15 @@ The standard cron format is used:
 
 ### Logs
 
-Synchronization logs are stored in:
-`/app/server/src/scripts/perimeters-portaildf/logs/sync-YYYYMMDD-HHMMSS.log`
+Cron execution logs are available from Clever Cloud:
 
-Logs older than 30 days are automatically deleted.
+```bash
+clever logs --addon-app cron
+```
+
+The current scheduled cron writes the monthly application log export. Cerema
+rights synchronization logs are part of the application logs because the sync is
+performed during authentication.
 
 ### Verification
 
@@ -106,15 +135,15 @@ git push clever master
 
 ### Debug
 
-If the cron doesn't work:
+If a cron doesn't work:
 
 1. Check Clever Cloud logs in the dashboard
 2. Verify that all environment variables are configured
-3. Check that the script is executable (`chmod +x`)
-4. Test the script manually via SSH:
+3. Check that the scheduled script is executable (`chmod +x`)
+4. Test the scheduled script manually via SSH:
    ```bash
    clever ssh
-   /app/server/src/scripts/perimeters-portaildf/cerema-sync.sh
+   /app/server/src/scripts/logs/export-monthly-logs.sh
    ```
 
 ### Python Dependencies

--- a/clevercloud/SETUP_CHECKLIST.md
+++ b/clevercloud/SETUP_CHECKLIST.md
@@ -30,16 +30,27 @@ POSTGRESQL_ADDON_PASSWORD=your_password
 
 ### 2. Verify Configuration Files
 
-- [x] `clevercloud/cron.json` - Cron configured every 30 minutes
+- [x] `clevercloud/cron.json` - Monthly logs export cron configured
 - [x] `clevercloud/post_build.sh` - Python dependencies installation script
 - [x] `server/src/scripts/perimeters-portaildf/requirements.txt` - Python dependencies
-- [x] `server/src/scripts/perimeters-portaildf/cerema-sync.sh` - Synchronization script
+
+There is no active Clever Cloud cron for Cerema rights synchronization. Cerema
+rights checks are performed by the application during login/account creation.
+The scripts in `server/src/scripts/perimeters-portaildf/` are available for
+manual audits and troubleshooting only.
+
+Legacy reference:
+
+- `server/src/scripts/perimeters-portaildf/cerema-sync.sh`
+- Former frequency: `*/30 * * * *`
+- Current status: not scheduled by `clevercloud/cron.json`
+- Replacement: login/account creation Cerema rights synchronization
 
 ### 3. Deploy the Application
 
 ```bash
 git add .
-git commit -m "feat: configure Cerema sync cron job with Python dependencies"
+git commit -m "chore: update Clever Cloud cron configuration"
 git push clever master
 ```
 
@@ -66,14 +77,14 @@ python3 --version
 # Check dependencies
 pip3 list | grep -E "requests|click|psycopg2|dateutil"
 
-# Test the script
-cd /app/server/src/scripts/perimeters-portaildf
-./cerema-sync.sh
+# Test the scheduled cron script
+/app/server/src/scripts/logs/export-monthly-logs.sh
 ```
 
 #### 4.3 Verify Cron
 
-Clever Cloud dashboard → "Cron" tab → Verify that the task appears and executes
+Clever Cloud dashboard → "Cron" tab → Verify that the monthly logs export task
+appears and executes.
 
 ### 5. Monitoring
 
@@ -89,12 +100,14 @@ clever logs --addon-app cron
 clever logs
 ```
 
-#### Synchronization Logs on Server
+#### Cerema Synchronization Logs
 
 ```bash
-clever ssh
-tail -f /app/server/src/scripts/perimeters-portaildf/logs/sync-*.log
+clever logs
 ```
+
+Cerema rights synchronization is executed during authentication, so its logs are
+application logs, not cron logs.
 
 ## 🔧 Quick Troubleshooting
 
@@ -102,7 +115,7 @@ tail -f /app/server/src/scripts/perimeters-portaildf/logs/sync-*.log
 
 1. Verify that `cron.json` is committed
 2. Check environment variables
-3. Check permissions: `chmod +x cerema-sync.sh`
+3. Check permissions: `chmod +x server/src/scripts/logs/export-monthly-logs.sh`
 4. Redeploy the application
 
 ### Python Not Found
@@ -157,8 +170,6 @@ tail -f /app/server/src/scripts/perimeters-portaildf/logs/sync-*.log
 
 Once configured, the system will:
 
-- ✅ Automatically authenticate with Cerema API
-- ✅ Retrieve data every 30 minutes
-- ✅ Update structures and users
-- ✅ Generate logs for each synchronization
-- ✅ Clean up logs older than 30 days
+- ✅ Run the monthly application logs export
+- ✅ Keep Python dependencies available for manual Cerema audit scripts
+- ✅ Refresh Cerema rights from the application during login/account creation

--- a/server/src/controllers/auth-controller.ts
+++ b/server/src/controllers/auth-controller.ts
@@ -63,7 +63,10 @@ async function changeEstablishmentBySession(
   const establishmentId = request.params.establishmentId;
 
   if (user.role !== UserRole.ADMIN && user.role !== UserRole.VISITOR) {
-    await refreshAuthorizedEstablishments(user, { authoritative: true });
+    await refreshAuthorizedEstablishments(user, {
+      authoritative: true,
+      establishmentId
+    });
     const authorised =
       await userEstablishmentRepository.getAuthorizedEstablishments(user.id);
     const authorisedIds = authorised

--- a/server/src/infra/auth.ts
+++ b/server/src/infra/auth.ts
@@ -114,16 +114,22 @@ const authOptions = {
             });
           }
 
-          await refreshAuthorizedEstablishments(user);
-
+          const sessionEstablishmentId =
+            typeof session.activeEstablishmentId === 'string'
+              ? session.activeEstablishmentId
+              : null;
           const activeEstablishmentId =
-            session.activeEstablishmentId ?? user.establishmentId;
+            sessionEstablishmentId ?? user.establishmentId;
 
           if (!activeEstablishmentId) {
             throw new APIError('UNPROCESSABLE_ENTITY', {
               message: 'User has no active establishment'
             });
           }
+
+          await refreshAuthorizedEstablishments(user, {
+            establishmentId: activeEstablishmentId
+          });
 
           return {
             data: {

--- a/server/src/services/ceremaService/ceremaService.test.ts
+++ b/server/src/services/ceremaService/ceremaService.test.ts
@@ -6,7 +6,8 @@ import config from '~/infra/config';
 import { CeremaService } from './ceremaService';
 import type { CeremaGroup, CeremaPerimeter } from './consultUserService';
 
-const BASE_URL = config.cerema.api;
+const BASE_URL =
+  config.cerema.authVersion === 'v2' ? config.cerema.apiV2 : config.cerema.api;
 const TOKEN = 'test-token';
 
 const lovacGroup: CeremaGroup = {
@@ -36,7 +37,23 @@ const pastDate = new Date(Date.now() - 86_400_000).toISOString();
 const structure = { siret: '12345678900001', acces_lovac: futureDate };
 
 function interceptAuth() {
+  if (config.cerema.authVersion === 'v2') {
+    nock(BASE_URL)
+      .post('/api/token/')
+      .reply(200, { access: TOKEN, refresh: 'refresh-token' });
+    return;
+  }
+
   nock(BASE_URL).post('/api/api-token-auth/').reply(200, { token: TOKEN });
+}
+
+function interceptAuthFailure() {
+  if (config.cerema.authVersion === 'v2') {
+    nock(BASE_URL).post('/api/token/').reply(401, 'Unauthorized');
+    return;
+  }
+
+  nock(BASE_URL).post('/api/api-token-auth/').reply(401, 'Unauthorized');
 }
 
 function interceptUsers(email: string, users: object[]) {
@@ -71,7 +88,7 @@ afterEach(() => {
 describe('CeremaService', () => {
   describe('consultUsers', () => {
     it('returns [] when auth fails', async () => {
-      nock(BASE_URL).post('/api/api-token-auth/').reply(401, 'Unauthorized');
+      interceptAuthFailure();
       const service = new CeremaService();
 
       const result = await service.consultUsers('user@test.fr');
@@ -128,7 +145,13 @@ describe('CeremaService', () => {
     it('returns user with hasCommitment true when structure has valid LOVAC and group has LOVAC access', async () => {
       interceptAuth();
       interceptUsers('user@test.fr', [
-        { email: 'user@test.fr', structure: 10, groupe: 1 }
+        {
+          email: 'user@test.fr',
+          structure: 10,
+          groupe: 1,
+          cgu_valide: '2026-03-11T12:36:01.255000+01:00',
+          date_expiration: null
+        }
       ]);
       interceptStructure(10, structure);
       interceptGroup(1, lovacGroup);
@@ -142,6 +165,11 @@ describe('CeremaService', () => {
         email: 'user@test.fr',
         establishmentSiren: '123456789',
         hasCommitment: true,
+        cguValide: '2026-03-11T12:36:01.255000+01:00',
+        userExpiresAt: null,
+        structureAccessExpiresAt: futureDate,
+        structureHasLovac: true,
+        groupHasLovac: true,
         group: lovacGroup,
         perimeter: frEntierePerimeter
       });

--- a/server/src/services/ceremaService/ceremaService.test.ts
+++ b/server/src/services/ceremaService/ceremaService.test.ts
@@ -210,6 +210,25 @@ describe('CeremaService', () => {
       expect(result[0].hasCommitment).toBe(false);
     });
 
+    it('keeps group LOVAC access unknown when group fetch fails', async () => {
+      interceptAuth();
+      interceptUsers('user@test.fr', [
+        { email: 'user@test.fr', structure: 10, groupe: 1 }
+      ]);
+      interceptStructure(10, structure);
+      nock(BASE_URL).get('/api/groupes/1/').reply(503, 'Unavailable');
+      const service = new CeremaService();
+
+      const result = await service.consultUsers('user@test.fr');
+
+      expect(result[0]).toMatchObject({
+        hasCommitment: false,
+        group: undefined,
+        groupHasLovac: undefined,
+        groupFetchFailed: true
+      });
+    });
+
     it('returns user with group but no perimeter when group has no perimetre', async () => {
       const groupWithoutPerimeter: CeremaGroup = {
         ...lovacGroup,

--- a/server/src/services/ceremaService/ceremaService.ts
+++ b/server/src/services/ceremaService/ceremaService.ts
@@ -73,7 +73,13 @@ export class CeremaService implements ConsultUserService {
       const auth = await this.authProvider.authenticate();
 
       const { data: userContent } = await axios.get<{
-        results: Array<{ email: string; structure: number; groupe: number }>;
+        results: Array<{
+          email: string;
+          structure: number;
+          groupe: number;
+          cgu_valide?: string | null;
+          date_expiration?: string | null;
+        }>;
       }>(`${auth.apiUrl}/api/utilisateurs`, {
         params: { email },
         headers: authHeaders(auth)
@@ -81,65 +87,68 @@ export class CeremaService implements ConsultUserService {
 
       if (userContent) {
         const users = await Promise.all(
-          userContent.results.map(
-            async (user: { email: any; structure: number; groupe: number }) => {
-              const { data: establishmentContent } = await axios.get<any>(
-                `${auth.apiUrl}/api/structures/${user.structure}`,
-                { headers: authHeaders(auth) }
-              );
+          userContent.results.map(async (user) => {
+            const { data: establishmentContent } = await axios.get<any>(
+              `${auth.apiUrl}/api/structures/${user.structure}`,
+              { headers: authHeaders(auth) }
+            );
 
-              // Fetch group info if available
-              let group: CeremaGroup | undefined;
-              let perimeter: CeremaPerimeter | undefined;
+            // Fetch group info if available
+            let group: CeremaGroup | undefined;
+            let perimeter: CeremaPerimeter | undefined;
 
-              if (user.groupe) {
-                group =
-                  (await fetchPortailDF<CeremaGroup>(
+            if (user.groupe) {
+              group =
+                (await fetchPortailDF<CeremaGroup>(
+                  auth,
+                  `/api/groupes/${user.groupe}/`
+                )) ?? undefined;
+
+              // Fetch perimeter if group has one
+              if (group?.perimetre) {
+                perimeter =
+                  (await fetchPortailDF<CeremaPerimeter>(
                     auth,
-                    `/api/groupes/${user.groupe}/`
+                    `/api/perimetres/${group.perimetre}/`
                   )) ?? undefined;
-
-                // Fetch perimeter if group has one
-                if (group?.perimetre) {
-                  perimeter =
-                    (await fetchPortailDF<CeremaPerimeter>(
-                      auth,
-                      `/api/perimetres/${group.perimetre}/`
-                    )) ?? undefined;
-                }
               }
-
-              // hasCommitment is true only if:
-              // 1. Structure has a valid LOVAC access date (future date)
-              // 2. AND user's group has LOVAC access (niveau_acces === 'lovac' OR lovac === true)
-              const structureHasLovac = isLovacAccessValid(
-                establishmentContent.acces_lovac
-              );
-              const groupHasLovac = hasGroupLovacAccess(group);
-
-              logger.debug('LOVAC access check', {
-                email: user.email,
-                structureId: user.structure,
-                accesLovac: establishmentContent.acces_lovac,
-                structureHasLovac,
-                groupId: user.groupe,
-                groupNiveauAcces: group?.niveau_acces,
-                groupLovac: group?.lovac,
-                groupHasLovac,
-                hasCommitment: structureHasLovac && groupHasLovac
-              });
-
-              const u: CeremaUser = {
-                email: user.email,
-                establishmentSiren: establishmentContent.siret.substring(0, 9),
-                hasAccount: true,
-                hasCommitment: structureHasLovac && groupHasLovac,
-                group,
-                perimeter
-              };
-              return u;
             }
-          )
+
+            // hasCommitment is true only if:
+            // 1. Structure has a valid LOVAC access date (future date)
+            // 2. AND user's group has LOVAC access (niveau_acces === 'lovac' OR lovac === true)
+            const structureHasLovac = isLovacAccessValid(
+              establishmentContent.acces_lovac
+            );
+            const groupHasLovac = hasGroupLovacAccess(group);
+
+            logger.debug('LOVAC access check', {
+              email: user.email,
+              structureId: user.structure,
+              accesLovac: establishmentContent.acces_lovac,
+              structureHasLovac,
+              groupId: user.groupe,
+              groupNiveauAcces: group?.niveau_acces,
+              groupLovac: group?.lovac,
+              groupHasLovac,
+              hasCommitment: structureHasLovac && groupHasLovac
+            });
+
+            const u: CeremaUser = {
+              email: user.email,
+              establishmentSiren: establishmentContent.siret.substring(0, 9),
+              hasAccount: true,
+              hasCommitment: structureHasLovac && groupHasLovac,
+              cguValide: user.cgu_valide,
+              userExpiresAt: user.date_expiration,
+              structureAccessExpiresAt: establishmentContent.acces_lovac,
+              structureHasLovac,
+              groupHasLovac,
+              group,
+              perimeter
+            };
+            return u;
+          })
         );
         return users;
       }

--- a/server/src/services/ceremaService/ceremaService.ts
+++ b/server/src/services/ceremaService/ceremaService.ts
@@ -33,10 +33,7 @@ function isLovacAccessValid(accesLovac: string | null): boolean {
  * - niveau_acces is 'lovac', OR
  * - the lovac boolean flag is true
  */
-function hasGroupLovacAccess(group: CeremaGroup | undefined): boolean {
-  if (!group) {
-    return false;
-  }
+function hasGroupLovacAccess(group: CeremaGroup): boolean {
   return group.niveau_acces === 'lovac' || group.lovac === true;
 }
 
@@ -113,6 +110,8 @@ export class CeremaService implements ConsultUserService {
                   )) ?? undefined;
               }
             }
+            const groupFetchFailed = !!user.groupe && !group;
+            const perimeterFetchFailed = !!group?.perimetre && !perimeter;
 
             // hasCommitment is true only if:
             // 1. Structure has a valid LOVAC access date (future date)
@@ -120,7 +119,9 @@ export class CeremaService implements ConsultUserService {
             const structureHasLovac = isLovacAccessValid(
               establishmentContent.acces_lovac
             );
-            const groupHasLovac = hasGroupLovacAccess(group);
+            const groupHasLovac = group
+              ? hasGroupLovacAccess(group)
+              : undefined;
 
             logger.debug('LOVAC access check', {
               email: user.email,
@@ -131,19 +132,23 @@ export class CeremaService implements ConsultUserService {
               groupNiveauAcces: group?.niveau_acces,
               groupLovac: group?.lovac,
               groupHasLovac,
-              hasCommitment: structureHasLovac && groupHasLovac
+              groupFetchFailed,
+              perimeterFetchFailed,
+              hasCommitment: structureHasLovac && groupHasLovac === true
             });
 
             const u: CeremaUser = {
               email: user.email,
               establishmentSiren: establishmentContent.siret.substring(0, 9),
               hasAccount: true,
-              hasCommitment: structureHasLovac && groupHasLovac,
+              hasCommitment: structureHasLovac && groupHasLovac === true,
               cguValide: user.cgu_valide,
               userExpiresAt: user.date_expiration,
               structureAccessExpiresAt: establishmentContent.acces_lovac,
               structureHasLovac,
               groupHasLovac,
+              groupFetchFailed,
+              perimeterFetchFailed,
               group,
               perimeter
             };

--- a/server/src/services/ceremaService/consultUserService.ts
+++ b/server/src/services/ceremaService/consultUserService.ts
@@ -41,6 +41,16 @@ export interface CeremaUser {
   establishmentSiren: string;
   hasAccount: boolean;
   hasCommitment: boolean;
+  /** Portail DF Terms of Service validation date. Null means CGU are not valid. */
+  cguValide?: string | null;
+  /** Portail DF user rights expiration date. Null means no expiration date. */
+  userExpiresAt?: string | null;
+  /** Structure LOVAC access expiration date. */
+  structureAccessExpiresAt?: string | null;
+  /** Whether the structure currently has valid LOVAC access. */
+  structureHasLovac?: boolean;
+  /** Whether the user group currently grants LOVAC access. */
+  groupHasLovac?: boolean;
   /** User's group info from Portail DF */
   group?: CeremaGroup;
   /** User's perimeter info from Portail DF */

--- a/server/src/services/ceremaService/consultUserService.ts
+++ b/server/src/services/ceremaService/consultUserService.ts
@@ -51,6 +51,10 @@ export interface CeremaUser {
   structureHasLovac?: boolean;
   /** Whether the user group currently grants LOVAC access. */
   groupHasLovac?: boolean;
+  /** Whether the group details could not be retrieved from Portail DF. */
+  groupFetchFailed?: boolean;
+  /** Whether the perimeter details could not be retrieved from Portail DF. */
+  perimeterFetchFailed?: boolean;
   /** User's group info from Portail DF */
   group?: CeremaGroup;
   /** User's perimeter info from Portail DF */

--- a/server/src/services/ceremaService/mockCeremaService.ts
+++ b/server/src/services/ceremaService/mockCeremaService.ts
@@ -1,4 +1,7 @@
-import { SirenStrasbourg } from '~/infra/database/seeds/development/20240404235442_establishments';
+import {
+  SirenSaintLo,
+  SirenStrasbourg
+} from '~/infra/database/seeds/development/20240404235442_establishments';
 
 import {
   CeremaUser,
@@ -11,6 +14,13 @@ export const MOCK_ANY_SIREN = '*';
 
 export class MockCeremaService implements ConsultUserService {
   async consultUsers(email: string): Promise<CeremaUser[]> {
+    if (email === 'test.strasbourg@zlv.fr') {
+      return [
+        defaultOK(email, SirenStrasbourg),
+        defaultOK(email, SirenSaintLo)
+      ];
+    }
+
     const testAccount = getTestAccount(email);
     if (testAccount) {
       return [testAccount];
@@ -28,7 +38,31 @@ function defaultOK(email: string, siren: string): CeremaUser {
     email,
     establishmentSiren: siren,
     hasAccount: true,
-    hasCommitment: true
+    hasCommitment: true,
+    cguValide: '2026-01-01T00:00:00.000Z',
+    userExpiresAt: null,
+    structureAccessExpiresAt: '2028-01-01T00:00:00.000Z',
+    structureHasLovac: true,
+    groupHasLovac: true,
+    group: {
+      id_groupe: 1,
+      nom: 'Aucune restriction',
+      structure: 1,
+      perimetre: 1,
+      niveau_acces: 'lovac',
+      df_ano: false,
+      df_non_ano: false,
+      lovac: true
+    },
+    perimeter: {
+      perimetre_id: 1,
+      origine: 'mock',
+      fr_entiere: false,
+      reg: [],
+      dep: [],
+      epci: [siren],
+      comm: []
+    }
   };
 }
 

--- a/server/src/services/ceremaService/perimeterService.ts
+++ b/server/src/services/ceremaService/perimeterService.ts
@@ -14,10 +14,13 @@ export interface AccessRightsResult {
   errors: AccessRightsError[];
 }
 
-export type AccessRightsError =
-  | 'niveau_acces_invalide'
-  | 'perimetre_invalide'
-  | 'groupe_manquant';
+export const ACCESS_RIGHTS_ERROR_VALUES = [
+  'niveau_acces_invalide',
+  'perimetre_invalide',
+  'groupe_manquant'
+] as const;
+
+export type AccessRightsError = (typeof ACCESS_RIGHTS_ERROR_VALUES)[number];
 
 function toPerimeterShape(perimeter: CeremaPerimeter): PerimeterShape {
   return {

--- a/server/src/services/ceremaService/suspensionService.ts
+++ b/server/src/services/ceremaService/suspensionService.ts
@@ -81,6 +81,21 @@ function computeCeremaSuspensionCauses(ceremaUser: CeremaUser): string[] {
   return causes;
 }
 
+function getSuspendedAt(
+  user: UserApi,
+  suspendedCause: string | null
+): string | null {
+  if (suspendedCause === null) {
+    return null;
+  }
+
+  if (user.suspendedCause === suspendedCause && user.suspendedAt) {
+    return user.suspendedAt;
+  }
+
+  return new Date().toJSON();
+}
+
 export function getCeremaSuspensionState(
   user: UserApi,
   currentEstablishment: EstablishmentApi | null,
@@ -109,12 +124,7 @@ export function getCeremaSuspensionState(
   ]);
   const nextCauses = unique([...manualCauses, ...ceremaCauses]);
   const suspendedCause = nextCauses.length > 0 ? nextCauses.join(', ') : null;
-  const suspendedAt =
-    suspendedCause === null
-      ? null
-      : user.suspendedCause === suspendedCause && user.suspendedAt
-        ? user.suspendedAt
-        : new Date().toJSON();
+  const suspendedAt = getSuspendedAt(user, suspendedCause);
 
   return {
     suspendedAt,

--- a/server/src/services/ceremaService/suspensionService.ts
+++ b/server/src/services/ceremaService/suspensionService.ts
@@ -1,0 +1,123 @@
+import { SUSPENDED_CAUSE_VALUES } from '@zerologementvacant/models';
+
+import type { EstablishmentApi } from '~/models/EstablishmentApi';
+import type { UserApi } from '~/models/UserApi';
+
+import type { CeremaUser } from './consultUserService';
+import {
+  ACCESS_RIGHTS_ERROR_VALUES,
+  type AccessRightsError
+} from './perimeterService';
+
+const CEREMA_SUSPENSION_CAUSES = [
+  ...SUSPENDED_CAUSE_VALUES,
+  ...ACCESS_RIGHTS_ERROR_VALUES
+] as const;
+
+type SuspensionState = Pick<UserApi, 'suspendedAt' | 'suspendedCause'>;
+
+function unique(causes: string[]): string[] {
+  return [...new Set(causes)];
+}
+
+function splitSuspensionCauses(cause: string | null): string[] {
+  return (
+    cause
+      ?.split(',')
+      .map((value) => value.trim())
+      .filter(Boolean) ?? []
+  );
+}
+
+function isCeremaSuspensionCause(cause: string): boolean {
+  return CEREMA_SUSPENSION_CAUSES.includes(
+    cause as (typeof CEREMA_SUSPENSION_CAUSES)[number]
+  );
+}
+
+function isPastDate(value: string | null | undefined): boolean {
+  if (!value) {
+    return false;
+  }
+
+  const date = new Date(value);
+  return !Number.isNaN(date.getTime()) && date <= new Date();
+}
+
+function isLovacAccessExpired(value: string | null | undefined): boolean {
+  if (value === undefined) {
+    return false;
+  }
+
+  if (value === null || value === '') {
+    return true;
+  }
+
+  return isPastDate(value);
+}
+
+function computeCeremaSuspensionCauses(ceremaUser: CeremaUser): string[] {
+  const causes: string[] = [];
+
+  if (ceremaUser.cguValide === null || ceremaUser.cguValide === '') {
+    causes.push('cgu vides');
+  }
+
+  if (isPastDate(ceremaUser.userExpiresAt)) {
+    causes.push('droits utilisateur expires');
+  }
+
+  if (
+    ceremaUser.structureHasLovac === false ||
+    isLovacAccessExpired(ceremaUser.structureAccessExpiresAt)
+  ) {
+    causes.push('droits structure expires');
+  }
+
+  if (ceremaUser.groupHasLovac === false) {
+    causes.push('niveau_acces_invalide');
+  }
+
+  return causes;
+}
+
+export function getCeremaSuspensionState(
+  user: UserApi,
+  currentEstablishment: EstablishmentApi | null,
+  ceremaUsers: CeremaUser[],
+  accessErrors: AccessRightsError[]
+): SuspensionState | null {
+  const usersForCurrentEstablishment = currentEstablishment
+    ? ceremaUsers.filter(
+        (cu) =>
+          cu.establishmentSiren === currentEstablishment.siren ||
+          cu.establishmentSiren === '*'
+      )
+    : ceremaUsers;
+
+  if (currentEstablishment && usersForCurrentEstablishment.length === 0) {
+    return null;
+  }
+
+  const previousCauses = splitSuspensionCauses(user.suspendedCause);
+  const manualCauses = previousCauses.filter(
+    (cause) => !isCeremaSuspensionCause(cause)
+  );
+  const ceremaCauses = unique([
+    ...usersForCurrentEstablishment.flatMap(computeCeremaSuspensionCauses),
+    ...accessErrors
+  ]);
+  const nextCauses = unique([...manualCauses, ...ceremaCauses]);
+  const suspendedCause = nextCauses.length > 0 ? nextCauses.join(', ') : null;
+  const suspendedAt =
+    suspendedCause === null
+      ? null
+      : user.suspendedCause === suspendedCause && user.suspendedAt
+        ? user.suspendedAt
+        : new Date().toJSON();
+
+  return {
+    suspendedAt,
+    suspendedCause
+  };
+}

--- a/server/src/services/establishmentAuthService.ts
+++ b/server/src/services/establishmentAuthService.ts
@@ -10,9 +10,14 @@ import ceremaService from '~/services/ceremaService';
 import type { CeremaUser } from '~/services/ceremaService/consultUserService';
 import {
   verifyAccessRights,
-  accessErrorsToSuspensionCause,
   type AccessRightsError
 } from '~/services/ceremaService/perimeterService';
+import { getCeremaSuspensionState } from '~/services/ceremaService/suspensionService';
+
+interface RefreshOptions {
+  authoritative?: boolean;
+  establishmentId?: string | null;
+}
 
 interface AuthorizedEstablishment {
   establishmentId: string;
@@ -25,21 +30,52 @@ interface AuthorizationResult {
   accessErrors: AccessRightsError[];
 }
 
+function isIncompleteCeremaUser(ceremaUser: CeremaUser): boolean {
+  return !!(ceremaUser.groupFetchFailed || ceremaUser.perimeterFetchFailed);
+}
+
+function splitCeremaUsers(ceremaUsers: ReadonlyArray<CeremaUser>) {
+  const incompleteCeremaUsers = ceremaUsers.filter(isIncompleteCeremaUser);
+  return {
+    incompleteCeremaUsers,
+    syncableCeremaUsers: ceremaUsers.filter(
+      (ceremaUser) => !isIncompleteCeremaUser(ceremaUser)
+    )
+  };
+}
+
 function findCeremaUser(
   ceremaUsers: ReadonlyArray<CeremaUser>,
   establishmentSiren: string
 ): CeremaUser | undefined {
-  return ceremaUsers.find(
-    (ceremaUser) =>
-      ceremaUser.establishmentSiren === establishmentSiren ||
-      ceremaUser.establishmentSiren === '*'
+  return ceremaUsers.find((ceremaUser) =>
+    matchesCeremaSiren(ceremaUser, establishmentSiren)
   );
+}
+
+function matchesCeremaSiren(
+  ceremaUser: CeremaUser,
+  establishmentSiren: string
+): boolean {
+  return (
+    ceremaUser.establishmentSiren === establishmentSiren ||
+    ceremaUser.establishmentSiren === '*'
+  );
+}
+
+function getFailedCeremaEntries(ceremaUsers: ReadonlyArray<CeremaUser>) {
+  return ceremaUsers.map((ceremaUser) => ({
+    establishmentSiren: ceremaUser.establishmentSiren,
+    groupFetchFailed: ceremaUser.groupFetchFailed,
+    perimeterFetchFailed: ceremaUser.perimeterFetchFailed
+  }));
 }
 
 async function authorizeEstablishments(
   user: UserApi,
   knownEstablishments: ReadonlyArray<EstablishmentApi>,
-  ceremaUsers: ReadonlyArray<CeremaUser>
+  ceremaUsers: ReadonlyArray<CeremaUser>,
+  selectedEstablishment: EstablishmentApi | null
 ): Promise<AuthorizationResult> {
   const authorizedEstablishments: AuthorizedEstablishment[] = [];
   const accessErrors: AccessRightsError[] = [];
@@ -74,49 +110,61 @@ async function authorizeEstablishments(
         errors: accessRights.errors
       }
     );
-    accessErrors.push(...accessRights.errors);
+    if (establishment.id === selectedEstablishment?.id) {
+      accessErrors.push(...accessRights.errors);
+    }
   }
 
   return { authorizedEstablishments, accessErrors };
 }
 
-async function suspendIfCurrentEstablishmentLostAccess(
+async function syncCeremaSuspension(
   user: UserApi,
-  authorizedEstablishments: AuthorizedEstablishment[],
+  selectedEstablishment: EstablishmentApi | null,
+  ceremaUsers: CeremaUser[],
   accessErrors: AccessRightsError[]
 ): Promise<void> {
-  const currentEstablishmentStillValid = authorizedEstablishments.some(
-    (establishment) => establishment.establishmentId === user.establishmentId
-  );
-  if (
-    !user.establishmentId ||
-    currentEstablishmentStillValid ||
-    accessErrors.length === 0
-  ) {
-    return;
-  }
-
-  const suspensionCause = accessErrorsToSuspensionCause([
-    ...new Set(accessErrors)
-  ]);
-
-  logger.warn('Suspending user at login due to lost access rights', {
-    userId: user.id,
-    email: user.email,
-    establishmentId: user.establishmentId,
-    suspensionCause
-  });
-
-  // Re-fetch user to get latest lastAuthenticatedAt (updated by signIn)
+  // Re-fetch the user so we preserve fields updated by the sign-in flow and
+  // any manual suspension cause written concurrently.
   const currentUser = await userRepository.get(user.id);
   if (!currentUser) {
     return;
   }
 
+  const suspensionState = getCeremaSuspensionState(
+    currentUser,
+    selectedEstablishment,
+    ceremaUsers,
+    accessErrors
+  );
+  if (!suspensionState) {
+    logger.info('No Portail DF entry found for selected establishment', {
+      userId: user.id,
+      email: user.email,
+      establishmentId: selectedEstablishment?.id,
+      establishmentSiren: selectedEstablishment?.siren
+    });
+    return;
+  }
+
+  if (
+    currentUser.suspendedAt === suspensionState.suspendedAt &&
+    currentUser.suspendedCause === suspensionState.suspendedCause
+  ) {
+    return;
+  }
+
   await userRepository.update({
     ...currentUser,
-    suspendedAt: new Date().toJSON(),
-    suspendedCause: suspensionCause
+    ...suspensionState
+  });
+
+  logger.info('User suspension synchronized from Portail DF', {
+    userId: user.id,
+    email: user.email,
+    establishmentId: selectedEstablishment?.id,
+    previousSuspendedCause: currentUser.suspendedCause,
+    nextSuspendedCause: suspensionState.suspendedCause
   });
 }
 
@@ -239,7 +287,7 @@ async function saveAuthorizedEstablishmentPerimeters(
  */
 export async function refreshAuthorizedEstablishments(
   user: UserApi,
-  options: { authoritative?: boolean } = {}
+  options: RefreshOptions = {}
 ): Promise<void> {
   try {
     const ceremaUsers = await ceremaService.consultUsers(user.email);
@@ -255,7 +303,36 @@ export async function refreshAuthorizedEstablishments(
       return;
     }
 
-    const ceremaUsersWithCommitment = ceremaUsers.filter(
+    const selectedEstablishmentId =
+      options.establishmentId ?? user.establishmentId;
+    const selectedEstablishment = selectedEstablishmentId
+      ? await establishmentRepository.get(selectedEstablishmentId)
+      : null;
+    const { incompleteCeremaUsers, syncableCeremaUsers } =
+      splitCeremaUsers(ceremaUsers);
+    const incompleteSelectedCeremaUsers = selectedEstablishment
+      ? incompleteCeremaUsers.filter((ceremaUser) =>
+          matchesCeremaSiren(ceremaUser, selectedEstablishment.siren)
+        )
+      : [];
+
+    if (incompleteSelectedCeremaUsers.length > 0) {
+      logger.warn(
+        'Skipping Portail DF synchronization with incomplete selected establishment details',
+        {
+          userId: user.id,
+          email: user.email,
+          establishmentId: selectedEstablishment?.id,
+          failedEntries: getFailedCeremaEntries(incompleteSelectedCeremaUsers)
+        }
+      );
+      if (options.authoritative) {
+        throw new ExternalServiceUnavailableError('Portail DF');
+      }
+      return;
+    }
+
+    const ceremaUsersWithCommitment = syncableCeremaUsers.filter(
       (ceremaUser) => ceremaUser.hasCommitment
     );
     const establishmentSirens = ceremaUsersWithCommitment.map(
@@ -269,21 +346,41 @@ export async function refreshAuthorizedEstablishments(
       await authorizeEstablishments(
         user,
         knownEstablishments,
-        ceremaUsersWithCommitment
+        syncableCeremaUsers,
+        selectedEstablishment
       );
 
-    await suspendIfCurrentEstablishmentLostAccess(
-      user,
-      authorizedEstablishments,
-      accessErrors
-    );
-    await syncAuthorizedEstablishments(user, authorizedEstablishments);
+    if (selectedEstablishment) {
+      await syncCeremaSuspension(
+        user,
+        selectedEstablishment,
+        syncableCeremaUsers,
+        accessErrors
+      );
+    }
     await saveAuthorizedEstablishmentPerimeters(
       user,
       authorizedEstablishments,
       knownEstablishments,
-      ceremaUsersWithCommitment
+      syncableCeremaUsers
     );
+
+    if (incompleteCeremaUsers.length > 0) {
+      logger.warn(
+        'Skipping authorized establishments synchronization with incomplete Portail DF details',
+        {
+          userId: user.id,
+          email: user.email,
+          failedEntries: getFailedCeremaEntries(incompleteCeremaUsers)
+        }
+      );
+      if (options.authoritative) {
+        throw new ExternalServiceUnavailableError('Portail DF');
+      }
+      return;
+    }
+
+    await syncAuthorizedEstablishments(user, authorizedEstablishments);
   } catch (error) {
     // Log error but don't fail login
     logger.error('Failed to refresh authorized establishments at login', {

--- a/server/src/services/test/establishmentAuthService.test.ts
+++ b/server/src/services/test/establishmentAuthService.test.ts
@@ -22,6 +22,11 @@ import userRepository, {
   toUserDBO,
   Users
 } from '~/repositories/userRepository';
+import type {
+  CeremaGroup,
+  CeremaPerimeter,
+  CeremaUser
+} from '~/services/ceremaService/consultUserService';
 import { genEstablishmentApi, genUserApi } from '~/test/testFixtures';
 
 const mocks = vi.hoisted(() => ({
@@ -33,6 +38,44 @@ vi.mock('~/services/ceremaService', () => ({
 }));
 
 import { refreshAuthorizedEstablishments } from '../establishmentAuthService';
+
+const lovacGroup: CeremaGroup = {
+  id_groupe: 1,
+  nom: 'LOVAC',
+  structure: 1,
+  perimetre: 0,
+  niveau_acces: 'lovac',
+  df_ano: false,
+  df_non_ano: false,
+  lovac: true
+};
+
+const unrelatedCommunePerimeter: CeremaPerimeter = {
+  perimetre_id: 2,
+  origine: 'test',
+  fr_entiere: false,
+  reg: [],
+  dep: [],
+  epci: [],
+  comm: ['99999']
+};
+
+function genCeremaUser(
+  overrides: Partial<CeremaUser> &
+    Pick<CeremaUser, 'email' | 'establishmentSiren'>
+): CeremaUser {
+  return {
+    hasAccount: true,
+    hasCommitment: true,
+    cguValide: '2026-03-11T12:36:01.255000+01:00',
+    userExpiresAt: null,
+    structureAccessExpiresAt: '2028-01-15T09:16:31+01:00',
+    structureHasLovac: true,
+    groupHasLovac: true,
+    group: lovacGroup,
+    ...overrides
+  };
+}
 
 describe('refreshAuthorizedEstablishments', () => {
   const establishment = genEstablishmentApi('75056');
@@ -212,6 +255,209 @@ describe('refreshAuthorizedEstablishments', () => {
 
     await expect(userRepository.get(user.id)).resolves.toMatchObject({
       suspendedCause: 'niveau_acces_invalide'
+    });
+  });
+
+  it('replaces an obsolete CGU suspension with the current Cerema structure expiration', async () => {
+    const suspendedUser = {
+      ...user,
+      suspendedAt: new Date('2026-02-15T00:00:00.000Z').toJSON(),
+      suspendedCause: 'cgu vides'
+    };
+    await Users().where({ id: user.id }).update({
+      suspended_at: suspendedUser.suspendedAt,
+      suspended_cause: suspendedUser.suspendedCause
+    });
+    mocks.consultUsers.mockResolvedValue([
+      genCeremaUser({
+        email: user.email,
+        establishmentSiren: establishment.siren,
+        hasCommitment: false,
+        structureAccessExpiresAt: '2025-01-15T09:16:31+01:00',
+        structureHasLovac: false
+      })
+    ]);
+
+    await refreshAuthorizedEstablishments(suspendedUser);
+
+    await expect(userRepository.get(user.id)).resolves.toMatchObject({
+      suspendedAt: expect.any(String),
+      suspendedCause: 'droits structure expires'
+    });
+  });
+
+  it('clears an obsolete Cerema suspension when current rights are valid', async () => {
+    const suspendedUser = {
+      ...user,
+      suspendedAt: new Date('2026-02-15T00:00:00.000Z').toJSON(),
+      suspendedCause: 'cgu vides'
+    };
+    await Users().where({ id: user.id }).update({
+      suspended_at: suspendedUser.suspendedAt,
+      suspended_cause: suspendedUser.suspendedCause
+    });
+    mocks.consultUsers.mockResolvedValue([
+      genCeremaUser({
+        email: user.email,
+        establishmentSiren: establishment.siren
+      })
+    ]);
+
+    await refreshAuthorizedEstablishments(suspendedUser);
+
+    await expect(userRepository.get(user.id)).resolves.toMatchObject({
+      suspendedAt: null,
+      suspendedCause: null
+    });
+  });
+
+  it('preserves a manual suspension while clearing an obsolete Cerema cause', async () => {
+    const suspendedUser = {
+      ...user,
+      suspendedAt: new Date('2026-02-15T00:00:00.000Z').toJSON(),
+      suspendedCause: 'suspension manuelle, cgu vides'
+    };
+    await Users().where({ id: user.id }).update({
+      suspended_at: suspendedUser.suspendedAt,
+      suspended_cause: suspendedUser.suspendedCause
+    });
+    mocks.consultUsers.mockResolvedValue([
+      genCeremaUser({
+        email: user.email,
+        establishmentSiren: establishment.siren
+      })
+    ]);
+
+    await refreshAuthorizedEstablishments(suspendedUser);
+
+    await expect(userRepository.get(user.id)).resolves.toMatchObject({
+      suspendedAt: expect.any(String),
+      suspendedCause: 'suspension manuelle'
+    });
+  });
+
+  it('does not apply access errors from another establishment to the selected one', async () => {
+    mocks.consultUsers.mockResolvedValue([
+      genCeremaUser({
+        email: user.email,
+        establishmentSiren: establishment.siren
+      }),
+      genCeremaUser({
+        email: user.email,
+        establishmentSiren: secondEstablishment.siren,
+        perimeter: unrelatedCommunePerimeter
+      })
+    ]);
+
+    await refreshAuthorizedEstablishments(user, {
+      establishmentId: establishment.id
+    });
+
+    await expect(userRepository.get(user.id)).resolves.toMatchObject({
+      suspendedAt: null,
+      suspendedCause: null
+    });
+  });
+
+  it('updates the selected suspension without replacing links when another establishment is incomplete', async () => {
+    const suspendedUser = {
+      ...user,
+      suspendedAt: new Date('2026-02-15T00:00:00.000Z').toJSON(),
+      suspendedCause: 'cgu vides'
+    };
+    await Users().where({ id: user.id }).update({
+      suspended_at: suspendedUser.suspendedAt,
+      suspended_cause: suspendedUser.suspendedCause
+    });
+    await UsersEstablishments().insert({
+      user_id: user.id,
+      establishment_id: secondEstablishment.id,
+      establishment_siren: secondEstablishment.siren,
+      has_commitment: true
+    });
+    mocks.consultUsers.mockResolvedValue([
+      genCeremaUser({
+        email: user.email,
+        establishmentSiren: establishment.siren
+      }),
+      genCeremaUser({
+        email: user.email,
+        establishmentSiren: secondEstablishment.siren,
+        group: undefined,
+        groupHasLovac: undefined,
+        groupFetchFailed: true
+      })
+    ]);
+
+    await refreshAuthorizedEstablishments(suspendedUser, {
+      establishmentId: establishment.id
+    });
+
+    await expect(userRepository.get(user.id)).resolves.toMatchObject({
+      suspendedAt: null,
+      suspendedCause: null
+    });
+    await expect(
+      userEstablishmentRepository.getAuthorizedEstablishments(user.id)
+    ).resolves.toEqual([
+      {
+        establishmentId: secondEstablishment.id,
+        establishmentSiren: secondEstablishment.siren,
+        hasCommitment: true
+      }
+    ]);
+  });
+
+  it('rejects an authoritative refresh when the Cerema response is partial', async () => {
+    mocks.consultUsers.mockResolvedValue([
+      genCeremaUser({
+        email: user.email,
+        establishmentSiren: establishment.siren
+      }),
+      genCeremaUser({
+        email: user.email,
+        establishmentSiren: secondEstablishment.siren,
+        group: undefined,
+        groupHasLovac: undefined,
+        groupFetchFailed: true
+      })
+    ]);
+
+    await expect(
+      refreshAuthorizedEstablishments(user, {
+        authoritative: true,
+        establishmentId: establishment.id
+      })
+    ).rejects.toThrow('Portail DF is temporarily unavailable.');
+  });
+
+  it('keeps the current suspension when selected Cerema details are incomplete', async () => {
+    const suspendedUser = {
+      ...user,
+      suspendedAt: new Date('2026-02-15T00:00:00.000Z').toJSON(),
+      suspendedCause: 'cgu vides'
+    };
+    await Users().where({ id: user.id }).update({
+      suspended_at: suspendedUser.suspendedAt,
+      suspended_cause: suspendedUser.suspendedCause
+    });
+    mocks.consultUsers.mockResolvedValue([
+      genCeremaUser({
+        email: user.email,
+        establishmentSiren: establishment.siren,
+        group: undefined,
+        groupHasLovac: undefined,
+        groupFetchFailed: true
+      })
+    ]);
+
+    await refreshAuthorizedEstablishments(suspendedUser, {
+      establishmentId: establishment.id
+    });
+
+    await expect(userRepository.get(user.id)).resolves.toMatchObject({
+      suspendedAt: suspendedUser.suspendedAt,
+      suspendedCause: suspendedUser.suspendedCause
     });
   });
 });


### PR DESCRIPTION
## Résumé

Corrige la désynchronisation de l’état de suspension utilisateur après refresh des droits Cerema.

Avant, ZLV pouvait conserver une ancienne valeur `users.suspended_at / suspended_cause` même lorsque Cerema renvoyait un état courant différent. Cela pouvait afficher une modale obsolète, par exemple “CGU non validées”, alors que les CGU étaient désormais validées côté Cerema.

Cette PR rend le refresh Cerema idempotent à la connexion :
- expose les champs Cerema nécessaires au recalcul (`cgu_valide`, expiration utilisateur, expiration LOVAC structure),
- recalcule les causes de suspension depuis la réponse Cerema actuelle,
- remplace les anciennes causes Cerema obsolètes,
- remet `suspended_at` / `suspended_cause` à `NULL` quand plus aucune cause bloquante Cerema n’existe,
- préserve les éventuelles causes de suspension non-Cerema.

## Validation

- `yarn nx test server -- src/controllers/test/auth-controller.test.ts -t "obsolete"`
- `yarn nx test server -- src/services/ceremaService/ceremaService.test.ts`
- `yarn nx typecheck server`
- `yarn lint && yarn format`