### PR TITLE
fix(frontend): use blue-france color for housing filter icons

### DIFF
--- a/frontend/src/components/HousingListFilters/HousingListFiltersSidemenu.tsx
+++ b/frontend/src/components/HousingListFilters/HousingListFiltersSidemenu.tsx
@@ -1,4 +1,8 @@
-import type { FrIconClassName, RiIconClassName } from '@codegouvfr/react-dsfr';
+import {
+  fr,
+  type FrIconClassName,
+  type RiIconClassName
+} from '@codegouvfr/react-dsfr';
 import Accordion from '@codegouvfr/react-dsfr/Accordion';
 import Button from '@codegouvfr/react-dsfr/Button';
 import MuiDrawer from '@mui/material/Drawer';
@@ -71,7 +75,11 @@ interface TitleWithIconProps {
 function TitleWithIcon(props: TitleWithIconProps) {
   return (
     <>
-      <Icon name={props.icon} className={styles.icon} />
+      <Icon
+        name={props.icon}
+        className={styles.icon}
+        color={fr.colors.decisions.text.actionHigh.blueFrance.default}
+      />
       <span>{props.title}</span>
     </>
   );


### PR DESCRIPTION
## Summary

- Icons in the housing list filters sidemenu (`HousingListFiltersSidemenu`) were rendering in grey instead of the expected blue-france color
- The `Icon` component defaults to `fr.colors.decisions.text.default.grey.default` when no color prop is provided
- Fixed by passing `fr.colors.decisions.text.actionHigh.blueFrance.default` explicitly to each filter section icon via the `TitleWithIcon` helper component

## Changes

- `frontend/src/components/HousingListFilters/HousingListFiltersSidemenu.tsx`: added `fr` import and passed blue-france color to the `<Icon>` in `TitleWithIcon`

## Test plan

- [ ] Open the housing list (parc de logements) and click the filter button to open the sidemenu
- [ ] Verify that section icons (données, campagne, localisation, bâtiment, logement, propriétaires) are now displayed in blue-france instead of grey

🤖 Generated with [Claude Code](https://claude.com/claude-code)