### PR TITLE
feat(server): deploy demo on prod push, fix seed sub_status

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,11 +27,20 @@ jobs:
       branch: prod
     secrets: inherit
 
-  deploy-queue-production:
+  deploy-front-demo:
     uses: ./.github/workflows/deploy.yml
     with:
-      app: Queue production
-      alias: queue-production
+      app: zlv-demo-front
+      alias: zlv-demo-front
+      branch: prod
+      environment: Demo
+    secrets: inherit
+
+  deploy-api-demo:
+    uses: ./.github/workflows/deploy.yml
+    with:
+      app: zlv-demo-api
+      alias: zlv-demo-api
       branch: prod
     secrets: inherit
 

--- a/.talismanrc
+++ b/.talismanrc
@@ -1,4 +1,6 @@
 fileignoreconfig:
+- filename: .github/workflows/release.yml
+  checksum: 5b3a281c32a6fab83c8385a64a45faddcac10f226b8daa85bdbf6a29d6b062a8
 - filename: README.md
   checksum: e9453f34a422b94f243daf56302141d9fc22cddf802423f64da72cee91c407d2
 - filename: analytics/dagster/src/assets/dwh/ingest/ingest_postgres_asset.py

--- a/packages/factories/src/factories/housing.ts
+++ b/packages/factories/src/factories/housing.ts
@@ -79,15 +79,19 @@ export function createHousingFactory(adapter: PersistenceAdapter) {
       Array.dedupe
     );
 
-    const status = faker.helpers.weightedArrayElement([
-      {
-        value: HousingStatus.NEVER_CONTACTED,
-        weight: HOUSING_STATUS_VALUES.length - 1
-      },
-      ...HOUSING_STATUS_VALUES.filter(
-        (s) => s !== HousingStatus.NEVER_CONTACTED
-      ).map((s) => ({ value: s, weight: 1 }))
-    ]);
+    // Honour an overridden status so the derived subStatus stays consistent
+    // with it (e.g. a NEVER_CONTACTED housing must have a null subStatus).
+    const status =
+      params.status ??
+      faker.helpers.weightedArrayElement([
+        {
+          value: HousingStatus.NEVER_CONTACTED,
+          weight: HOUSING_STATUS_VALUES.length - 1
+        },
+        ...HOUSING_STATUS_VALUES.filter(
+          (s) => s !== HousingStatus.NEVER_CONTACTED
+        ).map((s) => ({ value: s, weight: 1 }))
+      ]);
     const subStatuses = [...getSubStatuses(status)];
     const subStatus =
       subStatuses.length === 0 ? null : faker.helpers.arrayElement(subStatuses);

--- a/packages/factories/src/factories/test/housing.test.ts
+++ b/packages/factories/src/factories/test/housing.test.ts
@@ -1,3 +1,8 @@
+import {
+  getSubStatuses,
+  HOUSING_STATUS_VALUES,
+  HousingStatus
+} from '@zerologementvacant/models';
 import { describe, expect, it, vi } from 'vitest';
 
 import { MemoryAdapter } from '../../memory-adapter';
@@ -34,6 +39,33 @@ describe('createHousingFactory', () => {
       'housings',
       expect.objectContaining({ id: housing.id })
     );
+  });
+
+  it('generates a null subStatus when the status is "never contacted"', () => {
+    const factory = createHousingFactory(new MemoryAdapter());
+
+    const housings = factory.buildList(20, {
+      status: HousingStatus.NEVER_CONTACTED
+    });
+
+    expect(housings.every((housing) => housing.subStatus === null)).toBe(true);
+  });
+
+  it('derives subStatus from an overridden status', () => {
+    const factory = createHousingFactory(new MemoryAdapter());
+
+    HOUSING_STATUS_VALUES.forEach((status) => {
+      const allowed = getSubStatuses(status);
+      const housings = factory.buildList(20, { status });
+
+      housings.forEach((housing) => {
+        if (allowed.size === 0) {
+          expect(housing.subStatus).toBeNull();
+        } else {
+          expect(allowed.has(housing.subStatus as string)).toBe(true);
+        }
+      });
+    });
   });
 
   it('builds a list of housings', () => {


### PR DESCRIPTION
## Summary
- Honour an overridden `status` in the housing factory (`packages/factories`) so `subStatus` is derived from the resolved status. `NEVER_CONTACTED` has no sub-statuses, so its `subStatus` is now `null` — fixing the demo seed producing non-null `sub_status` for never-contacted housings. Mirrors the existing `geoCode` override pattern, so the fix applies to every caller.
- Add `deploy-front-demo` / `deploy-api-demo` jobs to `release.yml` so the demo env (`zlv-demo-front`, `zlv-demo-api`) redeploys on every push to `prod`. Reseeding is handled by the existing Clever Cloud post-deploy hooks.
- Remove the unused `deploy-queue-production` job (the queue app was deleted).

## Test plan
- [x] `yarn nx test factories` — new tests assert `subStatus` is `null` for `NEVER_CONTACTED` and valid for every overridden status (6 passing).
- [ ] After merge + push to `prod`, confirm the demo apps redeploy in the Clever Cloud / Actions logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)