### PR TITLE
Fix/vacancy year 2023 wording

### DIFF
--- a/frontend/src/models/HousingFilters.tsx
+++ b/frontend/src/models/HousingFilters.tsx
@@ -613,9 +613,9 @@ export const multiOwnerOptions: SelectOption[] = [
  */
 export const vacancyYearOptions: SelectOption<VacancyYear>[] = [
   {
-    value: '2022',
-    label: '2022',
-    badgeLabel: 'Début de vacance : depuis 2022'
+    value: '2023',
+    label: '2023',
+    badgeLabel: 'Début de vacance : depuis 2023'
   },
   {
     value: '2021',
@@ -651,11 +651,6 @@ export const vacancyYearOptions: SelectOption<VacancyYear>[] = [
     value: 'missingData',
     label: 'Pas d’information',
     badgeLabel: 'Début de vacance : pas d’information'
-  },
-  {
-    value: 'inconsistency2023',
-    label: '2023 (incohérence donnée source)',
-    badgeLabel: 'Début de vacance : 2023 (incohérence données sources)'
   }
 ];
 export const VACANCY_YEAR_OPTIONS: Record<
@@ -665,6 +660,10 @@ export const VACANCY_YEAR_OPTIONS: Record<
     badgeLabel: string;
   }
 > = {
+  '2023': {
+    label: '2023',
+    badgeLabel: 'Début de vacance : depuis 2023'
+  },
   '2022': {
     label: '2022',
     badgeLabel: 'Début de vacance : depuis 2022'
@@ -696,10 +695,6 @@ export const VACANCY_YEAR_OPTIONS: Record<
   missingData: {
     label: 'Pas d’information',
     badgeLabel: 'Début de vacance : pas d’information'
-  },
-  inconsistency2023: {
-    label: '2023 (incohérence données sources)',
-    badgeLabel: 'Début de vacance : 2023 (incohérence données sources)'
   }
 };
 

--- a/packages/models/src/VacancyYear.ts
+++ b/packages/models/src/VacancyYear.ts
@@ -1,4 +1,5 @@
 export const VACANCY_YEAR_VALUES = [
+  '2023',
   '2022',
   '2021',
   '2020',
@@ -6,8 +7,7 @@ export const VACANCY_YEAR_VALUES = [
   '2018to2015',
   '2014to2010',
   'before2010',
-  'missingData',
-  'inconsistency2023'
+  'missingData'
 ] as const;
 
 export type VacancyYear = (typeof VACANCY_YEAR_VALUES)[number];

--- a/server/src/repositories/housingRepository.ts
+++ b/server/src/repositories/housingRepository.ts
@@ -848,7 +848,7 @@ function filteredQuery(opts: FilteredQueryOptions) {
         if (filters.vacancyYears?.includes('missingData')) {
           where.orWhereNull('vacancy_start_year');
         }
-        if (filters.vacancyYears?.includes('inconsistency2023')) {
+        if (filters.vacancyYears?.includes('2023')) {
           where.orWhere('vacancy_start_year', 2023);
         }
       });

--- a/server/src/repositories/test/housingRepository.test.ts
+++ b/server/src/repositories/test/housingRepository.test.ts
@@ -1309,8 +1309,8 @@ describe('Housing repository', () => {
               housing.vacancyStartYear === null
           },
           {
-            name: '2023 (incohérence donnée source)',
-            filter: ['inconsistency2023'],
+            name: '2023',
+            filter: ['2023'],
             predicate: (housing: HousingApi) =>
               (housing.vacancyStartYear as number) === 2023
           }


### PR DESCRIPTION
## Contexte

Le filtre "Année de début de vacance" affichait encore une entrée `inconsistency2022` (libellé : _"2022 (incohérence donnée source)"_) qui n'existe plus dans les données. Le code n'était plus à jour par rapport à l'état réel de l'application.

## Changements

- Remplace la valeur `inconsistency2022` par `'2023'` dans le type `VacancyYear`
- Renomme le libellé en `"2023"` (suppression de la note _"incohérence données sources"_)
- Remonte l'entrée `2023` en tête de liste, au-dessus de `2022` (ordre chronologique)
- Met à jour le filtre serveur pour cibler `vacancy_start_year = 2023`
- Met à jour le test du repository en conséquence

## Plan de test

- [x] Ouvrir le filtre "Année de début de vacance" → vérifier que `2023` apparaît en premier, sans parenthèse
- [x] Sélectionner `2023` → vérifier que les logements avec `vacancy_start_year = 2023` remontent bien
- [x] Vérifier que les autres années (2022, 2021…) fonctionnent toujours correctement