### PR TITLE
fix(map): reduce perimeter fill opacity to limit overlap whiteout

### DIFF
--- a/frontend/src/components/Map/Perimeters.tsx
+++ b/frontend/src/components/Map/Perimeters.tsx
@@ -37,7 +37,7 @@ function Perimeters(props: Props) {
         type="fill"
         paint={{
           'fill-color': props.backgroundColor ?? '#f6f6f6',
-          'fill-opacity': isVisible ? 0.51 : 0
+          'fill-opacity': isVisible ? 0.25 : 0
         }}
       />
       <Layer


### PR DESCRIPTION
## What

Lower the fill opacity of map perimeters from `0.51` to `0.25` in `Perimeters.tsx`.

## Why

Perimeter polygons are filled with a near-white colour (`#f6f6f6`). MapLibre composites overlapping fills, so where perimeters overlap the effective opacity stacks:

| Overlapping perimeters | Before (`0.51`) | After (`0.25`) |
|---|---|---|
| 1 | 51 % | 25 % |
| 2 | ~76 % | ~44 % |
| 3 | ~88 % | ~58 % |

At `0.51` the overlap zones washed out the basemap and street labels almost completely (up to ~94 % white with four overlapping perimeters). `0.25` keeps a single perimeter clearly tinted while overlaps stay readable. The borders keep a fully opaque line, so each perimeter is still delineated regardless of the lighter fill.

## Notes for reviewer

- Single-line change; behaviour is purely visual.
- The value (`0.25`) was tuned interactively against a local map with several deliberately overlapping perimeters.
- A follow-up option, if overlap zones should stay perfectly uniform at a higher opacity, would be to dissolve/union the perimeter geometries so the fill no longer stacks — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)