### PR TITLE
fix(analytics): dedupe CEREMA LOVAC unregistered users by email

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -10,7 +10,7 @@ fileignoreconfig:
 - filename: analytics/dagster/src/config.py
   checksum: 8f99243a8283bb0b5ea0f6513647557274a5da958684e68a9dc3b86b44974a5b
 - filename: analytics/dbt/models/marts/production/marts_production_cerema_lovac_users_unregistered.sql
-  checksum: 4f5752352d75a7a4f9504cb7f1495c2a2cec6725942a34fa7f572feef03436a0
+  checksum: db7ab30e098c757dbb98638392782d97f90c745fab9944d327d17060441dcaa4
 - filename: analytics/dbt/models/staging/external/cerema/stg_external_cerema_lovac_users.sql
   checksum: e6ccfed9e9dd6d2b53f3f00eb89a1cb574e516736d7f2122e53c2f820b2f81f9
 - filename: analytics/dagster/src/assets/populate_edited_owners_ban_addresses.py

--- a/analytics/dbt/models/marts/production/marts_production_cerema_lovac_users_unregistered.sql
+++ b/analytics/dbt/models/marts/production/marts_production_cerema_lovac_users_unregistered.sql
@@ -1,10 +1,22 @@
 {{ config(materialized='table') }}
 
-select *
-from {{ ref('stg_external_cerema_lovac_users') }}
-where email not in (
-    select email
-    from {{ ref('int_production_users') }}
-    where email is not null
+with unregistered as (
+    select *
+    from {{ ref('stg_external_cerema_lovac_users') }}
+    where email not in (
+        select email
+        from {{ ref('int_production_users') }}
+        where email is not null
+    )
+      and structure_acces_lovac is not null
 )
-  and structure_acces_lovac is not null
+
+-- A user (email) can be attached to several Portail DF structures, which yields
+-- several source rows. Keep one row per user to contact, favouring the structure
+-- with the most recent LOVAC access.
+select *
+from unregistered
+qualify row_number() over (
+    partition by email
+    order by structure_acces_lovac desc, structure_siret
+) = 1

--- a/analytics/dbt/models/marts/production/schema.yml
+++ b/analytics/dbt/models/marts/production/schema.yml
@@ -688,7 +688,7 @@ models:
     description: "LOVAC users from CEREMA Portail DF who do not yet have an account in ZLV — onboarding gap list refreshed monthly via Dagster."
     columns:
       - name: email
-        description: "Email of the LOVAC user from Portail DF. Unique within this mart since each user appears at most once in the source."
+        description: "Email of the LOVAC user from Portail DF. Deduplicated to one row per user (a user can be attached to several Portail DF structures); we keep the structure with the most recent LOVAC access."
         tests:
           - unique
           - not_null


### PR DESCRIPTION
## Summary

The `marts_production_cerema_lovac_users_unregistered` mart's `unique(email)` test was failing and breaking the Dagster pipeline.

**Root cause:** `stg_external_cerema_lovac_users` mirrors the raw source 1-to-1, and that source holds **one row per *rattachement*** (a user↔structure attachment). A user attached to several Portail DF structures therefore produces several rows sharing the same email. The mart did a plain `select *`, so those duplicates flowed through and tripped `unique(email)`.

**Fix:** collapse to one contact row per email with `QUALIFY ROW_NUMBER()`, keeping the structure with the most recent LOVAC access (`structure_acces_lovac desc`, `structure_siret` as a deterministic tie-break). Also corrected the `schema.yml` `email` description, which wrongly claimed *"each user appears at most once in the source."*

The `email` column is now genuinely unique, so the test passes and the intent — a distinct list of LOVAC users to contact — holds.

## Test plan

- [ ] `dbt build --select marts_production_cerema_lovac_users_unregistered` — model builds and `unique`/`not_null` tests on `email` pass
- [ ] Confirm the Dagster monthly refresh no longer fails on this test
- [ ] Spot-check that emails previously duplicated now appear exactly once

🤖 Generated with [Claude Code](https://claude.com/claude-code)