### PR TITLE
fix(schemas): stop bulk housing update from nulling sub-status

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -147,6 +147,8 @@ fileignoreconfig:
   checksum: d45082efb9f7475758beab81bb2d87f57bcb199d131648787d7541ecdfda3467
 - filename: docs/superpowers/specs/2026-06-13-reference-data-cache-design.md
   checksum: f08020ffee6beeda135a04955eeeb4a9be0a8e11cf98e8cd18327b67848ca7e2
+- filename: docs/superpowers/specs/2026-07-08-zlv-repair-harness-design.md
+  checksum: 3b78f0af3737a4b295511ab8998d4a0b441dac861846f034bf2f674bd5cc3277
 - filename: server/src/services/metabase/metabase-normalize.ts
   checksum: 1bd122150d2d7806ebf7cb708750814288d528fad4b3a1a3da0e1f9ae91f2f5d
 scopeconfig:

--- a/docs/superpowers/specs/2026-07-08-zlv-repair-harness-design.md
+++ b/docs/superpowers/specs/2026-07-08-zlv-repair-harness-design.md
@@ -1,0 +1,181 @@
+# ZLV Repair Harness — Design Spec
+
+**Date:** 2026-07-08
+**Status:** Approved
+
+## Problem
+
+The team repeatedly writes one-off scripts to bulk-correct housing data (status, sub-status, events). Each script reinvents the same scaffolding: chunking updates to stay under the Postgres parameter limit, wrapping everything in a transaction, collecting errors, providing a dry-run mechanism. The per-script logic (which housings to fix, what to change) is small; the boilerplate is large.
+
+Two recurring use cases drive this:
+
+1. **Business rule backfill** — historical data needs to reflect a new rule (e.g. reset housing to "Non suivi" if its campaign has no valid sending date).
+2. **Bug revert** — a system bug produced incorrect data and incorrect events (e.g. a bulk update that wiped `subStatus` to null, creating wrong `housing:status-updated` events).
+
+Bug reverts often require cleaning up the bad events as well as restoring the housing state, because downstream systems (LOVAC) read events and depend on their correctness.
+
+## Decision: data migrations vs repair harness
+
+**Deploy-coupled corrections** (small, predictable, bounded) stay in the existing Knex schema migration infrastructure — no new layer needed.
+
+**Manually-triggered bulk corrections** get the repair harness described here.
+
+## Decision: language and location
+
+Repairs live inside `server/` as TypeScript. They reuse the application's repository layer (`housingRepository`, `eventRepository`, `startTransaction()`), types (`HousingStatus`, `HousingEventApi`), and business logic. A Python or Dagster approach would require bypassing these abstractions and writing raw SQL, losing type safety and coupling.
+
+## Decision: imperative interface, not declarative config
+
+Each repair is a TypeScript file implementing a typed interface (`query` + `decide`). Query conditions are always multi-conditional and diverse; a declarative DSL would quickly become an underpowered reimplementation of SQL + TypeScript. The value is in the shared scaffold, not in abstracting away the logic.
+
+## Architecture
+
+```
+server/src/scripts/repairs/
+  lib/
+    types.ts        # Repair<H>, RepairAction, RepairSkip, RepairError, PlanRow
+    plan.ts         # query → decide → write plan.jsonl + errors.jsonl
+    apply.ts        # read plan.jsonl → chunk → transaction → commit
+  index.ts          # repair registry — imports and exports all repair definitions
+  cli.ts            # zlv repair subcommand (commander), reads from index.ts
+  campaign-sending-date.ts
+  sub-status-bug-revert.ts
+  ...
+
+server/src/bin/
+  zlv.ts            # top-level zlv binary entry point, registers repair subcommand
+```
+
+Repairs are registered by adding them to `index.ts`. The CLI resolves `<name>` against this registry at runtime. Adding a new repair = create the file + add one line to `index.ts`.
+
+The existing `fix-housing-sub-status/` script is not migrated — it predates this harness and is already deployed.
+
+## Core interface
+
+```typescript
+interface Repair<H extends HousingApi = HousingApi> {
+  name: string;
+  query(): Promise<H[]>;
+  decide(housing: H): RepairAction | RepairSkip | RepairError;
+}
+
+interface RepairAction {
+  update?: Partial<
+    Pick<HousingApi, 'status' | 'subStatus' | 'occupancy' | 'occupancyIntended'>
+  >;
+  createEvents?: HousingEventApi[]; // optional, must be explicitly set
+  deleteEventIds?: string[]; // hard-deleted from DB
+}
+
+interface RepairSkip {
+  action: 'skip';
+}
+interface RepairError {
+  action: 'error';
+  reason: string;
+}
+```
+
+`Repair<H>` is generic on `H` — what `query()` returns. This lets a repair fetch housings plus associated data (events, campaigns) in a single query and receive it fully typed in `decide()`.
+
+Example — simple field update:
+
+```typescript
+// H = HousingApi
+decide(housing) {
+  return { update: { status: HousingStatus.NEVER_CONTACTED, subStatus: null } }
+}
+```
+
+Example — event-aware bug revert:
+
+```typescript
+// H = HousingApi & { events: HousingEventApi[] }
+decide(housing) {
+  const bad = housing.events.find(e => e.nextNew.subStatus === null && e.nextOld.subStatus !== null)
+  if (!bad) return { action: 'skip' }
+  return { update: { subStatus: bad.nextOld.subStatus }, deleteEventIds: [bad.id] }
+}
+```
+
+## CLI
+
+The `zlv` binary is a new `commander`-based entry point in `server/`. `repair` is its first command group.
+
+```bash
+zlv repair list                          # list registered repairs
+zlv repair plan <name> [--out plan.jsonl]  # generate plan + errors files
+zlv repair stats <plan-file>             # summarise plan without touching DB
+zlv repair apply <plan-file>             # apply atomically
+```
+
+The naming mirrors Terraform (`plan` / `apply`) to make the intent immediately clear.
+
+## Execution flow
+
+### `zlv repair plan <name>`
+
+1. Load the repair definition by name.
+2. Call `query()` → array of `H`.
+3. For each housing, call `decide()`:
+   - `RepairAction` → written to `plan.jsonl`
+   - `RepairSkip` → silently omitted
+   - `RepairError` → written to `errors.jsonl`
+4. Print summary: N housings to update, N events to delete, N events to create, M errors.
+
+### `zlv repair apply <plan-file>`
+
+1. Read `plan.jsonl`.
+2. Group rows by update payload (to batch housings sharing the same target state).
+3. Chunk each group to 1000 housings per batch (Postgres parameter limit safety).
+4. Within a single transaction:
+   - `housingRepository.updateMany()` per chunk
+   - `eventRepository.deleteMany(deleteEventIds)` for all deletions
+   - `eventRepository.insertManyHousingEvents(createEvents)` if any
+5. Print result counts. On any failure the transaction rolls back fully.
+
+## Plan file format
+
+`plan.jsonl` — one JSON object per line:
+
+```jsonl
+{"housingId":"abc","housingGeoCode":"75056","update":{"status":0,"subStatus":null}}
+{"housingId":"def","housingGeoCode":"69123","update":{"subStatus":"Sortie de la vacance"},"deleteEventIds":["evt-1"]}
+{"housingId":"ghi","housingGeoCode":"13055","update":{"status":0},"createEvents":[{"type":"housing:status-updated","nextOld":{...},"nextNew":{...}}]}
+```
+
+`errors.jsonl` — same shape plus `reason`:
+
+```jsonl
+{
+  "housingId": "xyz",
+  "housingGeoCode": "31000",
+  "reason": "no restorable event found"
+}
+```
+
+The plan file is the dry-run artifact. It is independent of the repair definition — it can be inspected with `jq`, edited, filtered, or split before `apply` is run.
+
+## Event handling
+
+- **Hard-delete:** bad events (produced by system bugs) are hard-deleted. They are incorrect facts, not user actions to be reversed. Compensating events are not used — downstream systems (LOVAC) read events for correctness and a compensating event would leave wrong data in place.
+- **Create events:** optional and explicit. Set `createEvents` in `RepairAction` when the correction should be visible in the housing timeline (e.g. a status change that represents a real state transition). Omit for silent data fixes.
+- **Soft-delete / void:** not implemented. Hard-delete is sufficient; the audit trail of what happened is in git history and the repair script itself.
+
+## Error handling
+
+- `plan` errors go to `errors.jsonl` for manual review; they do not block the plan run.
+- `apply` runs in a single transaction. Any failure rolls back everything — no partial apply. The plan file is untouched and the run can be retried.
+- Editing `plan.jsonl` before `apply` (removing rows, correcting values) is explicitly supported.
+
+## Testing
+
+- Each repair definition (`query` + `decide`) is unit-tested in isolation: pass a constructed housing, assert the returned `RepairAction`.
+- The shared scaffold (`plan`, `apply`) has integration tests against the test DB.
+- No mocking of the DB in integration tests (consistent with project testing standards).
+
+## What this does not cover
+
+- Streaming / incremental application for very large datasets (millions of rows). Current repair use cases are hundreds to low thousands of housings.
+- Scheduled / automated execution. Repairs are always manually triggered by a developer.
+- A UI for non-developers. Repairs are a developer tool.

