### PR TITLE
Fix/group housing intercommunality filter

### DIFF
--- a/frontend/src/hooks/HousingFiltersContext.tsx
+++ b/frontend/src/hooks/HousingFiltersContext.tsx
@@ -76,6 +76,10 @@ export function HousingFiltersProvider({
             .toArray();
         }
 
+        if (next.localities?.length === 0) {
+          delete next.localities;
+        }
+
         return next;
       });
     },

--- a/frontend/src/hooks/test/HousingFiltersContext.test.tsx
+++ b/frontend/src/hooks/test/HousingFiltersContext.test.tsx
@@ -1,20 +1,35 @@
-import { act, renderHook } from '@testing-library/react';
-import { HousingStatus, Occupancy } from '@zerologementvacant/models';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import {
+  HousingStatus,
+  Occupancy,
+  UserRole,
+  type EstablishmentDTO
+} from '@zerologementvacant/models';
+import {
+  genEstablishmentDTO,
+  genUserDTO
+} from '@zerologementvacant/models/fixtures';
 import type { PropsWithChildren } from 'react';
 import { Provider as StoreProvider } from 'react-redux';
+
+import data from '~/mocks/handlers/data';
+import { fromEstablishmentDTO } from '~/models/Establishment';
+import { fromUserDTO, type AuthUser } from '~/models/User';
 
 import configureTestStore from '../../utils/storeUtils';
 import {
   HousingFiltersProvider,
   useHousingFilters
 } from '../HousingFiltersContext';
+import { useIntercommunalities } from '../useIntercommunalities';
 
 function createWrapper(
   initialFilters?: Parameters<
     typeof HousingFiltersProvider
-  >[0]['initialFilters']
+  >[0]['initialFilters'],
+  auth?: AuthUser
 ) {
-  const store = configureTestStore();
+  const store = configureTestStore(auth ? { auth } : undefined);
 
   // eslint-disable-next-line react/display-name
   return ({ children }: PropsWithChildren) => (
@@ -24,6 +39,14 @@ function createWrapper(
       </HousingFiltersProvider>
     </StoreProvider>
   );
+}
+
+function createAuthUser(establishment: EstablishmentDTO): AuthUser {
+  return {
+    accessToken: 'access-token',
+    establishment: fromEstablishmentDTO(establishment),
+    user: fromUserDTO(genUserDTO(UserRole.USUAL, establishment))
+  };
 }
 
 describe('HousingFiltersContext', () => {
@@ -139,6 +162,47 @@ describe('HousingFiltersContext', () => {
       });
 
       expect(result.current.filters.vacancyYears).toEqual(['2022']);
+    });
+
+    it('keeps locality filters unset when selecting an intercommunality without selected localities', async () => {
+      const department: EstablishmentDTO = {
+        ...genEstablishmentDTO(),
+        kind: 'DEP',
+        geoCodes: ['06004', '06012', '06088']
+      };
+      const intercommunality: EstablishmentDTO = {
+        ...genEstablishmentDTO(),
+        kind: 'CA',
+        geoCodes: ['06004', '06012']
+      };
+      data.establishments.push(department, intercommunality);
+
+      const { result } = renderHook(
+        () => ({
+          filters: useHousingFilters(),
+          intercommunalities: useIntercommunalities()
+        }),
+        {
+          wrapper: createWrapper(undefined, createAuthUser(department))
+        }
+      );
+
+      await waitFor(() => {
+        expect(result.current.intercommunalities.data).toContainEqual(
+          expect.objectContaining({ id: intercommunality.id })
+        );
+      });
+
+      act(() => {
+        result.current.filters.onChange({
+          intercommunalities: [intercommunality.id]
+        });
+      });
+
+      expect(result.current.filters.filters).toMatchObject({
+        intercommunalities: [intercommunality.id]
+      });
+      expect(result.current.filters.filters.localities).toBeUndefined();
     });
   });
 

--- a/frontend/src/utils/storeUtils.tsx
+++ b/frontend/src/utils/storeUtils.tsx
@@ -26,6 +26,7 @@ function configureTestStore(options?: Options) {
         isDsfrReady: true
       },
       authentication: {
+        authUser: options?.auth,
         logIn: options?.auth
           ? {
               data: options.auth,


### PR DESCRIPTION
Cette PR corrige le cas où les logements sélectionnés via un filtre d’intercommunalité n’étaient pas ajoutés au groupe.
Le problème venait de localities: [], envoyé dans le payload de création/ajout au groupe. Côté backend, ce filtre vide signifie explicitement “aucun logement”, alors que côté liste il était ignoré dans l’URL. Le fix supprime donc ce filtre vide avant l’envoi.
Côté tests, un test de régression a été ajouté pour couvrir la sélection d’une intercommunalité sans commune sélectionnée. Le helper de store de test a aussi été ajusté pour mieux refléter l’état d’auth réel utilisé par useIntercommunalities.