### PR TITLE
fix(server): fix Metabase visualizer dashcard series names and year date labels

### DIFF
--- a/server/src/controllers/dashboardController.ts
+++ b/server/src/controllers/dashboardController.ts
@@ -97,7 +97,7 @@ async function findOneCard(
       decimals: barRaw.decimals,
       labels: barRaw.labels,
       data: barRaw.data,
-      name: barRaw.name
+      name: dashcard.seriesName ?? barRaw.name
     });
     return;
   }
@@ -111,7 +111,7 @@ async function findOneCard(
       decimals: lineRaw.decimals,
       labels: lineRaw.labels,
       data: lineRaw.data,
-      name: lineRaw.name
+      name: dashcard.seriesName ?? lineRaw.name
     });
     return;
   }

--- a/server/src/controllers/test/dashboard-api.test.ts
+++ b/server/src/controllers/test/dashboard-api.test.ts
@@ -494,6 +494,109 @@ const mockLineCardQueryResultNumber = {
   status: 'completed'
 };
 
+// Visualizer bar chart: graph.x_axis.title_text holds the PM-curated series label.
+const mockMetabaseDashboardWithVisualizerBarCard = {
+  id: 13,
+  dashcards: [
+    {
+      id: 973,
+      card_id: 823,
+      dashboard_tab_id: null,
+      row: 0,
+      col: 0,
+      size_x: 6,
+      size_y: 4,
+      visualization_settings: {
+        visualization: {
+          settings: {
+            'card.title': 'Nombre de logements selon le statut de suivi',
+            'graph.dimensions': ['COLUMN_1'],
+            'graph.metrics': ['COLUMN_2'],
+            'graph.x_axis.title_text': 'Statuts de suivi'
+          }
+        }
+      },
+      card: {
+        id: 823,
+        name: 'Nombre de logements selon le statut de suivi',
+        display: 'bar',
+        description: null,
+        visualization_settings: {}
+      }
+    }
+  ]
+};
+
+const mockVisualizerBarCardQueryResult = {
+  data: {
+    rows: [
+      ['En suivi', 1200],
+      ['Sortie', 300]
+    ],
+    cols: [
+      { name: 'COLUMN_1', display_name: 'Status' },
+      {
+        name: 'COLUMN_2',
+        display_name: 'Valeurs distinctes de Housing ID'
+      }
+    ]
+  },
+  status: 'completed'
+};
+
+// Visualizer-style dashcard: real settings nested under visualization.settings.
+// COLUMN_1/COLUMN_2 are abstract names; graph.x_axis.title_text carries the
+// PM-curated series label "Années".
+const mockMetabaseDashboardWithVisualizerLineCard = {
+  id: 13,
+  dashcards: [
+    {
+      id: 972,
+      card_id: 822,
+      dashboard_tab_id: null,
+      row: 0,
+      col: 0,
+      size_x: 6,
+      size_y: 4,
+      visualization_settings: {
+        visualization: {
+          settings: {
+            'card.title':
+              'Évolution du nombre de logements vacants depuis plus de 2 ans',
+            'graph.dimensions': ['COLUMN_1'],
+            'graph.metrics': ['COLUMN_2'],
+            'graph.x_axis.title_text': 'Années'
+          }
+        }
+      },
+      card: {
+        id: 822,
+        name: 'Évolution du nombre de logements vacants depuis plus de 2 ans',
+        display: 'line',
+        description: null,
+        visualization_settings: {}
+      }
+    }
+  ]
+};
+
+const mockVisualizerLineCardQueryResult = {
+  data: {
+    rows: [
+      [2019, 45000],
+      [2020, 47000]
+    ],
+    cols: [
+      { name: 'COLUMN_1', display_name: 'Year' },
+      {
+        name: 'COLUMN_2',
+        display_name: 'Count Vacant Housing Private Fil Public'
+      }
+    ]
+  },
+  status: 'completed'
+};
+
 const mockMetabaseDashboardWithTableCard = {
   id: 13,
   dashcards: [
@@ -1110,6 +1213,50 @@ describe('Dashboard API', () => {
         decimals: 0,
         labels: ['2024', '2025'],
         data: [120, 145]
+      });
+    });
+
+    it('uses graph.x_axis.title_text as series name for visualizer bar charts', async () => {
+      nock(METABASE_URL)
+        .get('/api/dashboard/13')
+        .reply(200, mockMetabaseDashboardWithVisualizerBarCard);
+      nock(METABASE_URL)
+        .post('/api/dashboard/13/dashcard/973/card/823/query')
+        .reply(200, mockVisualizerBarCardQueryResult);
+
+      const response = await request(url)
+        .get('/dashboards/13-analyses/cards/973')
+        .use(tokenProvider(user));
+
+      expect(response.status).toBe(constants.HTTP_STATUS_OK);
+      expect(response.body).toMatchObject({
+        id: 973,
+        type: 'bar-chart',
+        name: 'Statuts de suivi',
+        labels: ['En suivi', 'Sortie'],
+        data: [1200, 300]
+      });
+    });
+
+    it('uses graph.x_axis.title_text as series name for visualizer line charts', async () => {
+      nock(METABASE_URL)
+        .get('/api/dashboard/13')
+        .reply(200, mockMetabaseDashboardWithVisualizerLineCard);
+      nock(METABASE_URL)
+        .post('/api/dashboard/13/dashcard/972/card/822/query')
+        .reply(200, mockVisualizerLineCardQueryResult);
+
+      const response = await request(url)
+        .get('/dashboards/13-analyses/cards/972')
+        .use(tokenProvider(user));
+
+      expect(response.status).toBe(constants.HTTP_STATUS_OK);
+      expect(response.body).toMatchObject({
+        id: 972,
+        type: 'line-chart',
+        name: 'Années',
+        labels: ['2019', '2020'],
+        data: [45000, 47000]
       });
     });
 