--- a/docs/superpowers/specs/2026-07-08-zlv-repair-harness-design.md
+++ b/docs/superpowers/specs/2026-07-08-zlv-repair-harness-design.md
@@ -119,9 +119,9 @@ The naming mirrors Terraform (`plan` / `apply`) to make the intent immediately c
 2. Call `query()` → array of `H`.
 3. For each housing, call `decide()`:
    - `RepairAction` → written to `plan.jsonl`
-   - `RepairSkip` → silently omitted
+   - `RepairSkip` → written to `skipped.jsonl`
    - `RepairError` → written to `errors.jsonl`
-4. Print summary: N housings to update, N events to delete, N events to create, M errors.
+4. Print summary: N housings to update, N skipped, N events to delete, N events to create, M errors.
 
 ### `zlv repair apply <plan-file>`
 
@@ -144,7 +144,16 @@ The naming mirrors Terraform (`plan` / `apply`) to make the intent immediately c
 {"housingId":"ghi","housingGeoCode":"13055","update":{"status":0},"createEvents":[{"type":"housing:status-updated","nextOld":{...},"nextNew":{...}}]}
 ```
 
-`errors.jsonl` — same shape plus `reason`:
+`skipped.jsonl` — housings `decide()` chose to leave untouched:
+
+```jsonl
+{
+  "housingId": "uvw",
+  "housingGeoCode": "75056"
+}
+```
+
+`errors.jsonl` — housings `decide()` could not handle, with reason:
 
 ```jsonl
 {

--- a/packages/schemas/src/housing-batch-update-payload.ts
+++ b/packages/schemas/src/housing-batch-update-payload.ts
@@ -23,23 +23,30 @@ export const housingBatchUpdatePayload: ObjectSchema<HousingBatchUpdatePayload> 
           status !== undefined &&
           isHousingStatus(status) &&
           getSubStatuses(status).size === 0,
-        then: (schema) => schema.transform(() => null),
+        then: (schema) => schema.transform(() => null).default(null),
         otherwise: (schema) =>
           schema.test({
             name: 'sub-status-coherence',
             test(value) {
-              if (value === null || value === undefined) return true;
               const { status } = this.parent as { status?: number };
+              // No status set in this payload: leave the sub-status untouched.
               if (status === undefined || !isHousingStatus(status)) return true;
+              // A valid status reaching the `otherwise` branch necessarily has
+              // sub-statuses (statuses without any go through `then`), so a
+              // sub-status is required here.
               const validSubStatuses = getSubStatuses(status);
+              if (value === null || value === undefined) {
+                return this.createError({
+                  message: `Le statut de suivi sélectionné requiert un sous-statut. Sous-statuts possibles : ${[...validSubStatuses].join(', ')}`
+                });
+              }
               if (validSubStatuses.has(value)) return true;
               return this.createError({
                 message: `Le sous-statut "${value}" n\u2019est pas coh\u00e9rent avec le statut de suivi. Sous-statuts possibles\u00a0: ${[...validSubStatuses].join(', ')}`
               });
             }
           })
-      })
-      .default(null),
+      }),
     occupancy: string().oneOf(OCCUPANCY_VALUES).optional(),
     occupancyIntended: string().oneOf(OCCUPANCY_VALUES).optional(),
     note: string().trim().min(1).optional(),

