### PR TITLE
fix(frontend): prevent housing list search tooltip from overflowing off-screen

### DIFF
--- a/frontend/src/views/HousingList/HousingListView.tsx
+++ b/frontend/src/views/HousingList/HousingListView.tsx
@@ -163,7 +163,7 @@ const HousingListView = () => {
                   />
                 </Stack>
                 <Tooltip
-                  align="start"
+                  align="end"
                   place="bottom"
                   title="Pour retrouver une liste de logements, copiez-collez dans la barre de recherche la liste de leurs identifiants fiscaux séparés par un espace. Exemple : « 750123456789 750123456790 750123456791 »"
                 />


### PR DESCRIPTION
## What

The help tooltip (`?` icon) next to the search bar in the housing list (**Parc de Logements**) overflowed off the right edge of the screen on hover.

Before → after: the tooltip now opens leftward and stays fully on screen.

## Why

The tooltip was forced into manual placement with `align="start"` + `place="bottom"`. Because the `?` icon sits near the right edge of the viewport (between the search bar and the Tableau/Carte switch), `align="start"` made the bubble grow *rightward* and run off screen. Forcing manual placement also disables DSFR's native collision detection, so it could never self-correct.

## How

Single-line change in `HousingListView.tsx`: `align="start"` → `align="end"`, so the tooltip aligns by its right edge and expands leftward. This matches the pattern already used by the tooltip in `HousingHeader.tsx`, which is similarly positioned near the right edge.

## Testing

- Verified locally on `/parc-de-logements`: hovering the `?` icon opens the tooltip toward the left, fully within the viewport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)