--- a/server/src/controllers/test/dashboard-api.test.ts
+++ b/server/src/controllers/test/dashboard-api.test.ts
@@ -343,6 +343,55 @@ const mockPieCardQueryResult = {
   status: 'completed'
 };
 
+// Bar chart where the x-axis is a year-bucketed date column. Metabase returns
+// full ISO timestamps; the column has temporal_unit: 'year' so labels should
+// be formatted as plain years.
+const mockMetabaseDashboardWithYearBarCard = {
+  id: 13,
+  dashcards: [
+    {
+      id: 974,
+      card_id: 824,
+      dashboard_tab_id: null,
+      row: 0,
+      col: 0,
+      size_x: 6,
+      size_y: 4,
+      visualization_settings: { 'card.title': 'Logements contactés par année' },
+      card: {
+        id: 824,
+        name: 'Logements contactés par année',
+        display: 'bar',
+        description: null,
+        visualization_settings: {
+          'graph.dimensions': ['contacted_at'],
+          'graph.metrics': ['count']
+        }
+      }
+    }
+  ]
+};
+
+const mockYearBarCardQueryResult = {
+  data: {
+    rows: [
+      ['2021-01-01T00:00:00.000Z', 4200],
+      ['2022-01-01T00:00:00.000Z', 5100],
+      ['2023-01-01T00:00:00.000Z', 3800]
+    ],
+    cols: [
+      {
+        name: 'contacted_at',
+        display_name: 'Contacted At: Year',
+        base_type: 'type/DateTime',
+        unit: 'year'
+      },
+      { name: 'count', display_name: 'Nombre de logements' }
+    ]
+  },
+  status: 'completed'
+};
+
 const mockMetabaseDashboardWithBarCard = {
   id: 13,
   dashcards: [
@@ -1110,6 +1159,27 @@ describe('Dashboard API', () => {
         type: 'pie-chart',
         labels: ['Appartements', 'Maisons'],
         data: [4876, 652]
+      });
+    });
+
+    it('formats year-bucketed date labels as plain years', async () => {
+      nock(METABASE_URL)
+        .get('/api/dashboard/13')
+        .reply(200, mockMetabaseDashboardWithYearBarCard);
+      nock(METABASE_URL)
+        .post('/api/dashboard/13/dashcard/974/card/824/query')
+        .reply(200, mockYearBarCardQueryResult);
+
+      const response = await request(url)
+        .get('/dashboards/13-analyses/cards/974')
+        .use(tokenProvider(user));
+
+      expect(response.status).toBe(constants.HTTP_STATUS_OK);
+      expect(response.body).toMatchObject({
+        id: 974,
+        type: 'bar-chart',
+        labels: ['2021', '2022', '2023'],
+        data: [4200, 5100, 3800]
       });
     });
 

--- a/server/src/services/metabase/metabase-api.ts
+++ b/server/src/services/metabase/metabase-api.ts
@@ -35,6 +35,13 @@ function scaleForFormat(
   return format === 'percent' ? values.map((v) => v / 100) : values;
 }
 