--- a/packages/schemas/src/housing-batch-update-payload.ts
+++ b/packages/schemas/src/housing-batch-update-payload.ts
@@ -29,8 +29,20 @@ export const housingBatchUpdatePayload: ObjectSchema<HousingBatchUpdatePayload> 
             name: 'sub-status-coherence',
             test(value) {
               const { status } = this.parent as { status?: number };
-              // No status set in this payload: leave the sub-status untouched.
-              if (status === undefined || !isHousingStatus(status)) return true;
+              if (status === undefined) {
+                // A sub-status has no meaning without a status to attach it to:
+                // an omitted sub-status is a no-op, but a provided one (a value
+                // or an explicit null) is rejected.
+                if (value !== undefined) {
+                  return this.createError({
+                    message:
+                      'Un sous-statut ne peut pas être défini sans statut de suivi.'
+                  });
+                }
+                return true;
+              }
+              // An invalid status is rejected by the `status` field itself.
+              if (!isHousingStatus(status)) return true;
               // A valid status reaching the `otherwise` branch necessarily has
               // sub-statuses (statuses without any go through `then`), so a
               // sub-status is required here.

--- a/packages/schemas/src/test/housing-batch-update-payload.test.ts
+++ b/packages/schemas/src/test/housing-batch-update-payload.test.ts
@@ -203,4 +203,22 @@ describe('Housing batch update payload', () => {
 
     expect(actual.subStatus).toBeNull();
   });
+
+  it('should reject a sub-status provided without a status', () => {
+    expect(() =>
+      housingBatchUpdatePayload.validateSync({
+        filters: { all: false },
+        subStatus: 'En accompagnement'
+      })
+    ).toThrow(ValidationError);
+  });
+
+  it('should reject an explicit null sub-status provided without a status', () => {
+    expect(() =>
+      housingBatchUpdatePayload.validateSync({
+        filters: { all: false },
+        subStatus: null
+      })
+    ).toThrow(ValidationError);
+  });
 });

