### PR TITLE
fix(front): allow editing owners whose BAN address has a zero score

### DIFF
--- a/frontend/src/components/Owner/HousingOwnerEditionAside.tsx
+++ b/frontend/src/components/Owner/HousingOwnerEditionAside.tsx
@@ -10,6 +10,7 @@ import {
   INCORRECT_OWNER_RANK,
   PREVIOUS_OWNER_RANK
 } from '@zerologementvacant/models';
+import { Predicate } from 'effect';
 import { Controller, FormProvider, useForm } from 'react-hook-form';
 import { match, Pattern } from 'ts-pattern';
 import * as yup from 'yup';
@@ -82,9 +83,9 @@ function HousingOwnerEditionAside(props: HousingOwnerEditionAsideProps) {
       banAddress:
         housingOwner?.banAddress &&
         housingOwner.banAddress.banId &&
-        housingOwner.banAddress.score &&
-        housingOwner.banAddress.latitude &&
-        housingOwner.banAddress.longitude
+        Predicate.isNotNullable(housingOwner.banAddress.score) &&
+        Predicate.isNotNullable(housingOwner.banAddress.latitude) &&
+        Predicate.isNotNullable(housingOwner.banAddress.longitude)
           ? {
               id: housingOwner.banAddress.banId,
               label: housingOwner.banAddress.label,

--- a/frontend/src/views/Housing/test/HousingOwnersView.test.tsx
+++ b/frontend/src/views/Housing/test/HousingOwnersView.test.tsx
@@ -318,6 +318,53 @@ describe('HousingOwnersView', () => {
     expect(cell).toBeVisible();
   });
 
+  it('should set the primary owner as deceased even when their address has a score of zero', async () => {
+    const housing = genHousingDTO();
+    const [first, second] = [genOwnerDTO(), genOwnerDTO()];
+    const owners: ReadonlyArray<OwnerDTO> = [
+      { ...first, banAddress: { ...first.banAddress!, score: 0 } },
+      second
+    ];
+    const housingOwners: ReadonlyArray<HousingOwnerDTO> = [
+      { ...genHousingOwnerDTO(owners[0]), rank: 1 },
+      { ...genHousingOwnerDTO(owners[1]), rank: 2 }
+    ];
+
+    renderView({
+      housing,
+      owners,
+      housingOwners
+    });
+
+    const button = await screen.findByRole('button', {
+      name: `Éditer ${getOwnerDisplayName(owners[0])}`
+    });
+    await user.click(button);
+    const isActive = await screen.findByRole('checkbox', {
+      name: /Actuellement propriétaire/
+    });
+    await user.click(isActive);
+    const inactiveRank = await screen.findByRole('combobox', {
+      name: 'État du propriétaire'
+    });
+    await user.click(inactiveRank);
+    const deceased = await screen.findByRole('option', {
+      name: 'Propriétaire décédé'
+    });
+    await user.click(deceased);
+    const save = await screen.findByRole('button', {
+      name: 'Enregistrer'
+    });
+    await user.click(save);
+    const row = await screen.findByRole('row', {
+      name: new RegExp(`^${getOwnerDisplayName(owners[0])}`)
+    });
+    const cell = await within(row).findByRole('cell', {
+      name: 'Propriétaire décédé'
+    });
+    expect(cell).toBeVisible();
+  });
+
   it('should set a secondary owner as deceased', async () => {
     const housing = genHousingDTO();
     const owners: ReadonlyArray<OwnerDTO> = [genOwnerDTO(), genOwnerDTO()];


### PR DESCRIPTION
## Summary

Fixes a flaky CI failure in `HousingOwnersView` (e.g. `should set the primary owner as deceased`) that surfaced as `TestingLibraryElementError: Unable to find role="row" and name /^…/` and could not be reproduced reliably locally.

**Root cause (data-dependent, ~1% per run):**
- `genAddressDTO()` produces `score` as a float in `[0, 1]` → it is exactly `0` roughly 1 in 101 times.
- `HousingOwnerEditionAside` rebuilt the form's `banAddress` only when `score && latitude && longitude` were **truthy**, so a valid `0` collapsed the whole address to `null`.
- The save guard `if (housingOwner.banAddress && !payload.banAddress)` then set a "select an address" error and returned **without saving**.
- Because the save never completed, the edition drawer stayed open → MUI marks the page background `aria-hidden="true"` → the owners table leaves the accessibility tree → `findByRole('row', …)` can never match → 1.3s timeout.

This latently affected every edit-then-assert-row test in the file; it just happened to surface on the deceased test on CI, which runs the suite far more often than local runs.

**Fix:** treat the numeric BAN address fields as *present* (`Predicate.isNotNullable`) instead of *truthy*, so a `0` value no longer voids the address. This unblocks status changes (e.g. marking an owner deceased) without silently wiping the owner's address — which a `dirtyFields`-based guard gate alone would have done.

## Test plan

- [x] Added a deterministic regression test (`should set the primary owner as deceased even when their address has a score of zero`) — fails before the fix, passes after.
- [x] `HousingOwnersView.test.tsx` — 15/15 pass.
- [x] Ran the full file in a 60× loop: **0/60 failures** (previously reproduced within ~25 runs).
- [x] `yarn nx typecheck frontend` passes.
- [x] `oxlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)