+function formatLabel(value: unknown, unit: string | undefined): string {
+  if (unit === 'year' && typeof value === 'string') {
+    return value.slice(0, 4);
+  }
+  return String(value);
+}
+
 function extractAxisValues(
   data: MetabaseQueryResult,
   labelColumn: string | null,
@@ -48,9 +55,12 @@ function extractAxisValues(
     : -1;
   const xIndex = labelIdx !== -1 ? labelIdx : 0;
   const yIndex = valueIdx !== -1 ? valueIdx : 1;
+  const labelCol = data.data.cols[xIndex];
   const valueCol = data.data.cols[yIndex];
   return {
-    labels: data.data.rows.map((row) => String(row[xIndex])),
+    labels: data.data.rows.map((row) =>
+      formatLabel(row[xIndex], labelCol?.unit)
+    ),
     values: data.data.rows.map((row) => Number(row[yIndex])),
     valueName: valueCol?.display_name ?? valueCol?.name ?? ''
   };

--- a/server/src/services/metabase/metabase-normalize.ts
+++ b/server/src/services/metabase/metabase-normalize.ts
@@ -315,6 +315,7 @@ export function findDashcardRef(
       decimals: 0,
       tableColumns: null,
       labelMap: Object.keys(labelMap).length > 0 ? labelMap : null,
+      seriesName: null,
       dashboardParameters
     };
   }
@@ -322,6 +323,7 @@ export function findDashcardRef(
   if (normalized.type === 'bar-chart' || normalized.type === 'line-chart') {
     const { labelColumn, valueColumn } = resolveAxisColumns(settings);
     const { format, decimals } = detectColumnFormat(settings, valueColumn);
+    const effSettings = dashcardSettings(found);
     return {
       dashcardId: found.id,
       cardId: found.card_id,
@@ -338,6 +340,7 @@ export function findDashcardRef(
       decimals,
       tableColumns: null,
       labelMap: null,
+      seriesName: effSettings['graph.x_axis.title_text'] ?? null,
       dashboardParameters
     };
   }
@@ -354,6 +357,7 @@ export function findDashcardRef(
       decimals: 0,
       tableColumns: buildTableColumnRefs(settings),
       labelMap: null,
+      seriesName: null,
       dashboardParameters
     };
   }
@@ -369,6 +373,7 @@ export function findDashcardRef(
     decimals: 0,
     tableColumns: null,
     labelMap: null,
+    seriesName: null,
     dashboardParameters
   };
 }

--- a/server/src/services/metabase/metabase-service.ts
+++ b/server/src/services/metabase/metabase-service.ts
@@ -95,6 +95,7 @@ export interface MetabaseCol {
   name: string;
   display_name?: string;
   base_type?: string;
+  unit?: string;
 }
 
 export interface MetabaseQueryResult {

--- a/server/src/services/metabase/metabase-service.ts
+++ b/server/src/services/metabase/metabase-service.ts
@@ -49,6 +49,7 @@ export interface MetabaseDashcardVisualizationSettings {
   'table.columns'?: Array<{ name: string; enabled: boolean }>;
   'graph.dimensions'?: string[];
   'graph.metrics'?: string[];
+  'graph.x_axis.title_text'?: string;
   'pie.rows'?: MetabasePieRow[];
   column_settings?: Record<string, MetabaseColumnSettings>;
   // "Visualizer" dashcards nest their real settings (including the title /
@@ -134,6 +135,9 @@ export interface DashcardRef {
   // Pie charts: maps raw query keys (e.g. "APPART") to the PM-curated display
   // names from pie.rows (e.g. "Appartements"). Null for non-pie cards.
   labelMap: Readonly<Record<string, string>> | null;
+  // PM-curated series label (line/bar charts). When set, overrides the column
+  // display_name from the query result. Sourced from graph.x_axis.title_text.
+  seriesName: string | null;
   dashboardParameters: ReadonlyArray<DashboardParameter>;
 }
 

--- a/server/src/services/metabase/test/metabase-cache.test.ts
+++ b/server/src/services/metabase/test/metabase-cache.test.ts
@@ -47,6 +47,7 @@ function genDashcardRef(): DashcardRef {
     decimals: 0,
     tableColumns: null,
     labelMap: null,
+    seriesName: null,
     dashboardParameters: []
   };
 }

--- a/server/src/utils/excelUtils.ts
+++ b/server/src/utils/excelUtils.ts
@@ -111,7 +111,7 @@ function withColumnOptions<A extends Record<string, unknown>>(
 function createWorksheet<A extends Record<string, unknown>>(
   workbook: Workbook,
   options: WorksheetOptions<A>
-) {
+): WritableStream<unknown> {
   const { name, alternateColumnColors } = options;
   const columns = withColumnOptions(
     options.columns,


### PR DESCRIPTION
## Summary

- **Series name for visualizer dashcards**: Metabase "visualizer" dashcards map source columns to abstract names (`COLUMN_1`, `COLUMN_2`), causing the query result `display_name` (e.g. "Count Vacant Housing Private Fil Public", "Valeurs distinctes de Housing ID") to appear as the chart legend label. The PM-curated label is already stored in `graph.x_axis.title_text` inside the nested `visualization.settings`. `DashcardRef` now carries a `seriesName` field sourced from that setting, which takes precedence over the raw column name in bar and line chart responses.
- **Year-bucketed date labels**: Metabase returns year-bucketed dates as full ISO timestamps (e.g. `"2020-01-01T00:00:00Z"`). The column metadata includes `unit: "year"` to signal the bucketing granularity. `formatLabel()` now slices the year prefix when that unit is present, so labels render as `"2020"` instead of the raw timestamp.

## Test plan

- [x] `yarn nx test server -- dashboard-api.test.ts` — all 31 tests pass
- [x] `yarn nx typecheck server` — no type errors
- [x] On `/analyses/lutte`: bar chart "Logements contactés par année" shows `2020`, `2021`, … instead of `2020-01-01T00:00:00Z`
- [x] On `/analyses/lutte`: bar chart "Nombre de logements selon le statut de suivi" shows "Statuts de suivi" as the series label
- [x] On `/analyses/lutte`: line chart "Évolution du nombre de logements vacants depuis plus de 2 ans" shows "Années" as the series label

🤖 Generated with [Claude Code](https://claude.com/claude-code)