--- a/packages/schemas/src/test/housing-batch-update-payload.test.ts
+++ b/packages/schemas/src/test/housing-batch-update-payload.test.ts
@@ -104,8 +104,9 @@ const validStatusSubStatusArb = fc.oneof(
     )
     .chain((status) => {
       const validSubs = [...getSubStatuses(status)];
+      // A sub-status-requiring status must always carry a valid sub-status.
       return fc
-        .option(fc.constantFrom(...validSubs), { nil: undefined })
+        .constantFrom(...validSubs)
         .map((subStatus) => ({ status, subStatus }));
     })
 );
@@ -174,5 +175,32 @@ describe('Housing batch update payload', () => {
         subStatus: 'some-sub-status'
       })
     ).toThrow(ValidationError);
+  });
+
+  it('should leave the sub-status untouched (undefined) when both status and sub-status are omitted', () => {
+    const actual = housingBatchUpdatePayload.validateSync({
+      filters: { all: false },
+      note: 'Just a note'
+    });
+
+    expect(actual.subStatus).toBeUndefined();
+  });
+
+  it('should require a sub-status when the status requires one but none is provided', () => {
+    expect(() =>
+      housingBatchUpdatePayload.validateSync({
+        filters: { all: false },
+        status: HousingStatus.IN_PROGRESS
+      })
+    ).toThrow(ValidationError);
+  });
+
+  it('should force the sub-status to null when the status has no sub-statuses even if the sub-status is omitted', () => {
+    const actual = housingBatchUpdatePayload.validateSync({
+      filters: { all: false },
+      status: HousingStatus.NEVER_CONTACTED
+    });
+
+    expect(actual.subStatus).toBeNull();
   });
 });

--- a/server/src/controllers/test/housing-api.test.ts
+++ b/server/src/controllers/test/housing-api.test.ts
@@ -1053,16 +1053,11 @@ describe('Housing API', () => {
                   )
                   .chain((status) => {
                     const validSubs = [...getSubStatuses(status)];
-                    const subStatusArb =
-                      validSubs.length > 0
-                        ? fc.option(fc.constantFrom(...validSubs), {
-                            nil: undefined
-                          })
-                        : fc.constant(undefined as string | undefined);
-                    return subStatusArb.map((subStatus) => ({
-                      status,
-                      subStatus
-                    }));
+                    // A sub-status-requiring status must always carry a
+                    // valid sub-status.
+                    return fc
+                      .constantFrom(...validSubs)
+                      .map((subStatus) => ({ status, subStatus }));
                   })
               )
               .map((ss) => ({ ...base, ...ss }))
@@ -1084,6 +1079,21 @@ describe('Housing API', () => {
         filters: { all: false },
         status: HousingStatus.IN_PROGRESS,
         subStatus: 'invalid-sub-status'
+      };
+
+      const { status } = await request(url)
+        .put(testRoute)
+        .send(payload)
+        .type('json')
+        .use(tokenProvider(user));
+
+      expect(status).toBe(constants.HTTP_STATUS_BAD_REQUEST);
+    });
+
+    it('should return 400 when the status requires a sub-status but none is provided', async () => {
+      const payload: HousingBatchUpdatePayload = {
+        filters: { all: false },
+        status: HousingStatus.IN_PROGRESS
       };
 
       const { status } = await request(url)
@@ -1197,6 +1207,46 @@ describe('Housing API', () => {
         status: payload.status,
         subStatus: null
       });
+    });
+
+    it('should not touch the sub-status nor create a status event when only a note is added', async () => {
+      const { housings } = await createHousings({
+        status: HousingStatus.IN_PROGRESS,
+        subStatus: 'En accompagnement'
+      });
+      const payload: HousingBatchUpdatePayload = {
+        filters: {
+          all: false,
+          housingIds: housings.map((housing) => housing.id)
+        },
+        note: 'Une note ajoutee sans changement de statut'
+      };
+
+      const { status } = await request(url)
+        .put(testRoute)
+        .send(payload)
+        .type('json')
+        .use(tokenProvider(user));
+
+      expect(status).toBe(constants.HTTP_STATUS_OK);
+      const actual = await Housing().whereIn(
+        ['geo_code', 'id'],
+        housings.map((housing) => [housing.geoCode, housing.id])
+      );
+      actual.forEach((housing) => {
+        expect(housing).toMatchObject<Partial<HousingRecordDBO>>({
+          status: HousingStatus.IN_PROGRESS,
+          sub_status: 'En accompagnement'
+        });
+      });
+      const events = await Events()
+        .join(HOUSING_EVENTS_TABLE, 'event_id', 'id')
+        .whereIn(
+          ['housing_geo_code', 'housing_id'],
+          housings.map((housing) => [housing.geoCode, housing.id])
+        )
+        .where({ type: 'housing:status-updated' });
+      expect(events).toEqual([]);
     });
 
     it('should create events related to the status change', async () => {
@@ -1577,7 +1627,8 @@ describe('Housing API', () => {
             housingIds: housings.map((housing) => housing.id)
           },
           documents: [document.id],
-          status: HousingStatus.IN_PROGRESS
+          status: HousingStatus.IN_PROGRESS,
+          subStatus: 'En accompagnement'
         } satisfies HousingBatchUpdatePayload)
         .use(tokenProvider(user));
 
@@ -1620,6 +1671,7 @@ describe('Housing API', () => {
             housingIds: [housings[0].id]
           },
           status: HousingStatus.IN_PROGRESS,
+          subStatus: 'En accompagnement',
           note: 'Batch update with docs',
           documents: [document.id]
         } satisfies HousingBatchUpdatePayload)
@@ -1651,6 +1703,7 @@ describe('Housing API', () => {
             housingIds: [housings[0].id]
           },
           status: HousingStatus.IN_PROGRESS,
+          subStatus: 'En accompagnement',
           documents: []
         } satisfies HousingBatchUpdatePayload)
         .use(tokenProvider(user));

--- a/server/src/controllers/test/housing-api.test.ts
+++ b/server/src/controllers/test/housing-api.test.ts
@@ -1105,6 +1105,21 @@ describe('Housing API', () => {
       expect(status).toBe(constants.HTTP_STATUS_BAD_REQUEST);
     });
 
+    it('should return 400 when a sub-status is provided without a status', async () => {
+      const payload: HousingBatchUpdatePayload = {
+        filters: { all: false },
+        subStatus: null
+      };
+
+      const { status } = await request(url)
+        .put(testRoute)
+        .send(payload)
+        .type('json')
+        .use(tokenProvider(user));
+
+      expect(status).toBe(constants.HTTP_STATUS_BAD_REQUEST);
+    });
+
     it('should be forbidden to set status "NeverContacted" for housings that have already been contacted', async () => {
       const { housings } = await createHousings({
         status: HousingStatus.WAITING


### PR DESCRIPTION
## Summary

In the housing bulk-edit side menu, updating a batch while leaving status/sub-status empty (e.g. only adding a note) silently wiped every selected housing's `sub_status` to `NULL` and emitted a spurious `housing:status-updated` event — corrupting housings whose status requires a sub-status. The `fix-housing-sub-status` repair script found this fingerprint on ~1,557 of 1,618 damaged housings.

**Root cause (server-side only — the frontend already omits an untouched sub-status):** the batch-update schema ended with `.default(null)` on `subStatus`. The request validator `validateSync`-casts the body, so an *omitted* sub-status became `null`, which the repository persisted and the controller diff turned into a status event.

A naive "drop `.default(null)`" would have broken intentional clearing: Yup 1.7.1 **skips custom transforms when the input is `undefined`** (`_cast`), so the `.when(...).transform(() => null)` branch never fires on an omitted field — the null-clear relies on the default.

## What changed (`packages/schemas/src/housing-batch-update-payload.ts`)

- **Move `.default(null)` into the no-sub-status branch of the `.when()`.** An omitted sub-status stays `undefined` → the repository skips it (no-op). Setting a status that takes no sub-status (`NeverContacted`/`Waiting`) still clears it to `null`.
- **Require a sub-status when the payload sets a status that has sub-statuses** (defense-in-depth matching the frontend, which already `.required()`s it).
- **Reject a sub-status provided without a status.** A sub-status is meaningful only relative to a status, so a value — or an explicit `null` — without a `status` is a 400. This closes the last vector for the original bug (an explicit `subStatus: null` with no status would otherwise still null the column + emit an event).

Behaviour by case (keyed on the payload's `status`):

| Payload `status` | Payload `subStatus` | Result |
|---|---|---|
| absent | absent | untouched (no-op) — the bug |
| absent | value or explicit `null` | **400** (a sub-status needs a status) |
| `null` / invalid number | any | 400 (rejected by the `status` field) |
| no-sub (NeverContacted/Waiting) | absent or any | → `null` |
| sub-requiring | valid | kept |
| sub-requiring | invalid | 400 |
| sub-requiring | absent | 400 (required) |

No frontend change needed — `HousingListTab` maps an untouched sub-status to `undefined`, and `HousingEditionMobilizationTab` disables/requires the field per status.

Independent of the `fix/housing-sub-status` repair branch (that cleans up existing damage; this stops recurrence).

## Test plan

- [x] `yarn nx test schemas` — property + unit tests (omitted → `undefined`; NeverContacted → `null`; sub-requiring without sub → throws; sub-status without status → throws, value and explicit `null`)
- [x] `yarn nx test server` — `housing-api.test.ts` (65 passed): note-only update leaves sub-status untouched & emits no status event; sub-requiring status without sub → 400; sub-status without status → 400
- [x] `yarn nx typecheck schemas server`
- [x] `yarn lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)