### PR TITLE
docs: mandate full RGAA accessibility compliance for frontend work

### DIFF
--- a/.claude/rules/rgaa-accessibility.md
+++ b/.claude/rules/rgaa-accessibility.md
@@ -29,143 +29,208 @@ tableau, navigation, contenu, style) :
   refactoring ou d'une intégration Figma (voir
   [figma-design-system.md](figma-design-system.md)).
 
-## Source de référence (canonique)
+## Source de référence (canonique) et fiabilité de cette liste
 
 Référentiel officiel : <https://accessibilite.numerique.gouv.fr/methode/criteres-et-tests/>
 
-Version en vigueur au moment de la rédaction de ce fichier : **RGAA 4.1.2**
-(déclinaison française de WCAG 2.1 niveau AA), organisée en **13 thématiques**
-et **106 critères de contrôle**, eux-mêmes décomposés en tests élémentaires.
+**Version : RGAA 4.1.2** (tag `v4.1.2`, dernière version publiée), déclinaison
+française de WCAG 2.1 niveau AA — **13 thématiques, 106 critères de contrôle,
+693 tests élémentaires**.
 
-**Important — numérotation exacte :** la numérotation précise des critères
-(ex. « critère 7.3 ») peut varier d'une version du RGAA à l'autre, et les
-outils de résumé automatique ne restituent pas toujours l'intégralité de la
-page de référence de façon fiable. Par conséquent :
+La liste ci-dessous a été **validée le 2026-07-08 directement depuis les
+données JSON sources faisant autorité** du dépôt officiel
+(`RGAA/criteres.json` dans
+[DISIC/accessibilite.numerique.gouv.fr](https://github.com/DISIC/accessibilite.numerique.gouv.fr)),
+et non depuis un résumé généré par un outil de fetch web (ces résumés se sont
+révélés incohérents d'un appel à l'autre lors de la rédaction de ce
+document — ne jamais leur faire confiance pour ce niveau de précision).
+Les 106 titres de critères ci-dessous sont donc le **texte officiel exact**,
+et les totaux (13 / 106 / 693) ont été vérifiés par calcul sur le JSON source,
+pas estimés.
 
-- Tu dois connaître **le fond de chaque règle par cœur** (ce qui suit dans ce
-  document) — c'est ce qui doit guider ton code au quotidien, sans avoir à
-  consulter une page à chaque ligne écrite.
-- Si tu dois **citer un numéro de critère précis** dans un document formel
-  (rapport d'audit, description de PR, commentaire de revue officiel),
-  **revérifie-le** via WebFetch/WebSearch sur l'URL ci-dessus plutôt que de
-  te fier à un numéro mémorisé — ne jamais inventer ou approximer un numéro
-  de critère dans un livrable destiné à être cité comme référence.
-- L'absence de certitude sur un numéro exact n'est **jamais** une excuse pour
-  ignorer la règle de fond correspondante.
+**Cela signifie que tu peux citer un numéro de critère (ex. « critère 7.3 »)
+directement depuis cette liste, avec confiance.** Le seul cas où il faut
+revérifier à la source : si une nouvelle version majeure du RGAA succède à la
+4.1.2 (auquel cas cette liste devient un instantané historique à mettre à
+jour — voir la date de validation ci-dessus).
 
-## Les 13 thématiques du RGAA — checklist obligatoire
+## Les 106 critères RGAA — liste officielle complète, par thématique
 
-Pour chaque changement frontend, passe en revue mentalement ces 13 axes.
-Chaque ligne ci-dessous est une reformulation opérationnelle des critères
-officiels, applicable directement dans le contexte DSFR/MUI/React de ce repo.
+Pour chaque changement frontend, passe en revue mentalement les 13
+thématiques. Chaque section donne le **texte officiel exact** des critères
+(faisant autorité) puis, quand utile, une **application concrète** dans le
+contexte DSFR/MUI/React de ce repo.
 
-### 1. Images
-- Toute image informative (`<img>`, `background-image` porteuse de sens,
-  icône SVG cliquable) a une alternative textuelle pertinente (`alt`,
-  `aria-label`, ou équivalent).
-- Toute image décorative a `alt=""` (jamais d'`alt` absent) ou
-  `aria-hidden="true"`, et n'est jamais focusable.
-- Les images complexes (graphiques, cartes) ont une description détaillée
-  accessible à proximité, pas seulement dans l'`alt`.
-- Ne jamais utiliser une image pour représenter du texte quand une vraie
-  balise texte stylée peut faire l'affaire.
+### 1. Images (9 critères)
+1.1 — Chaque image porteuse d'information a-t-elle une alternative textuelle ?
+1.2 — Chaque image de décoration est-elle correctement ignorée par les technologies d'assistance ?
+1.3 — Pour chaque image porteuse d'information ayant une alternative textuelle, cette alternative est-elle pertinente (hors cas particuliers) ?
+1.4 — Pour chaque image utilisée comme CAPTCHA ou comme image-test, ayant une alternative textuelle, cette alternative permet-elle d'identifier la nature et la fonction de l'image ?
+1.5 — Pour chaque image utilisée comme CAPTCHA, une solution d'accès alternatif au contenu ou à la fonction du CAPTCHA est-elle présente ?
+1.6 — Chaque image porteuse d'information a-t-elle, si nécessaire, une description détaillée ?
+1.7 — Pour chaque image porteuse d'information ayant une description détaillée, cette description est-elle pertinente ?
+1.8 — Chaque image texte porteuse d'information, en l'absence d'un mécanisme de remplacement, doit si possible être remplacée par du texte stylé. Cette règle est-elle respectée (hors cas particuliers) ?
+1.9 — Chaque légende d'image est-elle, si nécessaire, correctement reliée à l'image correspondante ?
 
-### 2. Cadres (iframes)
-- Chaque `<iframe>` a un attribut `title` explicite et pertinent décrivant
-  son contenu/fonction (ex. carte, lecteur vidéo, widget tiers).
+**Application concrète :** `alt` pertinent sur toute `<img>`/icône SVG porteuse de sens ; `alt=""` (jamais absent) sur le décoratif ; jamais de texte représenté en image quand une balise texte stylée suffit.
 
-### 3. Couleurs
-- L'information ne doit **jamais** être portée par la couleur seule (ex. un
-  statut rouge/vert doit aussi avoir un texte, une icône ou un motif).
-- Tout élément recevant un effet de contraste (lien souligné au survol,
-  focus, état actif) reste perceptible même sans distinction de couleur.
+### 2. Cadres (2 critères)
+2.1 — Chaque cadre a-t-il un titre de cadre ?
+2.2 — Pour chaque cadre ayant un titre de cadre, ce titre de cadre est-il pertinent ?
 
-### 4. Multimédia
-- Toute vidéo/audio préenregistré a, si nécessaire, transcription textuelle,
-  sous-titres et/ou audiodescription pertinents.
-- Aucun contenu ne doit clignoter/flasher de façon susceptible de déclencher
-  une crise d'épilepsie photosensible.
+**Application concrète :** tout `<iframe>` a un `title` explicite décrivant son contenu (carte, lecteur vidéo, widget tiers).
 
-### 5. Tableaux
-- Tout tableau de données a un titre (`<caption>` ou équivalent accessible)
-  pertinent.
-- Structure correcte : en-têtes `<th scope="col"|"row">`, pas de tableau
-  utilisé à des fins de mise en page.
+### 3. Couleurs (3 critères)
+3.1 — Dans chaque page web, l'information ne doit pas être donnée uniquement par la couleur. Cette règle est-elle respectée ?
+3.2 — Dans chaque page web, le contraste entre la couleur du texte et la couleur de son arrière-plan est-il suffisamment élevé (hors cas particuliers) ?
+3.3 — Dans chaque page web, les couleurs utilisées dans les composants d'interface ou les éléments graphiques porteurs d'informations sont-elles suffisamment contrastées (hors cas particuliers) ?
 
-### 6. Liens
-- Tout lien est explicite hors contexte : jamais « cliquer ici », « en savoir
-  plus » sans contexte associé (utiliser `aria-label`/`aria-labelledby` si le
-  libellé visuel est insuffisant).
-- Deux liens au texte identique mais menant à des destinations différentes
-  doivent être distingués (libellé ou attribut accessible).
+**Application concrète :** un statut ne se distingue jamais par la couleur seule (texte/icône/motif en plus) ; contraste texte ≥ 4.5:1 (≥ 3:1 pour grand texte), et ≥ 3:1 pour les composants d'interface/icônes porteurs de sens.
 
-### 7. Scripts
-- Tout composant interactif en JS (dropdown, accordéon, modale, DSFR
-  `Modal`, tabs) reste **entièrement utilisable au clavier** (Tab, Shift+Tab,
-  Entrée, Espace, Échap, flèches si composite widget) et expose les rôles/
-  états ARIA corrects (`role`, `aria-expanded`, `aria-selected`,
-  `aria-modal`, etc.).
-- Tout contenu généré dynamiquement et pertinent pour l'utilisateur (message
-  d'erreur, résultat de recherche, toast) doit être annoncé aux technologies
-  d'assistance (`aria-live`, focus management), pas seulement affiché
-  visuellement.
+### 4. Multimédia (13 critères)
+4.1 — Chaque média temporel pré-enregistré a-t-il, si nécessaire, une transcription textuelle ou une audiodescription (hors cas particuliers) ?
+4.2 — Pour chaque média temporel pré-enregistré ayant une transcription textuelle ou une audiodescription synchronisée, celles-ci sont-elles pertinentes (hors cas particuliers) ?
+4.3 — Chaque média temporel synchronisé pré-enregistré a-t-il, si nécessaire, des sous-titres synchronisés (hors cas particuliers) ?
+4.4 — Pour chaque média temporel synchronisé pré-enregistré ayant des sous-titres synchronisés, ces sous-titres sont-ils pertinents ?
+4.5 — Chaque média temporel pré-enregistré a-t-il, si nécessaire, une audiodescription synchronisée (hors cas particuliers) ?
+4.6 — Pour chaque média temporel pré-enregistré ayant une audiodescription synchronisée, celle-ci est-elle pertinente ?
+4.7 — Chaque média temporel est-il clairement identifiable (hors cas particuliers) ?
+4.8 — Chaque média non temporel a-t-il, si nécessaire, une alternative (hors cas particuliers) ?
+4.9 — Pour chaque média non temporel ayant une alternative, cette alternative est-elle pertinente ?
+4.10 — Chaque son déclenché automatiquement est-il contrôlable par l'utilisateur ?
+4.11 — La consultation de chaque média temporel est-elle, si nécessaire, contrôlable par le clavier et tout dispositif de pointage ?
+4.12 — La consultation de chaque média non temporel est-elle contrôlable par le clavier et tout dispositif de pointage ?
+4.13 — Chaque média temporel et non temporel est-il compatible avec les technologies d'assistance (hors cas particuliers) ?
 
-### 8. Éléments obligatoires
-- Chaque page a un `<title>` de page pertinent et à jour selon le contenu.
-- La langue par défaut du document est déclarée (`<html lang="fr">`).
+**Application concrète :** tout son/vidéo autoplay doit être contrôlable (pause/stop/volume) par l'utilisateur ; aucun contenu ne clignote de façon susceptible de déclencher une crise photosensible.
 
-### 9. Structuration de l'information
-- Hiérarchie de titres cohérente et sans saut (`h1` → `h2` → `h3`, jamais de
-  niveau sauté pour des raisons de style).
-- Vraies listes sémantiques (`<ul>`, `<ol>`, `<dl>`) pour tout contenu qui est
-  une liste, jamais simulées avec des `<div>`/tirets.
-- Citations, mise en emphase, changements de langue, abréviations sont
-  balisés sémantiquement (`<blockquote>`, `<em>`/`<strong>`, `lang="en"`
-  inline, `<abbr>`), pas seulement stylés visuellement.
+### 5. Tableaux (8 critères)
+5.1 — Chaque tableau de données complexe a-t-il un résumé ?
+5.2 — Pour chaque tableau de données complexe ayant un résumé, celui-ci est-il pertinent ?
+5.3 — Pour chaque tableau de mise en forme, le contenu linéarisé reste-t-il compréhensible ?
+5.4 — Pour chaque tableau de données ayant un titre, le titre est-il correctement associé au tableau de données ?
+5.5 — Pour chaque tableau de données ayant un titre, celui-ci est-il pertinent ?
+5.6 — Pour chaque tableau de données, chaque en-tête de colonne et chaque en-tête de ligne sont-ils correctement déclarés ?
+5.7 — Pour chaque tableau de données, la technique appropriée permettant d'associer chaque cellule avec ses en-têtes est-elle utilisée (hors cas particuliers) ?
+5.8 — Chaque tableau de mise en forme ne doit pas utiliser d'éléments propres aux tableaux de données. Cette règle est-elle respectée ?
 
-### 10. Présentation de l'information
-- L'information n'est jamais donnée uniquement par la forme, la taille ou la
-  position (ex. « le bouton à droite » sans libellé).
-- Contraste minimum **4.5:1** pour le texte normal, **3:1** pour le grand
-  texte (≥18pt ou ≥14pt gras) et pour les éléments d'interface non textuels
-  significatifs (icônes porteuses de sens, bordures d'input en erreur).
-- Jamais de texte justifié. Interlignage et espacement suffisants. Pas de
-  texte sous forme d'image sauf logo/exception justifiée.
+**Application concrète :** `<caption>` pertinent, `<th scope="col"|"row">` correctement déclarés ; jamais de `<table>` pour de la mise en page.
 
-### 11. Formulaires
-- Chaque champ a un `<label>` associé programmatiquement (`htmlFor`/`id`),
-  jamais un simple placeholder en guise de label.
-- Type de champ approprié (`type="email"`, `type="tel"`, etc.) pour
-  bénéficier de l'assistance native.
-- Erreurs de saisie identifiées, décrites en texte, associées au champ
-  concerné (`aria-describedby`, `aria-invalid`) et suggérant une correction.
-- Présence d'un bouton de soumission explicite ; jamais de soumission
-  automatique au changement de valeur.
-- Champs obligatoires signalés de façon non ambiguë (pas uniquement par la
-  couleur — cf. thématique 3).
+### 6. Liens (2 critères)
+6.1 — Chaque lien est-il explicite (hors cas particuliers) ?
+6.2 — Dans chaque page web, chaque lien a-t-il un intitulé ?
 
-### 12. Navigation
-- Menu de navigation cohérent, présent au même endroit sur toutes les pages.
-- Lien d'évitement / accès direct au contenu principal (« skip to content »)
-  présent et fonctionnel en tout début de page.
+**Application concrète :** jamais « cliquer ici » / « en savoir plus » sans contexte ; utiliser `aria-label`/`aria-labelledby` si le libellé visuel seul est insuffisant.
 
-### 13. Consultation
-- L'utilisateur peut arrêter/mettre en pause tout contenu en mouvement,
-  clignotant ou qui se met à jour automatiquement (carrousel, auto-refresh).
-- Le contenu reste utilisable et lisible avec un zoom texte à 200 % et en
-  redimensionnement de fenêtre (reflow), sans scroll horizontal ni perte de
-  fonctionnalité.
+### 7. Scripts (5 critères)
+7.1 — Chaque script est-il, si nécessaire, compatible avec les technologies d'assistance ?
+7.2 — Pour chaque script ayant une alternative, cette alternative est-elle pertinente ?
+7.3 — Chaque script est-il contrôlable par le clavier et par tout dispositif de pointage (hors cas particuliers) ?
+7.4 — Pour chaque script qui initie un changement de contexte, l'utilisateur est-il averti ou en a-t-il le contrôle ?
+7.5 — Dans chaque page web, les messages de statut sont-ils correctement restitués par les technologies d'assistance ?
+
+**Application concrète :** tout composant interactif (dropdown, accordéon, DSFR `Modal`, tabs) reste utilisable **entièrement au clavier** (Tab, Shift+Tab, Entrée, Espace, Échap, flèches) avec les bons rôles/états ARIA (`role`, `aria-expanded`, `aria-selected`, `aria-modal`) ; tout contenu dynamique pertinent (erreur, résultat, toast) est annoncé via `aria-live`/gestion du focus, pas seulement affiché visuellement.
+
+### 8. Éléments obligatoires (10 critères)
+8.1 — Chaque page web est-elle définie par un type de document ?
+8.2 — Pour chaque page web, le code source généré est-il valide selon le type de document spécifié ?
+8.3 — Dans chaque page web, la langue par défaut est-elle présente ?
+8.4 — Pour chaque page web ayant une langue par défaut, le code de langue est-il pertinent ?
+8.5 — Chaque page web a-t-elle un titre de page ?
+8.6 — Pour chaque page web ayant un titre de page, ce titre est-il pertinent ?
+8.7 — Dans chaque page web, chaque changement de langue est-il indiqué dans le code source (hors cas particuliers) ?
+8.8 — Dans chaque page web, le code de langue de chaque changement de langue est-il valide et pertinent ?
+8.9 — Dans chaque page web, les balises ne doivent pas être utilisées uniquement à des fins de présentation. Cette règle est-elle respectée ?
+8.10 — Dans chaque page web, les changements du sens de lecture sont-ils signalés ?
+
+**Application concrète :** `<html lang="fr">` ; `<title>` de page pertinent et à jour ; tout passage dans une autre langue est balisé (`lang="en"` inline, etc.) ; pas de balises détournées de leur sémantique pour du style.
+
+### 9. Structuration de l'information (4 critères)
+9.1 — Dans chaque page web, l'information est-elle structurée par l'utilisation appropriée de titres ?
+9.2 — Dans chaque page web, la structure du document est-elle cohérente (hors cas particuliers) ?
+9.3 — Dans chaque page web, chaque liste est-elle correctement structurée ?
+9.4 — Dans chaque page web, chaque citation est-elle correctement indiquée ?
+
+**Application concrète :** hiérarchie de titres sans saut (`h1`→`h2`→`h3`) ; vraies listes sémantiques `<ul>`/`<ol>`/`<dl>`, jamais simulées avec des `<div>`/tirets ; citations en `<blockquote>`/`<q>`, pas juste stylées visuellement.
+
+### 10. Présentation de l'information (14 critères)
+10.1 — Dans le site web, des feuilles de styles sont-elles utilisées pour contrôler la présentation de l'information ?
+10.2 — Dans chaque page web, le contenu visible porteur d'information reste-t-il présent lorsque les feuilles de styles sont désactivées ?
+10.3 — Dans chaque page web, l'information reste-t-elle compréhensible lorsque les feuilles de styles sont désactivées ?
+10.4 — Dans chaque page web, le texte reste-t-il lisible lorsque la taille des caractères est augmentée jusqu'à 200 %, au moins (hors cas particuliers) ?
+10.5 — Dans chaque page web, les déclarations CSS de couleurs de fond d'élément et de police sont-elles correctement utilisées ?
+10.6 — Dans chaque page web, chaque lien dont la nature n'est pas évidente est-il visible par rapport au texte environnant ?
+10.7 — Dans chaque page web, pour chaque élément recevant le focus, la prise de focus est-elle visible ?
+10.8 — Pour chaque page web, les contenus cachés ont-ils vocation à être ignorés par les technologies d'assistance ?
+10.9 — Dans chaque page web, l'information ne doit pas être donnée uniquement par la forme, taille ou position. Cette règle est-elle respectée ?
+10.10 — Dans chaque page web, l'information ne doit pas être donnée par la forme, taille ou position uniquement. Cette règle est-elle implémentée de façon pertinente ?
+10.11 — Pour chaque page web, les contenus peuvent-ils être présentés sans perte d'information ou de fonctionnalité et sans avoir recours soit à un défilement vertical pour une fenêtre ayant une hauteur de 256 px, soit à un défilement horizontal pour une fenêtre ayant une largeur de 320 px (hors cas particuliers) ?
+10.12 — Dans chaque page web, les propriétés d'espacement du texte peuvent-elles être redéfinies par l'utilisateur sans perte de contenu ou de fonctionnalité (hors cas particuliers) ?
+10.13 — Dans chaque page web, les contenus additionnels apparaissant à la prise de focus ou au survol d'un composant d'interface sont-ils contrôlables par l'utilisateur (hors cas particuliers) ?
+10.14 — Dans chaque page web, les contenus additionnels apparaissant via les styles CSS uniquement peuvent-ils être rendus visibles au clavier et par tout dispositif de pointage ?
+
+**Application concrète :** indicateur de focus **toujours visible** (jamais de `outline: none` sans remplacement) ; jamais d'information portée uniquement par la forme/taille/position (« le bouton à droite ») ; le texte reste lisible en zoom 200 % et en reflow à 320px de large sans scroll horizontal ; tooltips/popovers au survol/focus doivent être atteignables au clavier et dismissables.
+
+### 11. Formulaires (13 critères)
+11.1 — Chaque champ de formulaire a-t-il une étiquette ?
+11.2 — Chaque étiquette associée à un champ de formulaire est-elle pertinente (hors cas particuliers) ?
+11.3 — Dans chaque formulaire, chaque étiquette associée à un champ de formulaire ayant la même fonction et répétée plusieurs fois dans une même page ou dans un ensemble de pages est-elle cohérente ?
+11.4 — Dans chaque formulaire, chaque étiquette de champ et son champ associé sont-ils accolés (hors cas particuliers) ?
+11.5 — Dans chaque formulaire, les champs de même nature sont-ils regroupés, si nécessaire ?
+11.6 — Dans chaque formulaire, chaque regroupement de champs de même nature a-t-il une légende ?
+11.7 — Dans chaque formulaire, chaque légende associée à un regroupement de champs de même nature est-elle pertinente ?
+11.8 — Dans chaque formulaire, les items de même nature d'une liste de choix sont-ils regroupés de manière pertinente ?
+11.9 — Dans chaque formulaire, l'intitulé de chaque bouton est-il pertinent (hors cas particuliers) ?
+11.10 — Dans chaque formulaire, le contrôle de saisie est-il utilisé de manière pertinente (hors cas particuliers) ?
+11.11 — Dans chaque formulaire, le contrôle de saisie est-il accompagné, si nécessaire, de suggestions facilitant la correction des erreurs de saisie ?
+11.12 — Pour chaque formulaire qui modifie ou supprime des données, ou qui transmet des réponses à un test ou à un examen, ou dont la validation a des conséquences financières ou juridiques, les données saisies peuvent-elles être modifiées, mises à jour ou récupérées par l'utilisateur ?
+11.13 — La finalité d'un champ de saisie peut-elle être déduite pour faciliter le remplissage automatique des champs avec les données de l'utilisateur ?
+
+**Application concrète :** `<label htmlFor>` associé à chaque champ (jamais un simple `placeholder` en guise de label) ; champs de même nature groupés sous `<fieldset>`/`<legend>` pertinent ; erreurs décrites en texte, associées au champ (`aria-describedby`, `aria-invalid`) et suggérant une correction ; type de champ approprié (`type="email"`, `autocomplete="..."`) ; jamais de soumission automatique au changement de valeur.
+
+### 12. Navigation (11 critères)
+12.1 — Chaque ensemble de pages dispose-t-il de deux systèmes de navigation différents, au moins (hors cas particuliers) ?
+12.2 — Dans chaque ensemble de pages, le menu et les barres de navigation sont-ils toujours à la même place (hors cas particuliers) ?
+12.3 — La page « plan du site » est-elle pertinente ?
+12.4 — Dans chaque ensemble de pages, la page « plan du site » est-elle accessible à partir d'une fonctionnalité identique ?
+12.5 — Dans chaque ensemble de pages, le moteur de recherche est-il atteignable de manière identique ?
+12.6 — Les zones de regroupement de contenus présentes dans plusieurs pages web (zones d'en-tête, de navigation principale, de contenu principal, de pied de page et de moteur de recherche) peuvent-elles être atteintes ou évitées ?
+12.7 — Dans chaque page web, un lien d'évitement ou d'accès rapide à la zone de contenu principal est-il présent (hors cas particuliers) ?
+12.8 — Dans chaque page web, l'ordre de tabulation est-il cohérent ?
+12.9 — Dans chaque page web, la navigation ne doit pas contenir de piège au clavier. Cette règle est-elle respectée ?
+12.10 — Dans chaque page web, les raccourcis clavier n'utilisant qu'une seule touche (lettre minuscule ou majuscule, ponctuation, chiffre ou symbole) sont-ils contrôlables par l'utilisateur ?
+12.11 — Dans chaque page web, les contenus additionnels apparaissant au survol, à la prise de focus ou à l'activation d'un composant d'interface sont-ils si nécessaire atteignables au clavier ?
+
+**Application concrète :** menu de navigation cohérent au même endroit sur toutes les pages ; lien d'évitement (« skip to content ») fonctionnel en tout début de page ; ordre de tabulation logique, jamais de piège au clavier (un utilisateur clavier doit toujours pouvoir sortir d'un composant).
+
+### 13. Consultation (12 critères)
+13.1 — Pour chaque page web, l'utilisateur a-t-il le contrôle de chaque limite de temps modifiant le contenu (hors cas particuliers) ?
+13.2 — Dans chaque page web, l'ouverture d'une nouvelle fenêtre ne doit pas être déclenchée sans action de l'utilisateur. Cette règle est-elle respectée ?
+13.3 — Dans chaque page web, chaque document bureautique en téléchargement possède-t-il, si nécessaire, une version accessible (hors cas particuliers) ?
+13.4 — Pour chaque document bureautique ayant une version accessible, cette version offre-t-elle la même information ?
+13.5 — Dans chaque page web, chaque contenu cryptique (art ASCII, émoticône, syntaxe cryptique) a-t-il une alternative ?
+13.6 — Dans chaque page web, pour chaque contenu cryptique (art ASCII, émoticône, syntaxe cryptique) ayant une alternative, cette alternative est-elle pertinente ?
+13.7 — Dans chaque page web, les changements brusques de luminosité ou les effets de flash sont-ils correctement utilisés ?
+13.8 — Dans chaque page web, chaque contenu en mouvement ou clignotant est-il contrôlable par l'utilisateur ?
+13.9 — Dans chaque page web, le contenu proposé est-il consultable quelle que soit l'orientation de l'écran (portrait ou paysage) (hors cas particuliers) ?
+13.10 — Dans chaque page web, les fonctionnalités utilisables ou disponibles au moyen d'un geste complexe peuvent-elles être également disponibles au moyen d'un geste simple (hors cas particuliers) ?
+13.11 — Dans chaque page web, les actions déclenchées au moyen d'un dispositif de pointage sur un point unique de l'écran peuvent-elles faire l'objet d'une annulation (hors cas particuliers) ?
+13.12 — Dans chaque page web, les fonctionnalités qui impliquent un mouvement de l'appareil ou vers l'appareil peuvent-elles être satisfaites de manière alternative (hors cas particuliers) ?
+
+**Application concrète :** toute limite de temps (session, timeout) est contrôlable par l'utilisateur ; jamais de nouvelle fenêtre/onglet ouvert sans action explicite (et si c'est le cas, l'utilisateur est prévenu avant activation) ; tout contenu en mouvement/clignotant/auto-actualisé (carrousel, auto-refresh) est arrêtable ; export PDF/bureautique a, si besoin, une version accessible équivalente.
 
 ## Comportement obligatoire de l'agent (auto-contrôle)
 
 - Avant de considérer terminé tout changement touchant au balisage, au style
-  ou à l'interactivité frontend, **relis ton propre diff** à travers la
-  checklist des 13 thématiques ci-dessus.
+  ou à l'interactivité frontend, **relis ton propre diff** à travers la liste
+  des 106 critères ci-dessus (au moins par thématique — les 13 titres, en
+  gardant en tête les critères concrets les plus probablement impactés par le
+  type de changement fait).
 - Si tu identifies une violation potentielle — même incertaine, même hors du
   périmètre strict de la tâche demandée — tu dois **le signaler
   explicitement** dans ta réponse à l'utilisateur, avec ce format :
 
-  > ⚠️ **RGAA (thématique N — sujet)** : `<description du problème>` →
+  > ⚠️ **RGAA (critère N.M — sujet)** : `<description du problème>` →
   > `<correctif proposé>`
 
 - Ce signalement est **proactif** : tu ne l'inclus pas seulement quand on te
@@ -195,9 +260,10 @@ officiels, applicable directement dans le contexte DSFR/MUI/React de ce repo.
 
 ## Ce que « connaître par cœur » signifie concrètement
 
-Connaître le **fond** de chaque règle ci-dessus au point de l'appliquer par
-réflexe en écrivant du code — pas mémoriser un tableau de numéros de
-critères qui peut devenir obsolète d'une version du RGAA à l'autre. La
-numérotation se vérifie à la source si besoin (voir section précédente) ;
-la substance des règles, elle, doit être connue et appliquée sans avoir à
-la relire.
+Connaître **le texte et le numéro de chaque critère ci-dessus** au point de
+les appliquer par réflexe en écrivant du code, et de pouvoir citer le bon
+numéro dans une alerte. Cette liste est la donnée de référence : ne la
+recopie pas de mémoire ailleurs, ne l'approxime pas — si ce fichier est un
+jour désynchronisé d'une nouvelle version du RGAA, mets-le à jour depuis la
+source JSON officielle (voir section « Source de référence ») plutôt que de
+deviner.

--- a/.claude/rules/rgaa-accessibility.md
+++ b/.claude/rules/rgaa-accessibility.md
@@ -1,0 +1,203 @@
+---
+description: RGAA accessibility requirements — mandatory, non-negotiable for all frontend work
+paths: ["frontend/**"]
+---
+
+# Accessibilité RGAA — Exigence absolue et non négociable
+
+## Règle générale
+
+**Zéro Logement Vacant est un service public numérique.** Le respect du RGAA
+(Référentiel Général d'Amélioration de l'Accessibilité) n'est pas une option,
+une bonne pratique parmi d'autres, ou un chantier séparé : c'est une
+**obligation légale** et une **condition de complétude** de tout travail
+frontend, au même titre que la compilation ou les tests.
+
+Pour tout travail sur `frontend/**` (composant, vue, formulaire, modale,
+tableau, navigation, contenu, style) :
+
+- Tu dois connaître et appliquer **l'intégralité des critères RGAA**, sans
+  exception, sans les traiter comme un "nice to have" a posteriori.
+- Un code qui fonctionne visuellement mais qui viole un critère RGAA est un
+  **code incorrect**, au même titre qu'un bug fonctionnel.
+- Tu ne dois **jamais** livrer sciemment une régression d'accessibilité pour
+  gagner du temps ou simplifier une implémentation. Si un raccourci casse un
+  critère, tu le dis explicitement et tu proposes l'alternative conforme —
+  tu n'implémentes pas silencieusement la version non conforme par défaut.
+- Cette exigence s'applique à **tout** code frontend que tu écris ou modifies,
+  qu'il s'agisse d'une nouvelle fonctionnalité, d'un correctif, d'un
+  refactoring ou d'une intégration Figma (voir
+  [figma-design-system.md](figma-design-system.md)).
+
+## Source de référence (canonique)
+
+Référentiel officiel : <https://accessibilite.numerique.gouv.fr/methode/criteres-et-tests/>
+
+Version en vigueur au moment de la rédaction de ce fichier : **RGAA 4.1.2**
+(déclinaison française de WCAG 2.1 niveau AA), organisée en **13 thématiques**
+et **106 critères de contrôle**, eux-mêmes décomposés en tests élémentaires.
+
+**Important — numérotation exacte :** la numérotation précise des critères
+(ex. « critère 7.3 ») peut varier d'une version du RGAA à l'autre, et les
+outils de résumé automatique ne restituent pas toujours l'intégralité de la
+page de référence de façon fiable. Par conséquent :
+
+- Tu dois connaître **le fond de chaque règle par cœur** (ce qui suit dans ce
+  document) — c'est ce qui doit guider ton code au quotidien, sans avoir à
+  consulter une page à chaque ligne écrite.
+- Si tu dois **citer un numéro de critère précis** dans un document formel
+  (rapport d'audit, description de PR, commentaire de revue officiel),
+  **revérifie-le** via WebFetch/WebSearch sur l'URL ci-dessus plutôt que de
+  te fier à un numéro mémorisé — ne jamais inventer ou approximer un numéro
+  de critère dans un livrable destiné à être cité comme référence.
+- L'absence de certitude sur un numéro exact n'est **jamais** une excuse pour
+  ignorer la règle de fond correspondante.
+
+## Les 13 thématiques du RGAA — checklist obligatoire
+
+Pour chaque changement frontend, passe en revue mentalement ces 13 axes.
+Chaque ligne ci-dessous est une reformulation opérationnelle des critères
+officiels, applicable directement dans le contexte DSFR/MUI/React de ce repo.
+
+### 1. Images
+- Toute image informative (`<img>`, `background-image` porteuse de sens,
+  icône SVG cliquable) a une alternative textuelle pertinente (`alt`,
+  `aria-label`, ou équivalent).
+- Toute image décorative a `alt=""` (jamais d'`alt` absent) ou
+  `aria-hidden="true"`, et n'est jamais focusable.
+- Les images complexes (graphiques, cartes) ont une description détaillée
+  accessible à proximité, pas seulement dans l'`alt`.
+- Ne jamais utiliser une image pour représenter du texte quand une vraie
+  balise texte stylée peut faire l'affaire.
+
+### 2. Cadres (iframes)
+- Chaque `<iframe>` a un attribut `title` explicite et pertinent décrivant
+  son contenu/fonction (ex. carte, lecteur vidéo, widget tiers).
+
+### 3. Couleurs
+- L'information ne doit **jamais** être portée par la couleur seule (ex. un
+  statut rouge/vert doit aussi avoir un texte, une icône ou un motif).
+- Tout élément recevant un effet de contraste (lien souligné au survol,
+  focus, état actif) reste perceptible même sans distinction de couleur.
+
+### 4. Multimédia
+- Toute vidéo/audio préenregistré a, si nécessaire, transcription textuelle,
+  sous-titres et/ou audiodescription pertinents.
+- Aucun contenu ne doit clignoter/flasher de façon susceptible de déclencher
+  une crise d'épilepsie photosensible.
+
+### 5. Tableaux
+- Tout tableau de données a un titre (`<caption>` ou équivalent accessible)
+  pertinent.
+- Structure correcte : en-têtes `<th scope="col"|"row">`, pas de tableau
+  utilisé à des fins de mise en page.
+
+### 6. Liens
+- Tout lien est explicite hors contexte : jamais « cliquer ici », « en savoir
+  plus » sans contexte associé (utiliser `aria-label`/`aria-labelledby` si le
+  libellé visuel est insuffisant).
+- Deux liens au texte identique mais menant à des destinations différentes
+  doivent être distingués (libellé ou attribut accessible).
+
+### 7. Scripts
+- Tout composant interactif en JS (dropdown, accordéon, modale, DSFR
+  `Modal`, tabs) reste **entièrement utilisable au clavier** (Tab, Shift+Tab,
+  Entrée, Espace, Échap, flèches si composite widget) et expose les rôles/
+  états ARIA corrects (`role`, `aria-expanded`, `aria-selected`,
+  `aria-modal`, etc.).
+- Tout contenu généré dynamiquement et pertinent pour l'utilisateur (message
+  d'erreur, résultat de recherche, toast) doit être annoncé aux technologies
+  d'assistance (`aria-live`, focus management), pas seulement affiché
+  visuellement.
+
+### 8. Éléments obligatoires
+- Chaque page a un `<title>` de page pertinent et à jour selon le contenu.
+- La langue par défaut du document est déclarée (`<html lang="fr">`).
+
+### 9. Structuration de l'information
+- Hiérarchie de titres cohérente et sans saut (`h1` → `h2` → `h3`, jamais de
+  niveau sauté pour des raisons de style).
+- Vraies listes sémantiques (`<ul>`, `<ol>`, `<dl>`) pour tout contenu qui est
+  une liste, jamais simulées avec des `<div>`/tirets.
+- Citations, mise en emphase, changements de langue, abréviations sont
+  balisés sémantiquement (`<blockquote>`, `<em>`/`<strong>`, `lang="en"`
+  inline, `<abbr>`), pas seulement stylés visuellement.
+
+### 10. Présentation de l'information
+- L'information n'est jamais donnée uniquement par la forme, la taille ou la
+  position (ex. « le bouton à droite » sans libellé).
+- Contraste minimum **4.5:1** pour le texte normal, **3:1** pour le grand
+  texte (≥18pt ou ≥14pt gras) et pour les éléments d'interface non textuels
+  significatifs (icônes porteuses de sens, bordures d'input en erreur).
+- Jamais de texte justifié. Interlignage et espacement suffisants. Pas de
+  texte sous forme d'image sauf logo/exception justifiée.
+
+### 11. Formulaires
+- Chaque champ a un `<label>` associé programmatiquement (`htmlFor`/`id`),
+  jamais un simple placeholder en guise de label.
+- Type de champ approprié (`type="email"`, `type="tel"`, etc.) pour
+  bénéficier de l'assistance native.
+- Erreurs de saisie identifiées, décrites en texte, associées au champ
+  concerné (`aria-describedby`, `aria-invalid`) et suggérant une correction.
+- Présence d'un bouton de soumission explicite ; jamais de soumission
+  automatique au changement de valeur.
+- Champs obligatoires signalés de façon non ambiguë (pas uniquement par la
+  couleur — cf. thématique 3).
+
+### 12. Navigation
+- Menu de navigation cohérent, présent au même endroit sur toutes les pages.
+- Lien d'évitement / accès direct au contenu principal (« skip to content »)
+  présent et fonctionnel en tout début de page.
+
+### 13. Consultation
+- L'utilisateur peut arrêter/mettre en pause tout contenu en mouvement,
+  clignotant ou qui se met à jour automatiquement (carrousel, auto-refresh).
+- Le contenu reste utilisable et lisible avec un zoom texte à 200 % et en
+  redimensionnement de fenêtre (reflow), sans scroll horizontal ni perte de
+  fonctionnalité.
+
+## Comportement obligatoire de l'agent (auto-contrôle)
+
+- Avant de considérer terminé tout changement touchant au balisage, au style
+  ou à l'interactivité frontend, **relis ton propre diff** à travers la
+  checklist des 13 thématiques ci-dessus.
+- Si tu identifies une violation potentielle — même incertaine, même hors du
+  périmètre strict de la tâche demandée — tu dois **le signaler
+  explicitement** dans ta réponse à l'utilisateur, avec ce format :
+
+  > ⚠️ **RGAA (thématique N — sujet)** : `<description du problème>` →
+  > `<correctif proposé>`
+
+- Ce signalement est **proactif** : tu ne l'inclus pas seulement quand on te
+  le demande. Traite une violation RGAA avec le même niveau de sérieux qu'une
+  faille de sécurité ou une régression de types — jamais en silence.
+- En cas de doute réel sur la conformité d'un pattern (ex. usage ARIA
+  inhabituel, widget complexe), dis-le et propose de vérifier plutôt que de
+  supposer que c'est correct.
+- Ne jamais désactiver, contourner ou supprimer un attribut d'accessibilité
+  existant (`alt`, `aria-*`, `role`, `tabIndex`, `label`) pour résoudre un
+  problème visuel ou de layout — trouve la solution qui préserve les deux.
+
+## Réutilisation et outillage
+
+- Les composants **DSFR** (`@codegouvfr/react-dsfr`) sont conçus pour être
+  conformes RGAA par défaut : ils doivent toujours être préférés à un
+  composant custom pour cette raison. Ne jamais surcharger leur structure
+  interne (ARIA, gestion du focus, rôles) d'une façon qui casserait cette
+  garantie.
+- Avant de considérer une fonctionnalité UI terminée, vérifie manuellement :
+  navigation clavier complète, indicateur de focus visible, contraste des
+  couleurs custom introduites, comportement au zoom 200 %.
+- Ce repo n'a pas encore d'outillage a11y automatisé (`eslint-plugin-jsx-a11y`,
+  `axe-core`/`vitest-axe`). Si tu ajoutes un composant interactif complexe,
+  propose explicitement à l'utilisateur d'introduire cet outillage plutôt que
+  de t'appuyer uniquement sur une vérification manuelle silencieuse.
+
+## Ce que « connaître par cœur » signifie concrètement
+
+Connaître le **fond** de chaque règle ci-dessus au point de l'appliquer par
+réflexe en écrivant du code — pas mémoriser un tableau de numéros de
+critères qui peut devenir obsolète d'une version du RGAA à l'autre. La
+numérotation se vérifie à la source si besoin (voir section précédente) ;
+la substance des règles, elle, doit être connue et appliquée sans avoir à
+la relire.

--- a/.claude/rules/rgaa-accessibility.md
+++ b/.claude/rules/rgaa-accessibility.md
@@ -229,19 +229,50 @@ contexte DSFR/MUI/React de ce repo.
 
 **Application concrète :** toute limite de temps (session, timeout) est contrôlable par l'utilisateur ; jamais de nouvelle fenêtre/onglet ouvert sans action explicite (et si c'est le cas, l'utilisateur est prévenu avant activation) ; tout contenu en mouvement/clignotant/auto-actualisé (carrousel, auto-refresh) est arrêtable ; export PDF/bureautique a, si besoin, une version accessible équivalente.
 
-## Comportement obligatoire de l'agent (auto-contrôle)
+## Comportement obligatoire de l'agent (auto-contrôle) — procédure à exécuter à chaque tâche frontend
 
-- Avant de considérer terminé tout changement touchant au balisage, au style
-  ou à l'interactivité frontend, **relis ton propre diff** à travers la liste
-  des 106 critères ci-dessus (au moins par thématique — les 13 titres, en
-  gardant en tête les critères concrets les plus probablement impactés par le
-  type de changement fait).
-- Si tu identifies une violation potentielle — même incertaine, même hors du
-  périmètre strict de la tâche demandée — tu dois **le signaler
-  explicitement** dans ta réponse à l'utilisateur, avec ce format :
+Ceci n'est pas une vérification informelle "si j'y pense" : c'est une étape
+**obligatoire de la définition de fini** pour toute tâche touchant
+`frontend/**`, au même titre que faire passer le typecheck. Exécute-la dans
+l'ordre, systématiquement :
 
-  > ⚠️ **RGAA (critère N.M — sujet)** : `<description du problème>` →
-  > `<correctif proposé>`
+1. **Identifier les critères concernés par la tâche demandée.** À partir de
+   la nature du changement, repère les thématiques et critères pertinents
+   dans la liste des 106 ci-dessus — pas les 106 à chaque fois, seulement
+   ceux que le changement touche réellement. Exemples de mapping :
+   - Formulaire/champ/validation → thématique 11 (+ 3 pour les couleurs
+     d'erreur, + 10.7 pour le focus).
+   - Image/icône/SVG → thématique 1.
+   - Tableau de données → thématique 5.
+   - Lien/bouton/CTA → thématique 6 (+ 10.6, 10.7).
+   - Modale/dropdown/accordéon/tout composant interactif JS → thématique 7
+     (+ 12.8, 12.9 pour le focus trap/ordre de tabulation).
+   - Nouvelle page/route → thématique 8, 9, 12.
+   - Nouveau composant visuel/couleurs custom → thématique 3, 10.
+   - Vidéo/audio → thématique 4.
+   - Contenu qui bouge/s'actualise seul (carrousel, auto-refresh, toast
+     auto-dismiss) → thématique 13.
+2. **Lire la procédure de test exacte** des critères identifiés dans
+   [docs/rgaa/methodologie-tests.md](../../docs/rgaa/methodologie-tests.md)
+   (lecture ciblée sur les critères concernés, pas le fichier entier si non
+   nécessaire) — c'est la procédure qu'un auditeur RGAA suivrait réellement,
+   pas une paraphrase.
+3. **Vérifier le code produit contre cette procédure**, étape par étape,
+   comme le ferait l'auditeur (ex. pour 1.1.1 : l'image a-t-elle bien
+   `aria-labelledby`, `aria-label`, `alt` ou `title` ? pour 11.4 : le
+   `<label>` est-il bien accolé à son champ ?).
+4. **Rends compte du résultat dans ta réponse**, brièvement : quels critères
+   ont été vérifiés et le résultat (conforme, ou alerte — voir format
+   ci-dessous). Ne saute pas cette étape même si tout est conforme :
+   l'utilisateur doit voir que le contrôle a eu lieu, pas juste le résultat
+   d'un travail qui prétend l'avoir fait.
+
+Si tu identifies une violation potentielle — même incertaine, même hors du
+périmètre strict de la tâche demandée — tu dois **le signaler
+explicitement** dans ta réponse à l'utilisateur, avec ce format :
+
+> ⚠️ **RGAA (critère N.M — sujet)** : `<description du problème>` →
+> `<correctif proposé>`
 
 - Ce signalement est **proactif** : tu ne l'inclus pas seulement quand on te
   le demande. Traite une violation RGAA avec le même niveau de sérieux qu'une
@@ -252,11 +283,6 @@ contexte DSFR/MUI/React de ce repo.
 - Ne jamais désactiver, contourner ou supprimer un attribut d'accessibilité
   existant (`alt`, `aria-*`, `role`, `tabIndex`, `label`) pour résoudre un
   problème visuel ou de layout — trouve la solution qui préserve les deux.
-- Pour un audit précis d'un composant, ou avant d'affirmer qu'un pattern
-  ARIA/HTML complexe respecte un critère donné, **lis
-  [docs/rgaa/methodologie-tests.md](../../docs/rgaa/methodologie-tests.md)**
-  et applique la procédure de test officielle correspondante plutôt que de
-  juger uniquement sur la base du titre du critère.
 
 ## Réutilisation et outillage
 

--- a/.claude/rules/rgaa-accessibility.md
+++ b/.claude/rules/rgaa-accessibility.md
@@ -35,24 +35,34 @@ Référentiel officiel : <https://accessibilite.numerique.gouv.fr/methode/criter
 
 **Version : RGAA 4.1.2** (tag `v4.1.2`, dernière version publiée), déclinaison
 française de WCAG 2.1 niveau AA — **13 thématiques, 106 critères de contrôle,
-693 tests élémentaires**.
+258 tests élémentaires**.
 
 La liste ci-dessous a été **validée le 2026-07-08 directement depuis les
 données JSON sources faisant autorité** du dépôt officiel
-(`RGAA/criteres.json` dans
+(`RGAA/criteres.json` et `RGAA/methodologies.json` dans
 [DISIC/accessibilite.numerique.gouv.fr](https://github.com/DISIC/accessibilite.numerique.gouv.fr)),
 et non depuis un résumé généré par un outil de fetch web (ces résumés se sont
 révélés incohérents d'un appel à l'autre lors de la rédaction de ce
 document — ne jamais leur faire confiance pour ce niveau de précision).
 Les 106 titres de critères ci-dessous sont donc le **texte officiel exact**,
-et les totaux (13 / 106 / 693) ont été vérifiés par calcul sur le JSON source,
-pas estimés.
+et les totaux (13 / 106 / 258) ont été vérifiés par calcul sur le JSON
+source, pas estimés.
 
 **Cela signifie que tu peux citer un numéro de critère (ex. « critère 7.3 »)
 directement depuis cette liste, avec confiance.** Le seul cas où il faut
 revérifier à la source : si une nouvelle version majeure du RGAA succède à la
 4.1.2 (auquel cas cette liste devient un instantané historique à mettre à
 jour — voir la date de validation ci-dessus).
+
+**Procédures de test exactes (les 258 tests élémentaires) :** elles sont
+documentées intégralement, avec le même niveau de fidélité, dans
+[docs/rgaa/methodologie-tests.md](../../docs/rgaa/methodologie-tests.md).
+Ce fichier n'est **volontairement pas chargé automatiquement** (258 tests
+représentent ~34k tokens, ce qui alourdirait chaque tâche frontend même
+triviale) — va le lire explicitement quand tu dois : auditer précisément un
+composant, citer la procédure officielle d'un test dans un rapport, ou
+trancher un cas limite que le résumé "Application concrète" de chaque
+critère ci-dessous ne couvre pas.
 
 ## Les 106 critères RGAA — liste officielle complète, par thématique
 
@@ -242,6 +252,11 @@ contexte DSFR/MUI/React de ce repo.
 - Ne jamais désactiver, contourner ou supprimer un attribut d'accessibilité
   existant (`alt`, `aria-*`, `role`, `tabIndex`, `label`) pour résoudre un
   problème visuel ou de layout — trouve la solution qui préserve les deux.
+- Pour un audit précis d'un composant, ou avant d'affirmer qu'un pattern
+  ARIA/HTML complexe respecte un critère donné, **lis
+  [docs/rgaa/methodologie-tests.md](../../docs/rgaa/methodologie-tests.md)**
+  et applique la procédure de test officielle correspondante plutôt que de
+  juger uniquement sur la base du titre du critère.
 
 ## Réutilisation et outillage
 
@@ -266,4 +281,8 @@ numéro dans une alerte. Cette liste est la donnée de référence : ne la
 recopie pas de mémoire ailleurs, ne l'approxime pas — si ce fichier est un
 jour désynchronisé d'une nouvelle version du RGAA, mets-le à jour depuis la
 source JSON officielle (voir section « Source de référence ») plutôt que de
-deviner.
+deviner. Pour la procédure exacte d'un test (comment un auditeur RGAA
+vérifie concrètement un critère), la référence complète est
+[docs/rgaa/methodologie-tests.md](../../docs/rgaa/methodologie-tests.md) —
+volontairement séparée de ce fichier pour ne pas alourdir chaque tâche
+frontend, mais tout aussi exhaustive et vérifiée à la source (258 tests).

--- a/.talismanrc
+++ b/.talismanrc
@@ -171,6 +171,8 @@ fileignoreconfig:
   checksum: e94c840ab2212d1fe1d7e8060937abfce87401b97cf7dc1abda44aaf14a5d3e7
 - filename: .claude/rules/rgaa-accessibility.md
   checksum: be723fd0573e0bf1f6acf30401f6f2c288a3d358c4ce2000361a2f6ae6c591b5
+- filename: docs/rgaa/methodologie-tests.md
+  checksum: b396fb5a9d17e2a81cad49491c35cc459db9f2ff494c94dada9f3eeae0efeb53
 scopeconfig:
 - scope: node
 allowed_patterns:

--- a/.talismanrc
+++ b/.talismanrc
@@ -169,6 +169,8 @@ fileignoreconfig:
   checksum: f4ce3945b8c77a11f90ea9016d3f59e4465657b07c52f13a78a25b834451e30c
 - filename: server/src/scripts/repairs/README.md
   checksum: e94c840ab2212d1fe1d7e8060937abfce87401b97cf7dc1abda44aaf14a5d3e7
+- filename: .claude/rules/rgaa-accessibility.md
+  checksum: be723fd0573e0bf1f6acf30401f6f2c288a3d358c4ce2000361a2f6ae6c591b5
 scopeconfig:
 - scope: node
 allowed_patterns:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,12 @@ Yarn v4 monorepo with Nx for build orchestration and task running. French govern
 
 **Stack:** TypeScript, React (frontend), Express (backend), PostgreSQL
 
+## Accessibility (RGAA) — mandatory, non-negotiable
+
+**Zéro Logement Vacant is a French public service.** Any frontend work MUST comply with **every single criterion** of the RGAA (Référentiel Général d'Amélioration de l'Accessibilité — France's WCAG 2.1 AA implementation: <https://accessibilite.numerique.gouv.fr/methode/criteres-et-tests/>), with no exceptions. This is a hard requirement, not a best-effort guideline — treat an RGAA violation with the same severity as a functional bug or a security issue.
+
+Full rules, the 13 RGAA thematics broken down into actionable checks, and the mandatory self-review/alerting protocol are in [.claude/rules/rgaa-accessibility.md](.claude/rules/rgaa-accessibility.md). **Read and apply it for every change under `frontend/`.** You must proactively flag any suspected RGAA violation in your response — do not wait to be asked, and do not ship a known violation silently.
+
 ## Monorepo Structure
 
 ```
@@ -29,7 +35,7 @@ Yarn v4 monorepo with Nx for build orchestration and task running. French govern
 
 **When to work in each workspace:**
 
-- **Frontend work** (React components, UI, state management) → Work in `frontend/`; conventions in [.claude/rules/frontend-conventions.md](.claude/rules/frontend-conventions.md)
+- **Frontend work** (React components, UI, state management) → Work in `frontend/`; conventions in [.claude/rules/frontend-conventions.md](.claude/rules/frontend-conventions.md); accessibility is **mandatory** — see [.claude/rules/rgaa-accessibility.md](.claude/rules/rgaa-accessibility.md)
 - **Backend work** (API endpoints, database, validation) → Work in `server/`; conventions in [.claude/rules/backend-conventions.md](.claude/rules/backend-conventions.md)
 - **Shared types/models** → Work in `packages/models/` (DTOs used by both frontend and server)
 - **Validation schemas** → Work in `packages/schemas/` (shared Yup schemas)
@@ -242,6 +248,7 @@ After opening any PR with `gh pr create`, always:
 ## Workspace-Specific Documentation
 
 - **Frontend conventions** → [.claude/rules/frontend-conventions.md](.claude/rules/frontend-conventions.md)
+- **RGAA accessibility (mandatory for all frontend work)** → [.claude/rules/rgaa-accessibility.md](.claude/rules/rgaa-accessibility.md)
 - **Backend conventions** → [.claude/rules/backend-conventions.md](.claude/rules/backend-conventions.md)
 - **Packages conventions** → [.claude/rules/packages-conventions.md](.claude/rules/packages-conventions.md)
 

--- a/docs/rgaa/methodologie-tests.md
+++ b/docs/rgaa/methodologie-tests.md
@@ -1,0 +1,2305 @@
+# RGAA 4.1.2 — Méthodologie de test complète (258 tests, 106 critères)
+
+> **Référence exhaustive, pas un document à charger en permanence.** Ce
+> fichier n'est **pas** injecté automatiquement dans le contexte (contrairement
+> à [.claude/rules/rgaa-accessibility.md](../../.claude/rules/rgaa-accessibility.md),
+> qui contient les 106 critères et reste toujours chargé pour tout travail sous
+> `frontend/**`). Consulte ce fichier avec l'outil de lecture quand tu as
+> besoin de :
+>
+> - La procédure exacte qu'un auditeur RGAA suivrait pour un test donné.
+> - Citer la formulation officielle d'un test dans un rapport d'audit ou une
+>   revue de code formelle.
+> - Vérifier un cas limite (ex. `<svg>`, `<object>`, image réactive côté
+>   serveur) que le résumé "Application concrète" de la règle courte ne couvre
+>   pas explicitement.
+
+**Source et fiabilité :** ce contenu est le texte officiel exact du dépôt
+[DISIC/accessibilite.numerique.gouv.fr](https://github.com/DISIC/accessibilite.numerique.gouv.fr)
+(fichiers `RGAA/criteres.json` pour la structure et `RGAA/methodologies.json`
+pour le contenu des tests), récupéré directement en JSON — pas via un résumé
+d'outil de fetch web (ceux-ci se sont montrés incohérents lors de la
+validation de ce document). Comptages vérifiés par script le 2026-07-08 :
+**13 thématiques, 106 critères, 258 tests**, correspondance 1:1 confirmée
+entre les identifiants de `criteres.json` et les clés de
+`methodologies.json`.
+
+Chaque test est identifié `<critère>.<test>` (ex. `1.1.1` = 1er test du
+critère 1.1). Le texte ci-dessous est reproduit tel quel (formulation
+officielle), organisé par thématique puis par critère.
+
+---
+
+## 1. Images
+
+### Critère 1.1 — Chaque image porteuse d’information a-t-elle une alternative textuelle ?
+
+**Test 1.1.1 :**
+
+1. Retrouver dans le document les images structurées au moyen d’un élément `<img>` ou d’un élément possédant l’attribut WAI-ARIA `role="img"` ;
+2. Pour chaque image, déterminer si l’image est porteuse d’information ;
+3. Dans le cas où il s’agit d’un élément `<img>`, vérifier que l’image est pourvue au moins d’une alternative textuelle parmi les suivantes :
+   - Passage de texte associé via l’attribut WAI-ARIA `aria-labelledby` ;
+   - Contenu de l’attribut WAI-ARIA `aria-label` ;
+   - Contenu de l’attribut `alt` ;
+   - Contenu de l’attribut `title`.
+4. Dans le cas où il s’agit d’un élément possédant l’attribut WAI-ARIA `role="img"`, vérifier que l’image est pourvue au moins d’une alternative textuelle parmi les suivantes :
+   - Passage de texte associé via l’attribut WAI-ARIA `aria-labelledby` ;
+   - Contenu de l’attribut WAI-ARIA `aria-label`.
+5. Si au moins une alternative textuelle est trouvée, **le test est validé**.
+
+**Test 1.1.2 :**
+
+1. Retrouver dans le document les éléments `<area>` ;
+2. Pour chaque élément `<area>`, déterminer si la zone réactive est porteuse d’information ;
+3. Vérifier que la zone réactive est pourvue au moins d’une alternative textuelle parmi les suivantes :
+   - Contenu de l’attribut WAI-ARIA `aria-label` ;
+   - Contenu de l’attribut `alt` ;
+4. Si au moins une alternative textuelle est trouvée, **le test est validé**.
+
+**Test 1.1.3 :**
+
+1. Retrouver dans le document les éléments `<input>` pourvus de l’attribut `type="image"` ;
+2. Pour chaque élément `<input>` pourvu de l’attribut type="image", déterminer si l’image utilisée est porteuse d’information ;
+3. Vérifier que l’élément `<input>` est pourvu au moins d’une alternative textuelle parmi les suivantes :
+   - Passage de texte associé via l’attribut WAI-ARIA `aria-labelledby` ;
+   - Contenu de l’attribut WAI-ARIA `aria-label` ;
+   - Contenu de l’attribut `alt` ;
+   - Contenu de l’attribut `title`.
+4. Si au moins une alternative textuelle est trouvée, **le test est validé**.
+
+**Test 1.1.4 :**
+
+1. Retrouver dans le document les éléments `<img>` pourvus de l’attribut `ismap` ;
+2. Pour chaque élément `<img>` pourvu de l’attribut `ismap`, vérifier la présence d’un lien ou d’un ensemble de liens (ou bien d’un autre type de composant d’interface qui jouerait un rôle similaire comme une liste de sélection, par exemple) permettant d’accéder aux mêmes ressources que lorsque l’image fait l’objet d’un clic.
+3. Si c’est le cas, **le test est validé**.
+
+**Test 1.1.5 :**
+
+1. Retrouver dans le document les éléments `<svg>` ;
+2. Pour chaque élément `<svg>`, déterminer si l’image est porteuse d’information ;
+3. S’assurer que l’élément `<svg>` est pourvu d’un attribut WAI-ARIA `role="img"` ;
+4. Si ce n’est pas le cas, le test est invalidé.
+5. Le cas échéant, vérifier que l’élément `<svg>` est pourvu au moins d’une alternative textuelle parmi les suivantes :
+   - Contenu de l’élément `<title>` ;
+   - Passage de texte associé via l’attribut WAI-ARIA `aria-labelledby` ;
+   - Contenu de l’attribut WAI-ARIA `aria-label` ;
+6. Si au moins une alternative textuelle est trouvée, **le test est validé**.
+
+**Test 1.1.6 :**
+
+1. Retrouver dans le document les balises ouvrantes `<object>` pourvues de l'attribut `type="image/…"` ;
+2. Pour chaque balise ouvrante `<object>` pourvue de l'attribut `type="image/…"`, déterminer si l’image utilisée est porteuse d'information ;
+3. Vérifier que l’élément `<object>` est pourvu d’un attribut WAI-ARIA `role="img"` ;
+4. Vérifier que l’élément `<object>` est pourvu au moins d’une alternative textuelle parmi les suivantes :
+   - Passage de texte associé via l’attribut WAI-ARIA `aria-labelledby` ;
+   - Contenu de l’attribut WAI-ARIA `aria-label` ;
+   - Contenu de l’attribut `title`.
+5. Si au moins une alternative textuelle est trouvée, **le test est validé** ;
+6. Sinon, vérifier que l'élément `<object>` est :
+   - Soit immédiatement suivi d'un lien ou bouton adjacent permettant d'accéder à un contenu alternatif ;
+   - Soit un mécanisme permet à l'utilisateur de remplacer l'élément `<object>` par un contenu alternatif.
+7. Si c'est le cas, **le test est validé**.
+
+**Test 1.1.7 :**
+
+1. Pour chaque élément `<embed>` pourvu de l’attribut `type="image/…"`, déterminer si l’image utilisée est porteuse d’information ;
+2. Vérifier que l’élément `<embed>` est pourvu d’un attribut WAI-ARIA `role="img"` ;
+3. Vérifier que l’élément `<embed>` est pourvu au moins d’une alternative textuelle parmi les suivantes :
+   - Passage de texte associé via l’attribut WAI-ARIA `aria-labelledby` ;
+   - Contenu de l’attribut WAI-ARIA `aria-label` ;
+   - Contenu de l’attribut `title`.
+4. Si au moins une alternative textuelle est trouvée, **le test est validé** ;
+5. Sinon, vérifier que l’élément `<embed>` est :
+   - Soit immédiatement suivi d’un lien ou bouton adjacent permettant d’accéder à un contenu alternatif ;
+   - Soit un mécanisme permet à l’utilisateur de remplacer l’élément `<embed>` par un contenu alternatif.
+6. Si c’est le cas, **le test est validé**.
+
+**Test 1.1.8 :**
+
+1. Retrouver dans le document les éléments `<canvas>` ;
+2. Pour chaque élément `<canvas>`, déterminer si l’image utilisée est porteuse d’information ;
+3. Vérifier que l’élément `<canvas>` est pourvu d’un attribut WAI-ARIA `role="img"` ;
+4. Vérifier que la balise ouvrante `<canvas>` est pourvue au moins d’une alternative textuelle parmi les suivantes :
+   - Passage de texte associé via l’attribut WAI-ARIA `aria-labelledby` ;
+   - Contenu de l’attribut WAI-ARIA `aria-label`.
+5. Si au moins une alternative textuelle est trouvée, **le test est validé**.
+6. Si les étapes 3 et 4 ne sont pas satisfaites, vérifier que l’élément `<canvas>` est :
+   - Soit pourvu d’un contenu alternatif présent entre les balises `<canvas>` et `</canvas>` ;
+   - Soit immédiatement suivi d’un lien ou bouton adjacent permettant d’accéder à un contenu alternatif ;
+   - Soit un mécanisme permet à l’utilisateur de remplacer l’élément `<canvas>` par un contenu alternatif.
+7. Si c’est le cas, **le test est validé**.
+
+Note : si l'élément `<canvas>` dispose d'un rôle `img`, son alternative ne peut être fournie que par les techniques listées à l'étape 4.
+
+### Critère 1.2 — Chaque image de décoration est-elle correctement ignorée par les technologies d’assistance ?
+
+**Test 1.2.1 :**
+
+1. Retrouver dans le document les images décoratives dépourvues de légende structurées au moyen d’un élément `<img>` ;
+2. Pour chaque image, vérifier que l’image ne possède pas d’attributs `aria-labelledby`, `aria-label` ou `title` et qu’elle possède :
+   - Soit un attribut `alt` vide (`alt=""`) ;
+   - Soit un attribut WAI-ARIA `aria-hidden="true"` ou `role="presentation"`.
+3. Si c’est le cas pour chaque image, **le test est validé**.
+
+**Test 1.2.2 :**
+
+1. Retrouver dans le document les images décoratives structurées au moyen d’un élément `<area>` (sans attribut `href`) ;
+2. Pour chaque image, vérifier que l’élément `<area>` ne possède pas d’attributs `aria-labelledby`, `aria-label` ou `title` et qu’il possède :
+   - Soit un attribut `alt` vide (`alt=""`) ;
+   - Soit un attribut WAI-ARIA `aria-hidden="true"` ou `role="presentation"`.
+3. Si c’est le cas pour chaque image, **le test est validé**.
+
+**Test 1.2.3 :**
+
+1. Retrouver dans le document les images décoratives structurées dépourvues de légende au moyen d’un élément `<object>` (avec un attribut `type="image/…"`) ;
+2. Pour chaque image, vérifier que la balise ouvrante `<object>` ne possède pas d’attributs `aria-labelledby`, `aria-label` ou `title` et qu’elle :
+   - Possède un attribut WAI-ARIA `aria-hidden="true"` ;
+   - Et est dépourvue d’alternative textuelle ;
+   - Et est dépourvue d’un contenu alternatif présent entre les balises `<object>` et `</object>`.
+3. Si c’est le cas pour chaque image, **le test est validé**.
+
+**Test 1.2.4 :**
+
+1. Retrouver dans le document les images décoratives dépourvues de légende structurées au moyen d’un élément `<svg>` ;
+2. Pour chaque image, vérifier que l’élément `<svg>` ne possède pas d’attributs `aria-labelledby` ou `aria-label` et qu’il :
+   - Possède un attribut WAI-ARIA `aria-hidden="true"` ;
+   - Et est dépourvu d’alternative textuelle (ainsi que ses éléments enfants) ;
+   - Et ne contient pas d’éléments `<title>` et `<desc>` à moins que vides de contenu ;
+   - Et est dépourvu d’attribut `title` (ainsi que ses éléments enfants).
+3. Si c’est le cas pour chaque image, **le test est validé**.
+
+**Test 1.2.5 :**
+
+1. Retrouver dans le document les images décoratives dépourvues de légende structurées au moyen d’un élément `<canvas>` ;
+2. Pour chaque image, vérifier que l’élément `<canvas>` ne possède pas d’attributs `aria-labelledby`, `aria-label` ou `title` et qu’il :
+   - Possède un attribut WAI-ARIA `aria-hidden="true"` ;
+   - Et est dépourvu d’alternative textuelle ;
+   - Et est dépourvu d’un contenu alternatif présent entre les balises `<canvas>` et `</canvas>`.
+3. Si c’est le cas pour chaque image, **le test est validé**.
+
+**Test 1.2.6 :**
+
+1. Retrouver dans le document les images décoratives dépourvues de légende structurées au moyen d’un élément `<embed>` (avec un attribut `type="image/…"`) ;
+2. Pour chaque image, vérifier que l’élément `<embed>` ne possède pas d’attributs `aria-labelledby`, `aria-label` ou `title` et qu’il :
+   - Possède un attribut WAI-ARIA `aria-hidden="true"` ;
+   - Et est dépourvu d’alternative textuelle ;
+3. Si c’est le cas pour chaque image, **le test est validé**.
+
+### Critère 1.3 — Pour chaque image porteuse d’information ayant une alternative textuelle, cette alternative est-elle pertinente (hors cas particuliers) ?
+
+**Test 1.3.1 :**
+
+1. Retrouver dans le document les images structurées au moyen d’un élément `<img>` (ou d’un élément possédant l’attribut WAI-ARIA `role="img"`) pourvues d’une alternative textuelle ;
+2. Pour chaque image, vérifier que l’alternative textuelle est pertinente ;
+3. Si c’est le cas pour chaque image, **le test est validé**.
+
+**Test 1.3.2 :**
+
+1. Retrouver dans le document les éléments `<area>` pourvus d’une alternative textuelle ;
+2. Pour chaque élément `<area>`, vérifier que l’alternative textuelle est pertinente ;
+3. Si c’est le cas pour chaque image, **le test est validé**.
+
+**Test 1.3.3 :**
+
+1. Retrouver dans le document les éléments `<input>` pourvus de l’attribut `type="image"` et d’une alternative textuelle ;
+2. Pour chaque élément `<input>` pourvu de l’attribut `type="image"`, vérifier que l’alternative textuelle est pertinente ;
+3. Si c’est le cas pour chaque image, **le test est validé**.
+
+**Test 1.3.4 :**
+
+1. Retrouver dans le document les éléments `<object>` pourvus de l’attribut `type="image/…"` et d’une alternative textuelle ;
+2. Pour chaque élément `<object>` pourvu de l’attribut `type="image/…"`, vérifier que l’alternative textuelle est pertinente ;
+3. Si c’est le cas pour chaque image, **le test est validé**.
+
+**Test 1.3.5 :**
+
+1. Retrouver dans le document les éléments `<embed>` pourvus de l’attribut `type="image/…"` et d’une alternative textuelle ;
+2. Pour chaque élément `<embed>` pourvu de l’attribut `type="image/…"`, vérifier que l’alternative textuelle est pertinente ;
+3. Si c’est le cas pour chaque image, **le test est validé**.
+
+**Test 1.3.6 :**
+
+1. Retrouver dans le document les éléments `<svg>` pourvus d’une alternative textuelle ;
+2. Pour chaque élément `<svg>`, vérifier que l’alternative textuelle est pertinente ;
+3. Si c’est le cas pour chaque image, **le test est validé**.
+
+**Test 1.3.7 :**
+
+1. Retrouver dans le document les éléments `<canvas>` pourvus d’une alternative textuelle ;
+2. Pour chaque élément `<canvas>`, vérifier que l’alternative textuelle est pertinente ;
+3. Si c’est le cas pour chaque image, **le test est validé**.
+
+**Test 1.3.8 :**
+
+1. Retrouver dans le document les éléments `<canvas>` pourvus d’un contenu alternatif entre les balises `<canvas>` et `</canvas>` ;
+2. Pour chaque élément `<canvas>`, vérifier que le contenu alternatif est correctement restitué par les technologies d’assistance ;
+3. Si c’est le cas pour chaque image, **le test est validé**.
+
+**Test 1.3.9 :**
+
+1. Retrouver dans le document les images pourvues d’une alternative textuelle ;
+2. Pour chaque image, vérifier l’alternative textuelle est courte et concise ;
+3. Si c’est le cas pour chaque image, **le test est validé**.
+
+### Critère 1.4 — Pour chaque image utilisée comme CAPTCHA ou comme image-test, ayant une alternative textuelle, cette alternative permet-elle d’identifier la nature et la fonction de l’image ?
+
+**Test 1.4.1 :**
+
+1. Retrouver dans le document les images structurées au moyen d’un élément `<img>` pourvues d’une alternative textuelle et utilisées comme CAPTCHA ou comme image-test ;
+2. Pour chaque image, vérifier que l’alternative textuelle est pertinente ;
+3. Si c’est le cas pour chaque image, **le test est validé**.
+
+**Test 1.4.2 :**
+
+1. Retrouver dans le document les éléments `<area>` pourvus d’une alternative textuelle et utilisés comme CAPTCHA ou comme image-test ;
+2. Pour chaque élément `<area>`, vérifier que l’alternative textuelle est pertinente ;
+3. Si c’est le cas pour chaque image, **le test est validé**.
+
+**Test 1.4.3 :**
+
+1. Retrouver dans le document les éléments `<input>` pourvus de l’attribut `type="image"` et d’une alternative textuelle, et utilisés comme CAPTCHA ou comme image-test ;
+2. Pour chaque élément `<input>` pourvu de l’attribut `type="image"`, vérifier que l’alternative textuelle est pertinente ;
+3. Si c’est le cas pour chaque image, **le test est validé**.
+
+**Test 1.4.4 :**
+
+1. Retrouver dans le document les éléments `<object>` pourvus de l’attribut `type="image/…"` et d’une alternative textuelle, et utilisés comme CAPTCHA ou comme image-test ;
+2. Pour chaque élément `<object>` pourvu de l’attribut `type="image/…"`, vérifier que l’alternative textuelle est pertinente ;
+3. Si c’est le cas pour chaque image, **le test est validé**.
+
+**Test 1.4.5 :**
+
+1. Retrouver dans le document les éléments `<embed>` pourvus de l’attribut `type="image/…"` et d’une alternative textuelle, et utilisés comme CAPTCHA ou comme image-test ;
+2. Pour chaque élément `<embed>` pourvu de l’attribut `type="image/…"`, vérifier que l’alternative textuelle est pertinente ;
+3. Si c’est le cas pour chaque image, **le test est validé**.
+
+**Test 1.4.6 :**
+
+1. Retrouver dans le document les éléments `<svg>` pourvus d’une alternative textuelle et utilisés comme CAPTCHA ou comme image-test ;
+2. Pour chaque élément `<svg>`, vérifier que l’alternative textuelle est pertinente ;
+3. Si c’est le cas pour chaque image, **le test est validé**.
+
+**Test 1.4.7 :**
+
+1. Retrouver dans le document les éléments `<canvas>` pourvus d’une alternative textuelle et utilisés comme CAPTCHA ou comme image-test ;
+2. Pour chaque élément `<canvas>`, vérifier que l’alternative textuelle est pertinente ;
+3. Si c’est le cas pour chaque image, **le test est validé**.
+
+### Critère 1.5 — Pour chaque image utilisée comme CAPTCHA, une solution d’accès alternatif au contenu ou à la fonction du CAPTCHA est-elle présente ?
+
+**Test 1.5.1 :**
+
+1. Retrouver dans le document les images (éléments `<img>`, `<area>`, `<object>`, `<embed>`, `<svg>`, `<canvas>` ou possédant un attribut WAI-ARIA `role="img"`) utilisés comme CAPTCHA ou comme image-test ;
+2. Pour chaque image, vérifier qu’il existe :
+   - Soit une autre forme de CAPTCHA non graphique, au moins ;
+   - Soit une autre solution d’accès à la fonctionnalité qui est sécurisée par le CAPTCHA.
+3. Si c’est le cas pour chaque image, **le test est validé**.
+
+**Test 1.5.2 :**
+
+1. Retrouver dans le document les boutons associés à une image (éléments `<input>` avec l’attribut `type="image"`) utilisés comme CAPTCHA ou comme image-test ;
+2. Pour chaque bouton associé à une image, vérifier qu’il existe :
+   - Soit une autre forme de CAPTCHA non graphique, au moins ;
+   - Soit une autre solution d’accès à la fonctionnalité qui est sécurisée par le CAPTCHA.
+3. Si c’est le cas pour chaque image, **le test est validé**.
+
+### Critère 1.6 — Chaque image porteuse d’information a-t-elle, si nécessaire, une description détaillée ?
+
+**Test 1.6.1 :**
+
+1. Retrouver dans le document les images structurées au moyen d’un élément `<img>` (ou d’un élément possédant l’attribut WAI-ARIA `role="img"`) porteuses d’information qui nécessitent une description détaillée ;
+2. Pour chaque image, vérifier qu’il existe :
+   - Soit un attribut longdesc qui donne l’adresse (url) d’une page ou d’un emplacement dans la page contenant la description détaillée ;
+   - Soit une alternative textuelle contenant la référence à une description détaillée adjacente à l’image ;
+   - Soit un lien ou un bouton adjacent permettant d’accéder à la description détaillée.
+3. Si c’est le cas pour chaque image, **le test est validé**.
+
+**Test 1.6.2 :**
+
+1. Retrouver dans le document les éléments `<object>` pourvus de l’attribut `type="image/…"`, porteurs d’information qui nécessitent une description détaillée ;
+2. Pour chaque élément `<object>` pourvu de l’attribut `type="image/…"`, vérifier qu’il existe :
+   - Soit une alternative textuelle contenant la référence à une description détaillée adjacente à l’image ;
+   - Soit un lien ou un bouton adjacent permettant d’accéder à la description détaillée.
+3. Si c’est le cas pour chaque élément `<object>` pourvu de l’attribut `type="image/…"`, **le test est validé**.
+
+**Test 1.6.3 :**
+
+1. Retrouver dans le document les éléments `<embed>` pourvus de l’attribut `type="image/…"`, porteurs d’information qui nécessitent une description détaillée ;
+2. Pour chaque élément `<embed>` pourvu de l’attribut `type="image/…"`, vérifier qu’il existe :
+   - Soit une alternative textuelle contenant la référence à une description détaillée adjacente à l’image ;
+   - Soit un lien ou un bouton adjacent permettant d’accéder à la description détaillée.
+3. Si c’est le cas pour chaque élément `<embed>` pourvu de l’attribut `type="image/…"`, **le test est validé**.
+
+**Test 1.6.4 :**
+
+1. Retrouver dans le document les éléments `<input>` pourvus de l’attribut `type="image"`, porteurs d’information qui nécessitent une description détaillée ;
+2. Pour chaque élément `<input>` pourvu de l’attribut `type="image"`, vérifier qu’il existe :
+   - Soit une alternative textuelle contenant la référence à une description détaillée adjacente à l’image ;
+   - Soit un lien ou un bouton adjacent permettant d’accéder à la description détaillée ;
+   - Soit un attribut WAI-ARIA aria-describedby associant un passage de texte faisant office de description détaillée.
+3. Si c’est le cas pour chaque élément `<input>` pourvu de l’attribut `type="image"`, **le test est validé**.
+
+**Test 1.6.5 :**
+
+1. Retrouver dans le document les éléments `<svg>` porteurs d’information qui nécessitent une description détaillée ;
+2. Pour chaque élément `<svg>`, vérifier qu’il existe :
+   - Soit un attribut WAI-ARIA `aria-label` contenant l’alternative textuelle et une référence à une description détaillée adjacente ;
+   - Soit un attribut WAI-ARIA `aria-labelledby` associant un passage de texte faisant office d’alternative textuelle et un autre faisant office de description détaillée ;
+   - Soit un attribut WAI-ARIA `aria-describedby` associant un passage de texte faisant office de description détaillée ;
+   - Soit un lien ou un bouton adjacent permettant d’accéder à la description détaillée.
+3. Si c’est le cas pour chaque élément `<svg>`, **le test est validé**.
+
+**Test 1.6.6 :**
+
+1. Retrouver dans le document les éléments `<svg>` porteurs d’information dont la description détaillée est fournie au moyen d’un attribut `aria-label`, `aria-labelledby` ou `aria-describedby` ;
+2. Pour chaque élément `<svg>`, vérifier que le contenu de la description détaillée est correctement restitué par les technologies d’assistance ;
+3. Si c’est le cas pour chaque élément `<svg>`, **le test est validé**.
+
+**Test 1.6.7 :**
+
+1. Retrouver dans le document les éléments `<canvas>` porteurs d’information qui nécessitent une description détaillée ;
+2. Pour chaque élément `<canvas>`, vérifier qu’il existe :
+   - Soit un attribut WAI-ARIA aria-label contenant l’alternative textuelle et une référence à une description détaillée adjacente ;
+   - Soit un attribut WAI-ARIA aria-labelledby associant un passage de texte faisant office d’alternative textuelle et un autre faisant office de description détaillée ;
+   - Soit un contenu textuel entre `<canvas>` et `</canvas>` faisant référence à une description détaillée adjacente à l’image bitmap ;
+   - Soit un contenu textuel entre `<canvas>` et `</canvas>` faisant office de description détaillée ;
+   - Soit un lien ou un bouton adjacent permettant d’accéder à la description détaillée.
+3. Si c’est le cas pour chaque élément `<canvas>`, **le test est validé**.
+
+**Test 1.6.8 :**
+
+1. Retrouver dans le document les éléments `<canvas>` porteurs d’information dont la description détaillée est fournie au moyen d’un attribut `aria-label`, `aria-labelledby` ou `aria-describedby` ;
+2. Pour chaque élément `<canvas>`, vérifier que le contenu de la description détaillée est correctement restitué par les technologies d’assistance ;
+3. Si c’est le cas pour chaque élément `<canvas>`, **le test est validé**.
+
+**Test 1.6.9 :**
+
+1. Retrouver dans le document les images (éléments `<img>`, `<input>` avec l’attribut `type="image"`, `<area>`, `<object>`, `<embed>`, `<svg>`, `<canvas>` ou possédant un attribut WAI-ARIA `role="img"`) porteuses d’information dont la description détaillée utilise un attribut WAI-ARIA `aria-describedby` ;
+2. Pour chaque image, vérifier que le contenu de la description détaillée est correctement restitué par les technologies d’assistance ;
+3. Si c’est le cas pour chaque image, **le test est validé**.
+
+**Test 1.6.10 :**
+
+1. Retrouver dans le document les éléments pourvus d’un attribut WAI-ARIA `role="img"` porteurs d’information qui nécessitent une description détaillée ;
+2. Pour chaque élément `role="img"`, vérifier qu’il existe :
+   - Soit un attribut WAI-ARIA `aria-label` contenant l’alternative textuelle et une référence à une description détaillée adjacente ;
+   - Soit un attribut WAI-ARIA `aria-labelledby` associant un passage de texte faisant office d’alternative textuelle et un autre faisant office de description détaillée ;
+   - Soit un attribut WAI-ARIA `aria-describedby` associant un passage de texte faisant office de description détaillée ;
+   - Soit un lien ou un bouton adjacent permettant d’accéder à la description détaillée.
+3. Si c’est le cas pour chaque élément `role="img"`, **le test est validé**.
+
+### Critère 1.7 — Pour chaque image porteuse d’information ayant une description détaillée, cette description est-elle pertinente ?
+
+**Test 1.7.1 :**
+
+1. Retrouver dans le document les images structurées au moyen d’un élément `<img>` qui possèdent une description détaillée ;
+2. Pour chaque image, vérifier que la description détaillée est pertinente ;
+3. Si c’est le cas pour chaque image, **le test est validé**.
+
+**Test 1.7.2 :**
+
+1. Retrouver dans le document les éléments `<input>` pourvus de l’attribut `type="image"` qui possèdent une description détaillée ;
+2. Pour chaque élément `<input>` pourvu de l’attribut `type="image"`, vérifier que la description détaillée est pertinente ;
+3. Si c’est le cas pour chaque image, **le test est validé**.
+
+**Test 1.7.3 :**
+
+1. Retrouver dans le document les éléments `<object>` pourvus de l’attribut `type="image/…"` qui possèdent une description détaillée ;
+2. Pour chaque élément `<object>` pourvu de l’attribut `type="image/…"`, vérifier que la description détaillée est pertinente ;
+3. Si c’est le cas pour chaque image, **le test est validé**.
+
+**Test 1.7.4 :**
+
+1. Retrouver dans le document les éléments `<embed>` pourvus de l’attribut `type="image/…"` qui possèdent une description détaillée ;
+2. Pour chaque élément `<embed>` pourvu de l’attribut `type="image/…"`, vérifier que la description détaillée est pertinente ;
+3. Si c’est le cas pour chaque image, **le test est validé**.
+
+**Test 1.7.5 :**
+
+1. Retrouver dans le document les éléments `<svg>` qui possèdent une description détaillée ;
+2. Pour chaque élément `<svg>`, vérifier que la description détaillée est pertinente ;
+3. Si c’est le cas pour chaque image, **le test est validé**.
+
+**Test 1.7.6 :**
+
+1. Retrouver dans le document les éléments `<canvas>` qui possèdent une description détaillée ;
+2. Pour chaque élément `<canvas>`, vérifier que la description détaillée est pertinente ;
+3. Si c’est le cas pour chaque image, **le test est validé**.
+
+### Critère 1.8 — Chaque image texte porteuse d’information, en l’absence d’un mécanisme de remplacement, doit si possible être remplacée par du texte stylé. Cette règle est-elle respectée (hors cas particuliers) ?
+
+**Test 1.8.1 :**
+
+1. Retrouver dans le document les images texte structurées au moyen d’un élément `<img>` (ou d’un élément possédant l’attribut WAI-ARIA `role="img"`) ;
+2. Pour chaque image, vérifier que :
+   - Soit il existe un mécanisme de remplacement ;
+   - Soit l’image contient un texte qui fait appel à un effet graphique qui ne peut pas être reproduit en CSS.
+3. Si c’est le cas pour chaque image, **le test est validé**.
+
+**Test 1.8.2 :**
+
+1. Retrouver dans le document les boutons “images texte” (élément `<input>` avec l’attribut `type="image"`) ;
+2. Pour chaque image, vérifier que :
+   - Soit il existe un mécanisme de remplacement ;
+   - Soit l’image contient un texte qui fait appel à un effet graphique qui ne peut pas être reproduit en CSS.
+3. Si c’est le cas pour chaque image, **le test est validé**.
+
+**Test 1.8.3 :**
+
+1. Retrouver dans le document les images texte objet (élément `<object>` avec l’attribut `type="image/…"`) ;
+2. Pour chaque image, vérifier que :
+   - Soit il existe un mécanisme de remplacement ;
+   - Soit l’image contient un texte qui fait appel à un effet graphique qui ne peut pas être reproduit en CSS.
+3. Si c’est le cas pour chaque image, **le test est validé**.
+
+**Test 1.8.4 :**
+
+1. Retrouver dans le document les images texte embarquées (élément `<embed>` avec l’attribut `type="image/…"`) ;
+2. Pour chaque image, vérifier que :
+   - Soit il existe un mécanisme de remplacement ;
+   - Soit l’image contient un texte qui fait appel à un effet graphique qui ne peut pas être reproduit en CSS.
+3. Si c’est le cas pour chaque image, **le test est validé**.
+
+**Test 1.8.5 :**
+
+1. Retrouver dans le document les images texte bitmap (élément `<canvas>`) ;
+2. Pour chaque image, vérifier que :
+   - Soit il existe un mécanisme de remplacement ;
+   - Soit l’image contient un texte qui fait appel à un effet graphique qui ne peut pas être reproduit en CSS.
+3. Si c’est le cas pour chaque image, **le test est validé**.
+
+**Test 1.8.6 :**
+
+1. Retrouver dans le document les images texte vectorielle (élément `<svg>`) porteuse d’information et dont le texte n’est pas complètement structuré au moyen d’éléments `<text>` ;
+2. Pour chaque image, vérifier que :
+   - Soit il existe un mécanisme de remplacement ;
+   - Soit l’image contient un texte qui fait appel à un effet graphique qui ne peut pas être reproduit en CSS.
+3. Si c’est le cas pour chaque image, **le test est validé**.
+
+### Critère 1.9 — Chaque légende d’image est-elle, si nécessaire, correctement reliée à l’image correspondante ?
+
+**Test 1.9.1 :**
+
+1. Retrouver dans le document les images pourvues d’une légende structurées au moyen d’élément `<img>`, d’un élément `<input>` avec l’attribut `type="image"` ou d’un élément possédant l’attribut WAI-ARIA `role="img"` ;
+2. Pour chaque image, vérifier que :
+   - L’image et sa légende sont contenues dans une balise `<figure>` ;
+   - La balise `<figure>` possède une propriété WAI-ARIA `role="figure"` ou `role="group"` ;
+   - La balise `<figure>` possède un attribut WAI-ARIA `aria-label` dont le contenu est identique au contenu de la légende ;
+   - La légende est contenue dans une balise `<figcaption>`.
+3. Si c’est le cas pour chaque image, **le test est validé**.
+
+**Test 1.9.2 :**
+
+1. Retrouver dans le document les images objet pourvues d’une légende (élément `<object>` avec l’attribut `type="image/…"`) ;
+2. Pour chaque image, vérifier que :
+   - L’image et sa légende sont contenues dans une balise `<figure>` ;
+   - La balise `<figure>` possède une propriété WAI-ARIA `role="figure`" ou `role="group"` ;
+   - La balise `<figure>` possède un attribut WAI-ARIA `aria-label` dont le contenu est identique au contenu de la légende ;
+   - La légende est contenue dans une balise `<figcaption>`.
+3. Si c’est le cas pour chaque image, **le test est validé**.
+
+**Test 1.9.3 :**
+
+1. Retrouver dans le document les images embarquées pourvues d’une légende (élément `<embed>` avec l’attribut `type="image/…"`) ;
+2. Pour chaque image, vérifier que :
+   - L’image et sa légende sont contenues dans une balise `<figure>` ;
+   - La balise `<figure>` possède une propriété WAI-ARIA `role="figure"` ou `role="group"` ;
+   - La balise `<figure>` possède un attribut WAI-ARIA `aria-label` dont le contenu est identique au contenu de la légende ;
+   - La légende est contenue dans une balise `<figcaption>`.
+3. Si c’est le cas pour chaque image, **le test est validé**.
+
+**Test 1.9.4 :**
+
+1. Retrouver dans le document les images vectorielles pourvues d’une légende (élément `<svg>`) ;
+2. Pour chaque image, vérifier que :
+   - L’image et sa légende sont contenues dans une balise `<figure>` ;
+   - La balise `<figure>` possède une propriété WAI-ARIA `role="figure"` ou `role="group"` ;
+   - La balise `<figure>` possède un attribut WAI-ARIA `aria-label` dont le contenu est identique au contenu de la légende ;
+   - La légende est contenue dans une balise `<figcaption>`.
+3. Si c’est le cas pour chaque image, **le test est validé**.
+
+**Test 1.9.5 :**
+
+1. Retrouver dans le document les images bitmap (élément `<canvas>`) ;
+2. Pour chaque image, vérifier que :
+   - L’image et sa légende sont contenues dans une balise `<figure>` ;
+   - La balise `<figure>` possède une propriété WAI-ARIA `role="figure"` ou `role="group"` ;
+   - La balise `<figure>` possède un attribut WAI-ARIA `aria-label` dont le contenu est identique au contenu de la légende ;
+   - La légende est contenue dans une balise `<figcaption>`.
+3. Si c’est le cas pour chaque image, **le test est validé**.
+
+## 2. Cadres
+
+### Critère 2.1 — Chaque cadre a-t-il un titre de cadre ?
+
+**Test 2.1.1 :**
+
+1. Retrouver dans le document les cadres (élément `<iframe>` ou `<frame>`) ;
+2. Pour chaque cadre, vérifier qu’il possède un attribut `title `;
+3. Si c’est le cas pour chaque cadre, **le test est validé**.
+
+### Critère 2.2 — Pour chaque cadre ayant un titre de cadre, ce titre de cadre est-il pertinent ?
+
+**Test 2.2.1 :**
+
+1. Retrouver dans le document les cadres (élément `<iframe>` ou `<frame>`) ;
+2. Pour chaque cadre pourvu d’un attribut `title`, vérifier que son contenu est pertinent ;
+3. Si c’est le cas pour chaque cadre, **le test est validé**.
+
+## 3. Couleurs
+
+### Critère 3.1 — Dans chaque page web, l’information ne doit pas être donnée uniquement par la couleur. Cette règle est-elle respectée ?
+
+**Test 3.1.1 :**
+
+1. Retrouver dans le document les informations données par la couleur dans un mot ou un ensemble de mots ;
+2. Pour chacune de ces informations, vérifier qu’il existe un autre moyen de récupérer cette information (présence d’un attribut title, d’une icône ou d’un effet graphique de forme ou de position, un effet typographique…) ;
+3. Si c’est le cas pour chaque information, **le test est validé**.
+
+**Test 3.1.2 :**
+
+1. Retrouver dans le document les informations données par la couleur dans un texte ;
+2. Pour chacune de ces informations, vérifier qu’il existe un autre moyen de récupérer cette information (présence d’un attribut title, d’une icône ou d’un effet graphique de forme ou de position, un effet typographique…) ;
+3. Si c’est le cas pour chaque information, **le test est validé**.
+
+**Test 3.1.3 :**
+
+1. Retrouver dans le document les informations données par la couleur dans une image ;
+2. Pour chacune de ces informations, vérifier qu’il existe un autre moyen de récupérer cette information (présence d’un attribut title, d’une icône ou d’un effet graphique de forme ou de position, un effet typographique…) ;
+3. Si c’est le cas pour chaque information, **le test est validé**.
+
+**Test 3.1.4 :**
+
+1. Retrouver dans le document les informations données par la couleur dans une propriété CSS ;
+2. Pour chacune de ces informations, vérifier qu’il existe un autre moyen de récupérer cette information (présence d’un attribut title, d’une icône ou d’un effet graphique de forme ou de position, un effet typographique…) ;
+3. Si c’est le cas pour chaque information, **le test est validé**.
+
+**Test 3.1.5 :**
+
+1. Retrouver dans le document les informations données par la couleur dans un média temporel ;
+2. Pour chacune de ces informations, vérifier qu’il existe un autre moyen de récupérer cette information (présence d’un attribut title, d’une icône ou d’un effet graphique de forme ou de position, un effet typographique…) ;
+3. Si c’est le cas pour chaque information, **le test est validé**.
+
+**Test 3.1.6 :**
+
+1. Retrouver dans le document les informations données par la couleur dans un média non temporel ;
+2. Pour chacune de ces informations, vérifier qu’il existe un autre moyen de récupérer cette information (présence d’un attribut title, d’une icône ou d’un effet graphique de forme ou de position, un effet typographique…) ;
+3. Si c’est le cas pour chaque information, **le test est validé**.
+
+### Critère 3.2 — Dans chaque page web, le contraste entre la couleur du texte et la couleur de son arrière-plan est-il suffisamment élevé (hors cas particuliers) ?
+
+**Test 3.2.1 :**
+
+1. Retrouver dans le document les textes et les textes en image sans effet de graisse d’une taille restituée inférieure à 24px qui pourraient poser des problèmes de contraste ;
+2. Pour chacun de ces textes, vérifier que :
+   - Soit le rapport de contraste entre le texte et son arrière-plan est de 4.5:1, au moins ;
+   - Soit un mécanisme permet à l’utilisateur d’afficher le texte avec un rapport de contraste de 4.5:1, au moins.
+3. Si c’est le cas pour chaque texte, **le test est validé**.
+
+**Test 3.2.2 :**
+
+1. Retrouver dans le document les textes et les textes en image en gras d’une taille restituée inférieure à 18,5px qui pourraient poser des problèmes de contraste ;
+2. Pour chacun de ces textes, vérifier que :
+   - Soit le rapport de contraste entre le texte et son arrière-plan est de 4.5:1, au moins ;
+   - Soit un mécanisme permet à l’utilisateur d’afficher le texte avec un rapport de contraste de 4.5:1, au moins.
+3. Si c’est le cas pour chaque texte, **le test est validé**.
+
+**Test 3.2.3 :**
+
+1. Retrouver dans le document les textes et les textes en image sans effet de graisse d’une taille restituée supérieure ou égale à 24px qui pourraient poser des problèmes de contraste ;
+2. Pour chacun de ces textes, vérifier que :
+   - Soit le rapport de contraste entre le texte et son arrière-plan est de 3:1, au moins ;
+   - Soit un mécanisme permet à l’utilisateur d’afficher le texte avec un rapport de contraste de 3:1, au moins.
+3. Si c’est le cas pour chaque texte, **le test est validé**.
+
+**Test 3.2.4 :**
+
+1. Retrouver dans le document les textes et les textes en image en gras d’une taille restituée supérieure ou égale à 18,5px qui pourraient poser des problèmes de contraste ;
+2. Pour chacun de ces textes, vérifier que :
+   - Soit le rapport de contraste entre le texte et son arrière-plan est de 3:1, au moins ;
+   - Soit un mécanisme permet à l’utilisateur d’afficher le texte avec un rapport de contraste de 3:1, au moins.
+3. Si c’est le cas pour chaque texte, **le test est validé**.
+
+**Test 3.2.5 :**
+
+1. Retrouver dans le document les mécanismes qui permettent d’afficher un rapport de contraste conforme ;
+2. Pour chacun de ces mécanismes, vérifier que le rapport de contraste entre le texte et la couleur d’arrière-plan est suffisamment élevé ;
+3. Si c’est le cas pour chaque mécanisme, **le test est validé**.
+
+### Critère 3.3 — Dans chaque page web, les couleurs utilisées dans les composants d’interface ou les éléments graphiques porteurs d’informations sont-elles suffisamment contrastées (hors cas particuliers) ?
+
+**Test 3.3.1 :**
+
+1. Retrouver dans le document les composants d’interface qui pourraient poser des problèmes de contraste ;
+2. Pour chacun de ces composants, vérifier que :
+   - Soit le rapport de contraste entre les couleurs du composant dans ses différents états et la couleur d’arrière-plan contiguë est de 3:1, au moins ;
+   - Soit un mécanisme permet à l’utilisateur d’afficher le composant avec un rapport de contraste de 3:1, au moins.
+3. Si c’est le cas pour chaque composant, **le test est validé**.
+
+**Test 3.3.2 :**
+
+1. Retrouver dans le document les éléments graphiques qui pourraient poser des problèmes de contraste ;
+2. Pour chacun de ces éléments, vérifier que :
+   - Soit le rapport de contraste entre les couleurs de l’élément graphique nécessaires à sa compréhension et la couleur d’arrière-plan contiguë est de 3:1, au moins ;
+   - Soit un mécanisme permet à l’utilisateur d’afficher l’élément graphique avec un rapport de contraste de 3:1, au moins.
+3. Si c’est le cas pour chaque composant, **le test est validé**.
+
+**Test 3.3.3 :**
+
+1. Retrouver dans le document les éléments graphiques qui pourraient poser des problèmes de contraste ;
+2. Pour chacun de ces éléments, vérifier que :
+   - Soit le rapport de contraste des différentes couleurs contiguës de l’élément graphique entre elles, lorsqu’elles sont nécessaires à sa compréhension, est de 3:1, au moins ;
+   - Soit un mécanisme permet à l’utilisateur d’afficher l’élément graphique avec un rapport de contraste de 3:1, au moins.
+3. Si c’est le cas pour chaque élément graphique, **le test est validé**.
+
+**Test 3.3.4 :**
+
+1. Retrouver dans le document les mécanismes qui permettent d’afficher un rapport de contraste conforme ;
+2. Pour chacun de ces mécanismes, vérifier que le rapport de contraste entre les couleurs du composant ou des éléments graphiques porteurs d’informations qui le composent est suffisamment élevé ;
+3. Si c’est le cas pour chaque mécanisme, **le test est validé**.
+
+Note : le critère est non applicable dans ces situations :
+
+- Composant d'interface inactif (par exemple, un bouton avec un attribut `disabled`) sur lequel aucune action n'est possible ;
+- Composant d'interface pour lequel l'apparence est gérée par les styles natifs du navigateur sans aucune modification par l'auteur (par exemple, le style au focus natif dans Chrome ou Firefox) ;
+- Composant d'interface pour lequel la couleur n'est pas nécessaire pour identifier le composant ou son état (par exemple, un groupe de liens faisant office de navigation dont la position dans la page, la taille et la couleur du texte permettent de comprendre qu'il s'agit de liens même si la couleur du soulignement des liens avec le fond blanc n'a pas un ratio de 3:1 et que le texte lui a un ratio de 4.5:1) ;
+- Élément graphique ou parties d'élément graphique non porteur d'information ou ayant une alternative (description longue, informations identiques visibles dans la page) ;
+- Élément graphique ou parties d'élément graphique faisant partie d'un logo ou du nom de marque d'un organisme ou d'une société ;
+- Élément graphique ou parties d'élément graphique dont la présentation est essentielle à l'information véhiculée (exemple drapeaux, logotypes, photos de personnes ou de scènes, captures d'écran, diagrammes médicaux, carte de chaleurs) ;
+- Élément graphique ou parties d'élément graphique dynamiques dont le contraste au survol / focus est suffisant.
+
+## 4. Multimédia
+
+### Critère 4.1 — Chaque média temporel pré-enregistré a-t-il, si nécessaire, une transcription textuelle ou une audiodescription (hors cas particuliers) ?
+
+**Test 4.1.1 :**
+
+1. Retrouver dans le document les médias temporels (éléments `<audio>`, `<video>` ou `<object>`) seulement audio qui nécessitent une transcription textuelle ;
+2. Pour chaque média temporel seulement audio, vérifier la présence d’une transcription textuelle :
+   - Soit accessible au moyen d’un bouton ou d’un lien adjacent (une URL ou une ancre) ;
+   - Soit adjacente clairement identifiable.
+3. Si c’est le cas pour chaque média temporel, **le test est validé**.
+
+**Test 4.1.2 :**
+
+1. Retrouver dans le document les médias temporels (éléments `<video>` ou `<object>`) seulement vidéo qui nécessitent une transcription textuelle ;
+2. Pour chaque média temporel seulement vidéo, vérifier la présence :
+   - Soit d’une version alternative audio seulement accessible au moyen d’un lien ou bouton adjacent (une URL ou une ancre) ;
+   - Soit d’une version alternative audio seulement adjacente ;
+   - Soit d’une transcription textuelle accessible au moyen d’un bouton ou d’un lien adjacent (une URL ou une ancre) ;
+   - Soit d’une transcription textuelle adjacente clairement identifiable ;
+   - Soit d’une audiodescription synchronisée ;
+   - Soit d’une version alternative avec une audiodescription synchronisée accessible au moyen d’un bouton ou d'un lien adjacent (une URL ou une ancre).
+3. Si c’est le cas pour chaque média temporel, **le test est validé**.
+
+**Test 4.1.3 :**
+
+1. Retrouver dans le document les médias temporels (éléments `<video>` ou `<object>`) synchronisés qui nécessitent une transcription textuelle ;
+2. Pour chaque média temporel synchronisé, vérifier la présence :
+   - Soit d’une transcription textuelle accessible au moyen d’un lien ou bouton adjacent (une URL ou une ancre) ;
+   - Soit d’une transcription textuelle adjacente clairement identifiable ;
+   - Soit d’une audiodescription synchronisée ;
+   - Soit d’une version alternative avec une audiodescription synchronisée accessible au moyen d’un bouton ou d’un lien adjacent (une URL ou une ancre).
+3. Si c’est le cas pour chaque média temporel, **le test est validé**.
+
+### Critère 4.2 — Pour chaque média temporel pré-enregistré ayant une transcription textuelle ou une audiodescription synchronisée, celles-ci sont-elles pertinentes (hors cas particuliers) ?
+
+**Test 4.2.1 :**
+
+1. Retrouver dans le document les médias temporels pré-enregistrés seulement audio qui possèdent une transcription textuelle ;
+2. Pour chaque média temporel seulement audio, vérifier que transcription textuelle est pertinente ;
+3. Si c’est le cas pour chaque média temporel, **le test est validé**.
+
+**Test 4.2.2 :**
+
+1. Retrouver dans le document les médias temporels pré-enregistrés seulement vidéo qui possèdent une transcription textuelle ;
+2. Pour chaque média temporel seulement vidéo, vérifier la pertinence :
+   - Soit de la transcription textuelle ;
+   - Soit de l’audiodescription synchronisée ;
+   - Soit de l’audiodescription synchronisée de la version alternative ;
+   - Soit de la version alternative audio seulement.
+3. Si c’est le cas pour chaque média temporel, **le test est validé**.
+
+**Test 4.2.3 :**
+
+1. Retrouver dans le document les médias temporels pré-enregistrés synchronisés ;
+2. Pour chaque média temporel synchronisé, vérifier la pertinence :
+   - Soit de la transcription textuelle ;
+   - Soit de l’audiodescription synchronisée ;
+   - Soit de l’audiodescription synchronisée de la version alternative.
+3. Si c’est le cas pour chaque média temporel, **le test est validé**.
+
+### Critère 4.3 — Chaque média temporel synchronisé pré-enregistré a-t-il, si nécessaire, des sous-titres synchronisés (hors cas particuliers) ?
+
+**Test 4.3.1 :**
+
+1. Retrouver dans le document les médias temporels pré-enregistrés synchronisés ;
+2. Pour chaque média temporel synchronisé, vérifier la présence :
+   - Soit de sous-titres synchronisés ;
+   - Soit d’une version alternative possédant des sous-titres synchronisés accessible au moyen d’un lien ou d’un bouton adjacent.
+3. Si c’est le cas pour chaque média temporel, **le test est validé**.
+
+**Test 4.3.2 :**
+
+1. Retrouver dans le document les médias temporels synchronisés possédant des sous-titres synchronisés au moyen d’un élément `<track>` ;
+2. Pour chaque média temporel synchronisé, vérifier que la balise `<track>` possède un attribut `kind="caption"` ;
+3. Si c’est le cas pour chaque média temporel synchronisé, **le test est validé**.
+
+### Critère 4.4 — Pour chaque média temporel synchronisé pré-enregistré ayant des sous-titres synchronisés, ces sous-titres sont-ils pertinents ?
+
+**Test 4.4.1 :**
+
+1. Retrouver dans le document les médias temporels synchronisés possédant des sous-titres synchronisés ;
+2. Pour chaque média temporel synchronisé, vérifier que les sous-titres sont :
+   - Pertinents (toutes les informations sonores importantes sont présentes, les dialogues notamment) ;
+   - Et correctement synchronisés.
+3. Si c’est le cas pour chaque média temporel synchronisé, **le test est validé**.
+
+### Critère 4.5 — Chaque média temporel pré-enregistré a-t-il, si nécessaire, une audiodescription synchronisée (hors cas particuliers) ?
+
+**Test 4.5.1 :**
+
+1. Retrouver dans le document les médias temporels pré-enregistrés seulement vidéo qui nécessitent une audiodescription ;
+2. Pour chaque média temporel seulement vidéo, vérifier la présence :
+   - Soit d’une audiodescription synchronisée ;
+   - Soit d’une version alternative avec une audiodescription synchronisée accessible au moyen d’un bouton ou d’un lien adjacent (une URL ou une ancre).
+3. Si c’est le cas pour chaque média temporel seulement vidéo, **le test est validé**.
+
+**Test 4.5.2 :**
+
+1. Retrouver dans le document les médias temporels pré-enregistrés synchronisés qui nécessitent une audiodescription ;
+2. Pour chaque média temporel synchronisé, vérifier la présence :
+   - Soit d’une audiodescription synchronisée ;
+   - Soit d’une version alternative avec une audiodescription synchronisée accessible au moyen d’un bouton ou d’un lien adjacent (une URL ou une ancre).
+3. Si c’est le cas pour chaque média temporel synchronisé, **le test est validé**.
+
+### Critère 4.6 — Pour chaque média temporel pré-enregistré ayant une audiodescription synchronisée, celle-ci est-elle pertinente ?
+
+**Test 4.6.1 :**
+
+1. Retrouver dans le document les médias temporels seulement vidéo qui possèdent une audiodescription ;
+2. Pour chaque média temporel, vérifier que l’audiodescription synchronisée est pertinente (toutes les informations visuelles qu’il est possible de vocaliser dans les blancs de la bande son principale sont présentes, les textes incrustés notamment) ;
+3. Si c’est le cas pour chaque média temporel seulement vidéo, **le test est validé**.
+
+**Test 4.6.2 :**
+
+1. Retrouver dans le document les médias temporels synchronisés qui possèdent une audiodescription ;
+2. Pour chaque média temporel, vérifier que l’audiodescription synchronisée est pertinente (toutes les informations visuelles qu’il est possible de vocaliser dans les blancs de la bande son principale sont présentes, les textes incrustés notamment) ;
+3. Si c’est le cas pour chaque média temporel synchronisé, **le test est validé**.
+
+### Critère 4.7 — Chaque média temporel est-il clairement identifiable (hors cas particuliers) ?
+
+**Test 4.7.1 :**
+
+1. Retrouver dans le document les médias temporels pré-enregistrés seulement vidéo, audio ou synchronisés ;
+2. Pour chaque média temporel, vérifier que :
+   - Un passage de texte (un titre ou un paragraphe, par exemple) qui précède ou suit immédiatement le média temporel, permet de l’identifier ;
+   - Et le passage de texte est situé à l’extérieur du lecteur de contenu multimédia si ce dernier fait appel à la technologie Flash.
+3. Si c’est le cas pour chaque média temporel, **le test est validé**.
+
+### Critère 4.8 — Chaque média non temporel a-t-il, si nécessaire, une alternative (hors cas particuliers) ?
+
+**Test 4.8.1 :**
+
+1. Retrouver dans le document les médias non temporels ;
+2. Pour chaque média non temporel, vérifier qu’un lien ou un bouton adjacent, clairement identifiable :
+   - Soit contient l’adresse (url) d’une page contenant une alternative ;
+   - Soit permet d’accéder à une alternative dans la page.
+3. Si c’est le cas pour chaque média non temporel, **le test est validé**.
+
+**Test 4.8.2 :**
+
+1. Retrouver dans le document les médias non temporels associés à une alternative ;
+2. Pour chaque média non temporel, vérifier que :
+   - La page référencée par le lien ou le bouton adjacent est accessible ;
+   - L’alternative dans la page, référencée par le lien ou le bouton adjacent, est accessible.
+3. Si c’est le cas pour chaque média non temporel, **le test est validé**.
+
+Note : le critère est non applicable dans les situations où :
+
+- Le média non temporel est utilisé à des fins décoratives (c'est-à-dire qu'il n'apporte aucune information) ;
+- Le média non temporel est diffusé dans un environnement maîtrisé ;
+- Le média non temporel est inséré via JavaScript en vérifiant la présence et la version du plug-in, en remplacement d'un contenu alternatif déjà présent.
+
+### Critère 4.9 — Pour chaque média non temporel ayant une alternative, cette alternative est-elle pertinente ?
+
+**Test 4.9.1 :**
+
+1. Retrouver dans le document les médias non temporels associés à une alternative ;
+2. Pour chaque média non temporel, vérifier que l’alternative est pertinente (elle permet d’accéder au même contenu et à des fonctionnalités similaires) ;
+3. Si c’est le cas pour chaque média non temporel, **le test est validé**.
+
+### Critère 4.10 — Chaque son déclenché automatiquement est-il contrôlable par l’utilisateur ?
+
+**Test 4.10.1 :**
+
+1. Au chargement du document, si un son se déclenche automatiquement, vérifier que :
+   - Soit la séquence sonore a une durée inférieure ou égale à 3 secondes ;
+   - Soit un dispositif (un bouton par exemple), sur l’élément ayant déclenché le son (voir note), ou dans la page, permet de le stopper ;
+   - Soit le volume de la séquence peut être contrôlé par l’utilisateur, indépendamment du contrôle de volume du système.
+2. Si c’est le cas, **le test est validé**.
+
+Note : les éléments suivants sont susceptibles de déclencher des sons au chargement de la page : éléments `<audio>`, `<video>`, `<object>`, `<embed>`, `<bgsound>` ou un code JavaScript (utilisation de la Web Audio API, par exemple).
+
+### Critère 4.11 — La consultation de chaque média temporel est-elle, si nécessaire, contrôlable par le clavier et tout dispositif de pointage ?
+
+**Test 4.11.1 :**
+
+1. Retrouver dans le document les médias temporels ;
+2. Pour chaque média temporel, vérifier la présence des fonctionnalités obligatoires de contrôle de la consultation :
+   - Au minimum : lecture, pause ou stop ;
+   - Si le média a du son, il doit avoir une fonctionnalité d’activation / désactivation du son ;
+   - Si le média a des sous-titres, il doit avoir une fonctionnalité de contrôle de l’apparition/disparition des sous-titres ;
+   - Si le média a une audiodescription, il doit avoir une fonctionnalité de contrôle de l’apparition/disparition de l’audiodescription.
+3. Si c’est le cas pour chaque média temporel, **le test est validé**.
+
+**Test 4.11.2 :**
+
+1. Retrouver dans le document les médias temporels pourvus de fonctionnalités de contrôle ;
+2. Pour chaque média temporel, vérifier que :
+   - Soit la fonctionnalité est accessible par le clavier et tout dispositif de pointage ;
+   - Soit une fonctionnalité accessible par le clavier et tout dispositif de pointage permettant de réaliser la même action est présente dans la page.
+3. Si c’est le cas pour chaque média temporel, **le test est validé**.
+
+**Test 4.11.3 :**
+
+1. Retrouver dans le document les médias temporels pourvus de fonctionnalités de contrôle ;
+2. Pour chaque média temporel, vérifier que :
+   - Soit la fonctionnalité est activable par le clavier et tout dispositif de pointage ;
+   - Soit une fonctionnalité activable par le clavier et tout dispositif de pointage permettant de réaliser la même action est présente dans la page.
+3. Si c’est le cas pour chaque média temporel, **le test est validé**.
+
+### Critère 4.12 — La consultation de chaque média non temporel est-elle contrôlable par le clavier et tout dispositif de pointage ?
+
+**Test 4.12.1 :**
+
+1. Retrouver dans le document les médias non temporels pourvus de fonctionnalités de contrôle ;
+2. Pour chaque média non temporel, vérifier que :
+   - Soit la fonctionnalité est accessible par le clavier et tout dispositif de pointage ;
+   - Soit une fonctionnalité accessible par le clavier et tout dispositif de pointage permettant de réaliser la même action est présente dans la page.
+3. Si c’est le cas pour chaque média non temporel, **le test est validé**.
+
+**Test 4.12.2 :**
+
+1. Retrouver dans le document les médias non temporels pourvus de fonctionnalités de contrôle ;
+2. Pour chaque média non temporel, vérifier que :
+   - Soit la fonctionnalité est activable par le clavier et tout dispositif de pointage ;
+   - Soit une fonctionnalité activable par le clavier et tout dispositif de pointage permettant de réaliser la même action est présente dans la page.
+3. Si c’est le cas pour chaque média non temporel, **le test est validé**.
+
+### Critère 4.13 — Chaque média temporel et non temporel est-il compatible avec les technologies d’assistance (hors cas particuliers) ?
+
+**Test 4.13.1 :**
+
+1. Retrouver dans le document les médias temporels et non temporels ;
+2. Pour chaque média, vérifier que :
+   - Soit le nom, le rôle, la valeur, le paramétrage et les changements d’états des composants d’interfaces sont accessibles aux technologies d’assistance via une API d’accessibilité (par exemple, les zones mises à jour dynamiquement dans un lecteur vidéo sont correctement restituées) ;
+   - Soit une alternative compatible avec une API d’accessibilité permet d’accéder aux mêmes fonctionnalités.
+3. Si c’est le cas pour chaque média temporel ou non temporel, **le test est validé**.
+
+**Test 4.13.2 :**
+
+1. Retrouver dans le document les médias temporels et non temporels qui possèdent une alternative compatible avec les technologies d’assistance ;
+2. Pour chaque média, vérifier que :
+   - Soit l’alternative est adjacente au média temporel ou non temporel ;
+   - Soit l’alternative est accessible au moyen d’un lien ou d’un bouton adjacent ;
+   - Soit un mécanisme permet de remplacer le média temporel ou non temporel par son alternative.
+3. Si c’est le cas pour chaque média temporel ou non temporel, **le test est validé**.
+
+## 5. Tableaux
+
+### Critère 5.1 — Chaque tableau de données complexe a-t-il un résumé ?
+
+**Test 5.1.1 :**
+
+1. Retrouver dans le document les tableaux de données complexes (tableau de données - élément `<table>` ou élément pourvu d’un attribut WAI-ARIA `role="table"` - contenant des en-têtes qui ne sont pas répartis uniquement sur la première ligne et/ou la première colonne de la grille ou dont la portée n’est pas valable pour l’ensemble de la colonne ou de la ligne) ;
+2. Pour chaque tableau de données complexe, vérifier qu’un passage de texte permettant de comprendre la nature et la structure du tableau, est présent :
+   - Soit dans l’élément `<caption>` ;
+   - Soit dans l’attribut `summary` de l’élément `<table>` (dans les versions de HTML et de XHTML antérieures à HTML 5) ;
+   - Soit dans un passage de texte lié au tableau avec l’attribut `aria-describedby`.
+3. Si c’est le cas pour chaque tableau de données complexe, **le test est validé**.
+
+### Critère 5.2 — Pour chaque tableau de données complexe ayant un résumé, celui-ci est-il pertinent ?
+
+**Test 5.2.1 :**
+
+1. Retrouver dans le document les résumés de tableaux de données complexes (tels que déterminés par le test 5.1.1) ;
+2. Pour chaque résumé, vérifier que son contenu est pertinent ;
+3. Si c’est le cas pour chaque résumé de tableaux de données complexes, **le test est validé**.
+
+### Critère 5.3 — Pour chaque tableau de mise en forme, le contenu linéarisé reste-t-il compréhensible ?
+
+**Test 5.3.1 :**
+
+1. Retrouver dans le document les tableaux de mise en forme ;
+2. Pour chaque tableau de mise en forme, vérifier que :
+   - L’ordre d’accès aux cellules est cohérent avec le contenu ;
+   - L’élément `<table>` est pourvu d’un attribut WAI-ARIA `role="presentation"`.
+3. Si c’est le cas pour chaque tableau de mise en forme, **le test est validé**.
+
+### Critère 5.4 — Pour chaque tableau de données ayant un titre, le titre est-il correctement associé au tableau de données ?
+
+**Test 5.4.1 :**
+
+1. Retrouver dans le document les tableaux de données pourvus d’un titre ;
+2. Pour chaque titre, vérifier qu’il est fourni au moyen :
+   - Soit d’un élément `<caption>` ;
+   - Soit d’un attribut `title` ;
+   - Soit d’un attribut WAI-ARIA `aria-label` ;
+   - Soit d’un attribut WAI-ARIA `aria-labelledby` référençant un passage de texte.
+3. Si c’est le cas pour chaque titre de tableau de données, **le test est validé**.
+
+### Critère 5.5 — Pour chaque tableau de données ayant un titre, celui-ci est-il pertinent ?
+
+**Test 5.5.1 :**
+
+1. Retrouver dans le document les tableaux de données pourvus d’un titre ;
+2. Pour chaque titre, vérifier qu’il est pertinent ;
+3. Si c’est le cas pour chaque titre de tableau de données, **le test est validé**.
+
+### Critère 5.6 — Pour chaque tableau de données, chaque en-tête de colonne et chaque en-tête de ligne sont-ils correctement déclarés ?
+
+**Test 5.6.1 :**
+
+1. Retrouver dans le document les tableaux de données ;
+2. Pour chaque en-tête de colonnes s’appliquant à la totalité de la colonne, vérifier que l’en-tête de colonne est structuré au moyen :
+   - Soit d’un élément `<th>` ;
+   - Soit d’un élément pourvu d’un attribut WAI-ARIA `role="columnheader"`.
+3. Si c’est le cas pour chaque en-tête de colonne s’appliquant à la totalité de la colonne, **le test est validé**.
+
+**Test 5.6.2 :**
+
+1. Retrouver dans le document les tableaux de données ;
+2. Pour chaque en-tête de ligne s’appliquant à la totalité de la ligne, vérifier que l’en-tête de ligne est structuré au moyen :
+   - Soit d’un élément `<th>` ;
+   - Soit d’un élément pourvu d’un attribut WAI-ARIA `role="rowheader"`.
+3. Si c’est le cas pour chaque en-tête de ligne s’appliquant à la totalité de la ligne, **le test est validé**.
+
+**Test 5.6.3 :**
+
+1. Retrouver dans le document les tableaux de données ;
+2. Pour chaque en-tête ne s’appliquant pas à la totalité de la ligne ou de la colonne, vérifier que l’en-tête de ligne est structuré au moyen d’un élément `<th>` ;
+3. Si c’est le cas pour chaque en-tête ne s’appliquant pas à la totalité de la ligne ou de la colonne, **le test est validé**.
+
+**Test 5.6.4 :**
+
+1. Retrouver dans le document les tableaux de données ;
+2. Pour chaque cellule associée à plusieurs en-têtes est-elle structurée au moyen d’une balise `<th>` ou `<td>` ;
+3. Si c’est le cas pour chaque en-tête ne s’appliquant pas à la totalité de la ligne ou de la colonne, **le test est validé**.
+
+### Critère 5.7 — Pour chaque tableau de données, la technique appropriée permettant d’associer chaque cellule avec ses en-têtes est-elle utilisée (hors cas particuliers) ?
+
+**Test 5.7.1 :**
+
+1. Retrouver dans le document les tableaux de données ;
+2. Pour chaque en-tête (élément `<th>`) s’appliquant à la totalité de la ligne ou de la colonne, vérifier que l’élément `<th>` possède :
+   - Soit un attribut `id` unique ;
+   - Soit un attribut scope ;
+   - Soit un attribut WAI-ARIA `role="rowheader"` ou `"columnheader"`.
+3. Si c’est le cas pour chaque en-tête s’appliquant à la totalité de la ligne ou de la colonne, **le test est validé**.
+
+**Test 5.7.2 :**
+
+1. Retrouver dans le document les tableaux de données ;
+2. Pour chaque en-tête (élément `<th>`) s’appliquant à la totalité de la ligne ou de la colonne et pourvu d’un attribut `scope`, vérifier que l’attribut `scope` possède :
+   - Soit une valeur `"row"` pour les en-têtes de ligne ;
+   - Soit une valeur `"col"` pour les en-têtes de colonne.
+3. Si c’est le cas pour chaque en-tête s’appliquant à la totalité de la ligne ou de la colonne et pourvu d’un attribut `scope`, **le test est validé**.
+
+**Test 5.7.3 :**
+
+1. Retrouver dans le document les tableaux de données ;
+2. Pour chaque en-tête (élément `<th>`) ne s’appliquant pas à la totalité de la ligne ou de la colonne, vérifier que l’élément `<th>` :
+   - Possède un attribut `id` unique ;
+   - Et ne possède pas d’attribut `scope `;
+   - Et ne possède pas d’attribut WAI-ARIA `role="rowheader"` ou `"columnheader"`.
+3. Si c’est le cas pour chaque en-tête ne s’appliquant pas à la totalité de la ligne ou de la colonne, **le test est validé**.
+
+**Test 5.7.4 :**
+
+1. Retrouver dans le document les tableaux de données ;
+2. Pour chaque élément `<td>` ou `<th>` associé à un ou plusieurs en-têtes possédant un attribut `id`, vérifier que :
+   - L’élément `<td>` ou `<th>` possède un attribut `headers` ;
+   - Et l’attribut `headers` possède la liste des valeurs d’attribut `id` des en-têtes associés.
+3. Si c’est le cas pour chaque élément `<td>` ou `<th>` associé à un ou plusieurs en-têtes possédant un attribut `id`, **le test est validé**.
+
+**Test 5.7.5 :**
+
+1. Retrouver dans le document les tableaux de données ;
+2. Pour chaque en-tête s’appliquant à la totalité de la ligne ou de la colonne et pourvu d’un attribut WAI-ARIA `role="rowheader"` ou `"columnheader"`, vérifier que l’élément possède :
+   - Soit un attribut WAI-ARIA `role="rowheader"` pour les en-têtes de ligne ;
+   - Soit un attribut WAI-ARIA `role="columnheader"` pour les en-têtes de colonne.
+3. Si c’est le cas pour chaque en-tête s’appliquant à la totalité de la ligne ou de la colonne et pourvu d’un attribut WAI-ARIA `role="rowheader"` ou `"columnheader"`, **le test est validé**.
+
+### Critère 5.8 — Chaque tableau de mise en forme ne doit pas utiliser d’éléments propres aux tableaux de données. Cette règle est-elle respectée ?
+
+**Test 5.8.1 :**
+
+1. Retrouver dans le document les tableaux de mise en forme ;
+2. Pour chaque tableau de mise en forme, vérifier que :
+   - L’élément `<table>` ne possède pas d'attribut `summary`, d’éléments enfant `<caption>`, `<thead>`, `<th>`, `<tfoot>` ou d’éléments pourvus d’un attribut WAI-ARIA `role="rowheader"` ou `role="columnheader"` ;
+   - Les éléments `<td>` ne possèdent pas d’attributs `scope`, `headers` et `axis`.
+3. Si c’est le cas pour chaque tableau de mise en forme, **le test est validé**.
+
+## 6. Liens
+
+### Critère 6.1 — Chaque lien est-il explicite (hors cas particuliers) ?
+
+**Test 6.1.1 :**
+
+1. Retrouver dans le document les liens texte ;
+2. Pour chaque lien texte, vérifier que ce qui permet d’en comprendre la fonction et la destination est :
+   - Soit l’intitulé du lien seul ;
+   - Soit le contexte du lien.
+3. Si c’est le cas pour chaque lien texte, **le test est validé**.
+
+**Test 6.1.2 :**
+
+1. Retrouver dans le document les liens image (lien avec pour contenu un élément `<img>` ou un élément ayant l’attribut WAI-ARIA `role="img"`, un élément `<area>` possédant un attribut `href`, un élément `<object>`, un élément `<canvas>` ou un élément `<svg>`) ;
+2. Pour chaque lien image, vérifier que ce qui permet d’en comprendre la fonction et la destination est :
+   - Soit l’intitulé du lien seul, fourni par l’alternative textuelle de l’image ;
+   - Soit le contexte du lien.
+3. Si c’est le cas pour chaque lien image, **le test est validé**.
+
+**Test 6.1.3 :**
+
+1. Retrouver dans le document les liens composites (lien composé à la fois de contenu texte et d’éléments de type image) ;
+2. Pour chaque lien composite, vérifier que ce qui permet d’en comprendre la fonction et la destination est :
+   - Soit l’intitulé du lien seul, fourni par la combinaison du contenu texte et de l’alternative textuelle de l’image ;
+   - Soit le contexte du lien.
+3. Si c’est le cas pour chaque lien composite, **le test est validé**.
+
+**Test 6.1.4 :**
+
+1. Retrouver dans le document les liens SVG (élément `<svg>` qui possède un élément `<a>` pourvu d’un attribut `xlink-href` (SVG 1.1) ou `href` (SVG 2)) ;
+2. Pour chaque lien SVG, vérifier que ce qui permet d’en comprendre la fonction et la destination est :
+   - Soit l’intitulé du lien seul, fourni par le nom accessible de l’élément `<svg>` (résolu généralement à partir du contenu d’un élément `<text>`) ;
+   - Soit le contexte du lien.
+3. Si c’est le cas pour chaque lien SVG, **le test est validé**.
+
+**Test 6.1.5 :**
+
+1. Retrouver dans le document les liens autres que SVG dont le contenu est fourni à la fois par un intitulé visible et par le contenu soit d’un attribut title ou d’un attribut `aria-label` ou d’un attribut `aria-labelledby` ;
+2. Pour chaque lien, vérifier que le contenu de l’attribut `title` ou de l’attribut `aria-label` ou de l’attribut `aria-labelledby` contient l’intitulé visible ;
+3. Si c’est le cas pour chaque lien, **le test est validé** pour les liens autres que SVG.
+4. Retrouver dans le document les liens SVG dont le contenu est fourni à la fois par un intitulé visible et par le contenu soit d’un attribut `aria-labelledby`, ou d’un attribut `aria-label` ou d’un élément title (enfant direct de l’élément `<svg>`) ou d’un attribut x-link:title (SVG 1.1) ou d’un ou plusieurs éléments `<text>`;
+5. Pour chaque lien SVG, vérifier que le contenu de l’attribut `aria-labelledby` ou de l’attribut `aria-label` ou de l’élément `<title>` ou de l’attribut `x-link:title` ou d’un ou plusieurs éléments `<text>` contient l’intitulé visible ;
+6. Si c’est le cas pour chaque lien SVG, **le test est validé** pour les liens SVG.
+7. Si le test est validé à la fois pour les liens non SVG et pour les liens SVG, le test est globalement validé.
+
+Note : considérant la détermination du nom accessible, il existe deux cas particuliers et une particularité liée aux expressions mathématiques :
+
+- La ponctuation et les lettres majuscules présentes dans le texte de l’intitulé visible peuvent être ignorées dans le nom accessible sans porter à conséquence.
+- Si le texte de l’intitulé visible sert de symbole, il ne doit pas être interprété littéralement au niveau du nom accessible. Le nom doit exprimer la fonction véhiculée par le symbole (par exemple, "B" au niveau d'un éditeur de texte aura pour nom accessible "Mettre en gras", le signe ">" en fonction du contexte signifiera "Suivant" ou "Lancer la vidéo"). Le cas des symboles mathématiques fait cependant exception (voir le point ci-dessous).
+- Si l'étiquette visible représente une expression mathématique, les symboles mathématiques peuvent être repris littéralement pour servir d'étiquette au nom accessible (par exemple, "A>B"). Il est laissé à l'utilisateur le soin d'opérer la correspondance entre l'expression et ce qu'il doit épeler compte tenu de la connaissance qu'il a du fonctionnement de son logiciel de saisie vocale ("A plus grand que B" ou "A supérieur à B").
+
+### Critère 6.2 — Dans chaque page web, chaque lien a-t-il un intitulé ?
+
+**Test 6.2.1 :**
+
+1. Retrouver dans le document les liens quels qu’ils soient ;
+2. Pour chaque lien, vérifier que le contenu de l’élément `<a>` (ou d’un élément pourvu d’un attribut WAI-ARIA `role=link`) contient un intitulé (texte ou alternative) ;
+3. Si c’est le cas pour chaque lien, **le test est validé**.
+
+## 7. Scripts
+
+### Critère 7.1 — Chaque script est-il, si nécessaire, compatible avec les technologies d’assistance ?
+
+**Test 7.1.1 :**
+
+1. Retrouver dans le document tous les composants d’interface générés ou contrôlés au moyen de JavaScript ;
+2. Vérifier que :
+   - Le composant possède un rôle cohérent avec son usage (généralement un bouton ou un lien) ;
+   - Le composant possède un nom explicite ;
+   - Le nom du composant est cohérent avec l’état de la fonctionnalité ou des contenus contrôlés (par exemple pour une fonctionnalité permettant d’afficher ou de masquer une zone de contenu).
+3. Sinon, vérifier la présence d’un composant d’interface accessible permettant d’accéder aux mêmes fonctionnalités ;
+4. Sinon, vérifier la présence d’une alternative accessible permettant d’accéder aux mêmes fonctionnalités.
+5. Si c’est le cas, **le test est validé**.
+
+**Test 7.1.2 :**
+
+1. Pour chacun des composants d’interface ayant validé le test 7.1.1, vérifier que le composant d’interface est correctement restitué par les technologies d’assistance ;
+2. Sinon, vérifier qu’une alternative accessible au composant d’interface permet d’accéder aux mêmes fonctionnalités ;
+3. Si c’est le cas, **le test est validé**.
+
+**Test 7.1.3 :**
+
+1. Pour chacun des composants d’interface ayant validé le test 7.1.1, vérifier que le composant d’interface possède :
+   - Un nom pertinent (intitulé visible) ;
+   - Un rôle pertinent.
+2. Si le composant d’interface possède un nom accessible, vérifier que ce nom est pertinent et contient au moins l’intitulé visible.
+3. Si c’est le cas, **le test est validé**.
+
+### Critère 7.2 — Pour chaque script ayant une alternative, cette alternative est-elle pertinente ?
+
+**Test 7.2.1 :**
+
+1. Retrouver les alternatives aux fonctionnalités JavaScript :
+2. Chercher dans la page, les alternatives à un composant ou une fonctionnalité JavaScript mises à disposition.
+3. Désactiver JavaScript dans le document et retrouver les alternatives proposées.
+4. Pour chacune des alternatives proposées, vérifier qu’elle permet d’accéder aux mêmes contenus et à des fonctionnalités similaires.
+5. Si c’est le cas, **le test est validé**.
+
+**Test 7.2.2 :**
+
+1. Retrouver dans le document tous les éléments non textuels mis à jour par une fonctionnalité JavaScript.
+2. Si l'élément non textuel a une alternative, vérifier que :
+   - L'alternative est mise à jour lorsque le contenu non textuel est mis à jour ;
+   - L'alternative mise à jour est pertinente.
+3. Si c'est le cas, **le test est validé**.
+
+### Critère 7.3 — Chaque script est-il contrôlable par le clavier et par tout dispositif de pointage (hors cas particuliers) ?
+
+**Test 7.3.1 :**
+
+1. Retrouver dans le document, tous les éléments sur lesquels est implémenté un gestionnaire d’événements JavaScript (par exemple click, focus, mouseover, blur, keydown, touch…).
+2. Vérifier que l’élément est accessible au moyen du clavier :
+   - Il est atteignable avec la touche de tabulation (tab) ;
+   - Si l’élément gère une action simple, il est activable au clavier avec la touche entrée (Entrée) ;
+   - Si l’élément gère une action complexe, il est utilisable avec le clavier (généralement avec les touches de direction).
+3. Sinon, vérifier qu’un élément accessible par le clavier permettant de réaliser la même action est présent dans la page.
+4. Vérifier que l’élément est accessible par tout dispositif de pointage (souris, toucher, stylet…).
+5. Sinon, vérifier qu’un élément accessible au moyen d’un dispositif de pointage et permettant de réaliser la même action est présent dans la page.
+6. Si c’est le cas, **le test est validé**.
+
+**Test 7.3.2 :**
+
+1. Activer, l’un après l’autre, tous les éléments capables de recevoir le focus.
+2. Vérifier que le focus n’est pas supprimé via une fonctionnalité JavaScript.
+3. Si c’est le cas, **le test est validé**.
+
+### Critère 7.4 — Pour chaque script qui initie un changement de contexte, l’utilisateur est-il averti ou en a-t-il le contrôle ?
+
+**Test 7.4.1 :**
+
+1. Retrouver dans le document tous les événements JavaScript qui initient un changement de contexte, par exemple :
+   - Une mise à jour dynamique de champs de formulaire ;
+   - L’ouverture d’une nouvelle page à l’activation d’une option d’une liste de sélection (élément `<select>`) ;
+   - La mise à jour, via un procédé AJAX d’une partie essentielle de la page ;
+   - Le lancement automatique d’un lecteur vidéo suite à la sélection d’une playlist ;
+   - La manipulation du focus ayant pour résultat de modifier la position courante de l’utilisateur dans la page.
+2. Vérifier que :
+   - L’utilisateur est averti par un message de l’action du script et du type de changement avant son déclenchement ;
+   - Ou bien le changement de contexte est initié par un bouton (input de type submit, button ou image ou la balise button) explicite ;
+   - Ou bien le changement de contexte est initié par un lien explicite.
+3. Si c’est le cas, **le test est validé**.
+
+### Critère 7.5 — Dans chaque page web, les messages de statut sont-ils correctement restitués par les technologies d’assistance ?
+
+**Test 7.5.1 :**
+
+1. Retrouver dans le document les messages qui valent pour message de statut.
+2. Pour chacun de ces messages, déterminer la nature de l’information dont est porteur le message :
+3. Si le message informe de la réussite, du résultat d’une action ou bien de l’état d’une application, vérifier que l’élément qui contient le message :
+   - Soit utilise l’attribut WAI-ARIA `role=”status”` ;
+   - Soit utilise les attributs WAI-ARIA `aria-live=”polite”` et `aria-atomic=”true”`.
+4. Si le message présente une suggestion, ou avertit de l’existence d’une erreur, vérifier que l’élément qui contient le message :
+   - Soit utilise l’attribut WAI-ARIA `role=”alert”` ;
+   - Soit utilise les attributs `aria-live=”assertive”` et `aria-atomic=”true”`.
+5. Si le message indique la progression d’un processus, vérifier que l’élément qui contient le message :
+   - Soit utilise l’un des attributs WAI-ARIA `role=”log”`, `role=”progressbar”` ou `role=”status”` ;
+   - Soit utilise l’attribut WAI-ARIA `aria-live=”polite”` si l’intention est de signaler l’équivalent d’un `rôle “log”` ;
+   - Soit utilise les attributs WAI-ARIA `aria-live=”polite”` et aria-atomic=”true si l’intention est de signaler l’équivalent d’un rôle “status”.
+6. Si c’est le cas, **le test est validé**.
+
+**Test 7.5.2 :**
+Tests identiques à 7.5.1
+
+**Test 7.5.3 :**
+Tests identiques à 7.5.1
+
+## 8. Éléments obligatoires
+
+### Critère 8.1 — Chaque page web est-elle définie par un type de document ?
+
+**Test 8.1.1 :**
+
+1. Retrouver dans le document la balise DOCTYPE (par exemple `<!DOCTYPE html>`) ;
+2. Vérifier que :
+   - La balise DOCTYPE est placée avant la balise `<html>` ;
+   - Le type de document est valide.
+3. Si c’est le cas, **le test est validé**.
+
+**Test 8.1.2 :**
+Tests identiques à 8.1.1
+
+**Test 8.1.3 :**
+Tests identiques à 8.1.1
+
+### Critère 8.2 — Pour chaque page web, le code source généré est-il valide selon le type de document spécifié ?
+
+**Test 8.2.1 :**
+
+1. Dans le menu « Check », activer l’option « W3C Nu markup checker (all frames) ».
+2. Dans la page de résultats, vérifier que :
+   - Les balises, attributs et valeurs d’attributs respectent les règles d’écriture ;
+   - L’imbrication des balises est conforme ;
+   - L’ouverture et la fermeture des balises sont conformes ;
+   - Les valeurs d’attribut id sont uniques dans la page ;
+   - Les attributs ne sont pas doublés sur un même élément.
+3. Si c’est le cas, **le test est validé**.
+
+### Critère 8.3 — Dans chaque page web, la langue par défaut est-elle présente ?
+
+**Test 8.3.1 :**
+
+1. Retrouver dans le document l’indication de langue par défaut ;
+2. Vérifier la présence d’une indication de langue :
+   - Soit au moyen de l’attribut lang sur la balise html si le code est du HTML5 ou du HTML4 ;
+   - Soit au moyen des attributs lang et xml:lang sur la balise html si le code est du XHTML 1.0 ;
+   - Soit au moyen de l’attribut xml:lang sur la balise html si le code est du XHTML 1.1 ;
+   - Sinon, vérifier la présence d’une indication de langue sur chaque élément de texte ou l’un de ses parents.
+3. Si c’est le cas, **le test est validé**.
+
+### Critère 8.4 — Pour chaque page web ayant une langue par défaut, le code de langue est-il pertinent ?
+
+**Test 8.4.1 :**
+
+1. Retrouver dans le document l’indication de langue par défaut ;
+2. Vérifier la présence d’un code de langue :
+   - Valide (conforme à la norme ISO 639-1 ou ISO 639-2 et suivantes) ;
+   - Et pertinent (qui indique la langue principale du document).
+3. Si c’est le cas, **le test est validé**.
+
+### Critère 8.5 — Chaque page web a-t-elle un titre de page ?
+
+**Test 8.5.1 :**
+Test 8.5.1
+
+1. Retrouver dans le document le titre structuré au moyen d’un élément `<title>` ;
+2. Si c’est le cas, **le test est validé**.
+
+### Critère 8.6 — Pour chaque page web ayant un titre de page, ce titre est-il pertinent ?
+
+**Test 8.6.1 :**
+
+1. Retrouver dans le document le titre structuré au moyen d’un élément `<title>` ;
+2. Vérifier si le contenu de l’élément `<title>` est suffisamment pertinent (il permet de retrouver la page dans l’historique de navigation ou la liste des onglets).
+3. Si c’est le cas, **le test est validé**.
+
+### Critère 8.7 — Dans chaque page web, chaque changement de langue est-il indiqué dans le code source (hors cas particuliers) ?
+
+**Test 8.7.1 :**
+
+1. Retrouver les passages de texte en langue étrangère, à l’exception :
+   - Des noms propres ;
+   - Des mots d’origine étrangère, présents dans le dictionnaire de la langue du document ;
+   - Des mots d’origine étrangère et d’usage courant dont la prononciation ne provoque pas d’incompréhension.
+   - Vérifier que chaque passage de texte retenu possède une indication de langue (attribut `lang` et/ou `xml:lang` sur l’élément lui-même ou l’un de ses parents).
+2. Si c’est le cas, **le test est validé**.
+
+### Critère 8.8 — Dans chaque page web, le code de langue de chaque changement de langue est-il valide et pertinent ?
+
+**Test 8.8.1 :**
+
+1. Pour chaque passage de texte validé au test 8.7.1, vérifier que :
+   - L’indication de langue est valide ;
+   - L’indication de langue est pertinente.
+2. Si c’est le cas, **le test est validé**.
+
+### Critère 8.9 — Dans chaque page web, les balises ne doivent pas être utilisées uniquement à des fins de présentation. Cette règle est-elle respectée ?
+
+**Test 8.9.1 :**
+
+1. Retrouver dans le document l’ensemble des éléments sémantiques utilisés à des fins de présentation ;
+2. Pour chacun de ces éléments, vérifier que :
+   - L’élément est pourvu d’un attribut `role="presentation"` ;
+   - L’utilisation de cet élément à des fins de présentation reste justifée.
+3. Si c’est le cas, **le test est validé**.
+
+Note : Quelques exemples, non exhaustifs de détournement de balisage : un élément `<div>` utilisé comme paragraphe, un titre utilisé comme légende, un élément `<blockquote>` ou des paragraphes vides ou encore des espaces utilisés pour créer des effets de marges.
+L'utilisation d'un `role="presentation"` est formellement déconseillée, mais peut toutefois se justifier dans de rares cas. Cela peut être acceptable sur un élément `<blockquote>` ou un paragraphe vide, mais sera considéré comme non-conforme sur un titre.
+
+Le cas des tableaux : à noter que ce test aborde les tableaux de présentation qui ne devraient finalement pas apparaître au sein de la thématique Tableaux.
+
+### Critère 8.10 — Dans chaque page web, les changements du sens de lecture sont-ils signalés ?
+
+**Test 8.10.1 :**
+
+1. Retrouver dans le document les passages de textes qui utilisent une langue qui se lit dans le sens inverse de la langue du document (comme l’arabe ou l’hébreu pour le français par exemple).
+2. Pour chaque passage de texte, vérifier que le passage de texte est contenu dans une balise qui possède un attribut `dir`.
+3. Si c’est le cas pour chaque passage de texte, **le test est validé**.
+
+**Test 8.10.2 :**
+
+1. Pour chaque passage de texte validé au test 8.10.1, vérifier que :
+   - L’indication de sens de lecture est conforme (ltr, pour le sens « de gauche à droite » et rtl pour le sens « de droite à gauche ») ;
+   - L’indication de sens de lecture est pertinente.
+2. Si c’est le cas pour chaque passage de texte, **le test est validé**.
+
+## 9. Structuration de l’information
+
+### Critère 9.1 — Dans chaque page web, l’information est-elle structurée par l’utilisation appropriée de titres ?
+
+**Test 9.1.1 :**
+
+1. Retrouver dans le document les titres (balise `<hx>` ou balise possédant un attribut WAI-ARIA `role="heading"` associé à un attribut WAI-ARIA `aria-level`) ;
+2. Vérifier que la hiérarchie entre les titres est pertinente ;
+3. Si c’est le cas, **le test est validé**.
+
+**Test 9.1.2 :**
+
+1. Pour chaque titre identifié au test 9.1.1, vérifier que son contenu est pertinent ;
+2. Si c’est le cas pour chaque titre, **le test est validé**.
+
+**Test 9.1.3 :**
+
+1. Pour chaque titre identifié au test 9.1.1, vérifier que :
+   - Soit il est structuré au moyen d’une balise `<hx>` (“x” désignant une valeur numérique comprise entre 1 et 6);
+   - Soit il est structuré au moyen d’une balise possédant un attribut WAI-ARIA `role="heading"` et un attribut WAI-ARIA `aria-level=x` (“x” désignant une valeur numérique).
+2. Si c’est le cas pour chaque titre, **le test est validé**.
+
+### Critère 9.2 — Dans chaque page web, la structure du document est-elle cohérente (hors cas particuliers) ?
+
+**Test 9.2.1 :**
+
+1. Vérifier que la zone d’en-tête est structurée au moyen d’un élément `<header>` ;
+2. Vérifier que les zones de navigation principales et secondaires sont structurées au moyen d’un élément `<nav>` ;
+3. Vérifier que l’élément `<nav>` n’est pas utilisé en dehors de la structuration des zones de navigation principales et secondaires ;
+4. Vérifier que la zone de contenu principal est structurée au moyen d’un élément `<main>` ;
+5. Si le document possède plusieurs éléments `<main>`, vérifier qu’un seul de ces éléments est visible (les autres occurrences de l’élément sont pourvues d’un attribut `hidden`) ;
+6. Vérifier que la zone de pied de page est structurée au moyen d’un élément `<footer>`.
+7. Si c’est le cas pour chaque zone de contenu, **le test est validé**.
+
+### Critère 9.3 — Dans chaque page web, chaque liste est-elle correctement structurée ?
+
+**Test 9.3.1 :**
+
+1. Retrouver dans le document les éléments regroupés visuellement sous la forme d’une liste non ordonnée ;
+2. Pour chaque liste, vérifier que la liste est structurée :
+   - Soit au moyen des éléments `<ul>` et `<li>` ;
+   - Soit au moyen d’éléments pourvus d’attributs WAI-ARIA `role="list"` et `role="listitem"`.
+3. Si c’est le cas pour chaque liste non ordonnée, **le test est validé**.
+
+**Test 9.3.2 :**
+
+1. Retrouver dans le document les éléments regroupés visuellement sous la forme d’une liste ordonnée ;
+2. Pour chaque liste, vérifier que la liste est structurée :
+   - Soit au moyen des éléments `<ol>` et `<li>` ;
+   - Soit au moyen d’éléments pourvus d’attributs WAI-ARIA `role="list"` et `role="listitem"`.
+3. Si c’est le cas pour chaque liste ordonnée, **le test est validé**.
+
+**Test 9.3.3 :**
+
+1. Retrouver dans le document les éléments regroupés visuellement sous la forme d’une liste de description ;
+2. Pour chaque liste, vérifier que la liste est structurée au moyen des éléments `<dl>`, `<dt>` et `<dd>` ;
+3. Si c’est le cas pour chaque liste de description, **le test est validé**.
+
+### Critère 9.4 — Dans chaque page web, chaque citation est-elle correctement indiquée ?
+
+**Test 9.4.1 :**
+
+1. Retrouver dans le document les citations courtes (ou en ligne) ;
+2. Pour chaque citation, vérifier que la citation est structurée au moyen d’un élément `<q>` ;
+3. Si c’est le cas pour chaque citation courte, **le test est validé**.
+
+**Test 9.4.2 :**
+
+1. Retrouver dans le document les blocs de citation ;
+2. Pour chaque bloc de citation, vérifier que le bloc de citation est structuré au moyen d’un élément `<blockquote>` ;
+3. Si c’est le cas pour chaque bloc de citation, **le test est validé**.
+
+## 10. Présentation de l’information
+
+### Critère 10.1 — Dans le site web, des feuilles de styles sont-elles utilisées pour contrôler la présentation de l’information ?
+
+**Test 10.1.1 :**
+
+1. Vérifier l’absence des éléments de présentation `<basefont>`, `<big>`, `<blink>`, `<center>`, `<font>`, `<marquee>`, `<s>`, `<strike>`, `<tt>` ;
+2. Vérifier l’absence de l’élément `<u>` uniquement si le DOCTYPE du document ne correspond pas à HTML 5 ;
+3. Si c’est le cas, **le test est validé**.
+
+**Test 10.1.2 :**
+
+1. Vérifier l’absence des attributs de présentation : `align`, `alink`, `background`, `bgcolor`, `border`, `cellpadding`, `cellspacing`, `char`, `charoff`, `clear`, `color`, `compact`, `frameborder`, `hspace`, `link`, `marginheight`, `marginwidth`, `text`, `valign`, `vlink`, `vspace`, `size`(exception faite de l'élément `<select>`), `width` (exception faite des éléments `<img>`, `<object>`, `<embed>`, `<canvas>` et `<svg>`), `height` (exception faite des éléments `<img>`, `<object>`, `<embed>`, `<canvas>` et `<svg>`) ;
+2. Si c’est le cas, **le test est validé**.
+
+**Test 10.1.3 :**
+
+1. Désactiver les styles (CSS) du document ;
+2. Vérifier l’absence d’espaces utilisées :
+   - Entre les lettres d’un mot ;
+   - Pour créer des effets de marges ou d’alignement ;
+   - Pour simuler des tableaux ou des colonnes.
+3. Si c’est le cas, **le test est validé**.
+
+### Critère 10.2 — Dans chaque page web, le contenu visible porteur d’information reste-t-il présent lorsque les feuilles de styles sont désactivées ?
+
+**Test 10.2.1 :**
+
+1. Désactiver les styles (CSS) du document ;
+2. Comparer le document dépourvu de styles avec le document mis en forme ;
+3. Vérifier si dans le document dépourvu de styles, les contenus visibles porteurs d'information restent présents ;
+4. Si c’est le cas, **le test est validé**.
+
+### Critère 10.3 — Dans chaque page web, l’information reste-t-elle compréhensible lorsque les feuilles de styles sont désactivées ?
+
+**Test 10.3.1 :**
+
+1. Désactiver les styles (CSS) du document ;
+2. Vérifier que l’ordre dans lequel les contenus sont implémentés ne pose pas de problème de compréhension ;
+3. Si c’est le cas, **le test est validé**.
+
+### Critère 10.4 — Dans chaque page web, le texte reste-t-il lisible lorsque la taille des caractères est augmentée jusqu’à 200 %, au moins (hors cas particuliers) ?
+
+**Test 10.4.1 :**
+
+1. Vérifier dans le document si les textes restent présents et lisibles lorsque :
+   - Le zoom texte du navigateur est réglé à 200 % ;
+   - Le zoom graphique du navigateur est réglé à 200 % ;
+   - Les fonctionnalités de zoom personnalisées proposé par le document sont utilisés.
+2. Si c’est le cas, **le test est validé**.
+
+**Test 10.4.2 :**
+
+1. Vérifier dans le document si les textes sont effectivement agrandis lorsque :
+   - Le zoom texte du navigateur est réglé à 200 % ;
+   - Le zoom graphique du navigateur est réglé à 200 % ;
+   - Les fonctionnalités de zoom personnalisées proposé par le document sont utilisés.
+2. Si c’est le cas, **le test est validé**.
+
+### Critère 10.5 — Dans chaque page web, les déclarations CSS de couleurs de fond d’élément et de police sont-elles correctement utilisées ?
+
+**Test 10.5.1 :**
+
+1. Retrouver dans le document les textes mis en couleur, à l’exception des couleurs par défaut (par exemple les liens, etc.) ;
+2. Déterminer l’élément qui contient le texte et vérifier la présence d’une valeur calculée pour la propriété `background-color` de l’élément ;
+3. Si c’est le cas, **le test est validé**.
+
+**Test 10.5.2 :**
+
+1. Retrouver dans le document les textes mis en couleur, à l’exception des couleurs par défaut (par exemple les liens, etc.) ;
+2. Déterminer l’élément qui contient le texte et vérifier la présence d’une valeur calculée pour la propriété `color` de l’élément ;
+3. Si c’est le cas, **le test est validé**.
+
+**Test 10.5.3 :**
+
+1. Retrouver dans le document les textes dont l’arrière-plan est constitué d’une image (propriété background-image) ;
+2. Déterminer l’élément qui contient le texte et vérifier que si l’image d’arrière-plan est absente, le texte reste lisible ;
+3. Si c’est le cas, **le test est validé**.
+
+### Critère 10.6 — Dans chaque page web, chaque lien dont la nature n’est pas évidente est-il visible par rapport au texte environnant ?
+
+**Test 10.6.1 :**
+
+1. Retrouver dans le document les éléments de type lien (élément `<a>` ou élément pourvu d’un attribut WAI-ARIA `role="link"`) ;
+2. Pour chaque élément de type lien, s’il peut être confondu avec un texte normal lorsqu’il est signalé uniquement par la couleur, vérifier que le contraste entre la couleur de police du lien et la couleur de police du texte environnant est de 3:1, au moins ;
+3. Cette vérification doit être faite pour les différents états du lien s’ils sont présentés au moyen d’une couleur différente : l’état non visité, l’état visité, l’état activé, l’état au survol et l’état à la prise de focus ;
+4. Si c’est le cas pour chaque élément de type lien, **le test est validé**.
+
+### Critère 10.7 — Dans chaque page web, pour chaque élément recevant le focus, la prise de focus est-elle visible ?
+
+**Test 10.7.1 :**
+
+1. Retrouver dans le document les éléments susceptibles de recevoir le focus (les éléments d’interface tels que les liens ou les contrôles de formulaire, ainsi que tout élément pourvu d’un attribut `tabindex` d’une valeur égale ou supérieure à 1) ;
+2. Pour chaque élément susceptible de recevoir le focus, vérifier que l’indication visuelle de la prise de focus est présente (en agissant sur le contour ou le fond ou les deux) et est suffisamment contrastée (ratio de contraste égal ou supérieur à 3:1) ;
+3. Si c’est le cas pour chaque élément susceptible de recevoir le focus, **le test est validé**.
+
+### Critère 10.8 — Pour chaque page web, les contenus cachés ont-ils vocation à être ignorés par les technologies d’assistance ?
+
+**Test 10.8.1 :**
+
+1. Retrouver les contenus cachés (éléments pourvus de l’attribut hidden ou de l’attribut WAI-ARIA aria-hidden, ou bien d’une classe ou d’un ensemble de styles CSS susceptibles de masquer le contenu).
+2. Pour chaque contenu caché, vérifier que :
+   - Soit le contenu caché a vocation à être ignoré par les technologies d’assistance (un élément statistique de visites par exemple) ;
+   - Soit le contenu caché n’a pas vocation à être ignoré par les technologies d’assistance, et dans ce cas il est rendu restituable par les technologies d’assistance au moyen :
+     - Soit d’une action de l’utilisateur réalisable au clavier ou par tout dispositif de pointage sur un élément précédent le contenu caché ;
+     - Soit d’une fonction de programmation qui repositionne le focus sur le contenu.
+3. Si c’est le cas pour chaque contenu caché, **le test est validé**.
+
+### Critère 10.9 — Dans chaque page web, l’information ne doit pas être donnée uniquement par la forme, taille ou position. Cette règle est-elle respectée ?
+
+**Test 10.9.1 :**
+
+1. Retrouver dans le document les informations d’un texte données par la forme, la taille ou la position ;
+2. Pour chaque information donnée par la forme, la taille ou la position, vérifier qu’il existe un autre moyen de récupérer cette information ;
+3. Si c’est le cas pour chaque information, **le test est validé**.
+
+**Test 10.9.2 :**
+
+1. Retrouver dans le document les informations d’une image données par la forme, la taille ou la position ;
+2. Pour chaque information donnée par la forme, la taille ou la position, vérifier qu’il existe un autre moyen de récupérer cette information ;
+3. Si c’est le cas pour chaque information, **le test est validé**.
+
+**Test 10.9.3 :**
+
+1. Retrouver dans le document les informations d’un média temporel données par la forme, la taille ou la position ;
+2. Pour chaque information donnée par la forme, la taille ou la position, vérifier qu’il existe un autre moyen de récupérer cette information ;
+3. Si c’est le cas pour chaque information, **le test est validé**.
+
+**Test 10.9.4 :**
+
+1. Retrouver dans le document les informations d’un média non temporel données par la forme, la taille ou la position ;
+2. Pour chaque information donnée par la forme, la taille ou la position, vérifier qu’il existe un autre moyen de récupérer cette information ;
+3. Si c’est le cas pour chaque information, **le test est validé**.
+
+### Critère 10.10 — Dans chaque page web, l’information ne doit pas être donnée par la forme, taille ou position uniquement. Cette règle est-elle implémentée de façon pertinente ?
+
+**Test 10.10.1 :**
+
+1. Retrouver dans le document les informations d’un texte données par la forme, la taille ou la position ;
+2. Pour chaque information donnée par la forme, la taille ou la position, vérifier que le moyen alternatif de récupérer cette information est pertinent, c’est-à-dire qu’il permet de transmettre l’information dans tous les contextes de consultation et pour tous les utilisateurs.
+3. Si c’est le cas pour chaque information, **le test est validé**.
+
+**Test 10.10.2 :**
+
+1. Retrouver dans le document les informations d’une image données par la forme, la taille ou la position ;
+2. Pour chaque information donnée par la forme, la taille ou la position, vérifier que le moyen alternatif de récupérer cette information est pertinent, c’est-à-dire qu’il permet de transmettre l’information dans tous les contextes de consultation et pour tous les utilisateurs.
+3. Si c’est le cas pour chaque information, **le test est validé**.
+
+**Test 10.10.3 :**
+
+1. Retrouver dans le document les informations d’un média temporel données par la forme, la taille ou la position ;
+2. Pour chaque information donnée par la forme, la taille ou la position, vérifier que le moyen alternatif de récupérer cette information est pertinent, c’est-à-dire qu’il permet de transmettre l’information dans tous les contextes de consultation et pour tous les utilisateurs.
+3. Si c’est le cas pour chaque information, **le test est validé**.
+
+**Test 10.10.4 :**
+
+1. Retrouver dans le document les informations d’un média non temporel données par la forme, la taille ou la position ;
+2. Pour chaque information donnée par la forme, la taille ou la position, vérifier que le moyen alternatif de récupérer cette information est pertinent, c’est-à-dire qu’il permet de transmettre l’information dans tous les contextes de consultation et pour tous les utilisateurs.
+3. Si c’est le cas pour chaque information, **le test est validé**.
+
+### Critère 10.11 — Pour chaque page web, les contenus peuvent-ils être présentés sans perte d’information ou de fonctionnalité et sans avoir recours soit à un défilement vertical pour une fenêtre ayant une hauteur de 256 px, soit à un défilement horizontal pour une fenêtre ayant une largeur de 320 px (hors cas particuliers) ?
+
+**Test 10.11.1 :**
+
+1. Retrouver dans le document si son contenu est conçu pour défiler verticalement (le sens de lecture du texte est horizontal), les informations et fonctionnalités ;
+2. Réduire la fenêtre d’affichage à une largeur de 320 px et vérifier que les informations et les fonctionnalités restent disponibles sans aucun défilement horizontal ;
+3. Si c’est le cas, **le test est validé**.
+
+**Test 10.11.2 :**
+
+1. Retrouver dans le document si son contenu est conçu pour défiler horizontalement (le sens de lecture du texte est vertical), les informations et fonctionnalités ;
+2. Réduire la fenêtre d’affichage à une hauteur de 256 px et vérifier que les informations et les fonctionnalités restent disponibles sans aucun défilement vertical ;
+3. Si c’est le cas, **le test est validé**.
+
+### Critère 10.12 — Dans chaque page web, les propriétés d’espacement du texte peuvent-elles être redéfinies par l’utilisateur sans perte de contenu ou de fonctionnalité (hors cas particuliers) ?
+
+**Test 10.12.1 :**
+
+1. Modifier les styles du document en donnant :
+   - Une valeur de 1.5 à la propriété `line-height` de tous les éléments du document ;
+   - Une valeur de 2em à la propriété `margin-bottom` des éléments `<p>` ;
+   - Une valeur de 0.12em à la propriété `letter-spacing` de tous les éléments du document ;
+   - Une valeur de 0.16em à la propriété `word-spacing` de tous les éléments du document ;
+2. Pour chaque passage de texte, vérifier qu’il reste lisible, à l’exception :
+   - Des sous-titres directement intégrés à une vidéo ;
+   - Des images texte ;
+   - Des textes au sein d’une balise `<canvas>`.
+3. Si c’est le cas pour chaque passage de texte, **le test est validé**.
+
+Note : une implémentation de ces règles de modification est disponible dans les ressources du critère de succès WCAG 1.4.12 (https://github.com/alastc/adaptation-scripts/blob/master/scripts/text-adaptation.js).
+
+### Critère 10.13 — Dans chaque page web, les contenus additionnels apparaissant à la prise de focus ou au survol d’un composant d’interface sont-ils contrôlables par l’utilisateur (hors cas particuliers) ?
+
+**Test 10.13.1 :**
+
+1. Retrouver dans le document les contenus additionnels devenant visible à la prise de focus ou au survol d’un composant d’interface, à l’exception :
+   - Des contenus additionnels contrôlés par l’agent utilisateur (par exemple, les infobulles associées à l’attribut `title` ou à la validation native d’un formulaire ;
+   - Des contenus additionnels devenant visibles par une activation de l’utilisateur (par exemple, une fenêtre de dialogue).
+2. Pour chaque contenu additionnel, vérifier que :
+   - Soit le contenu additionnel est positionné de façon à ce qu’il ne gêne pas la consultation des autres contenus informatifs sur lesquels il viendrait se superposer (y compris le composant d’interface qui a déclenché son apparition), quelles que soient les conditions de consultation (y compris lors de l’utilisation d’un mécanisme de zoom) ;
+   - Soit un mécanisme (au clavier) permet de faire disparaître le contenu additionnel (par exemple, la touche Echap).
+3. Si c’est le cas pour chaque contenu additionnel, **le test est validé**.
+
+**Test 10.13.2 :**
+
+1. Retrouver dans le document les contenus additionnels devenant visible au survol d’un composant d’interface, à l’exception :
+   - Des contenus additionnels contrôlés par l’agent utilisateur (par exemple, les infobulles associées à l’attribut title ou à la validation native d’un formulaire) ;
+   - Des contenus additionnels devenant visibles par une activation de l’utilisateur (par exemple, une fenêtre de dialogue).
+2. Pour chaque contenu additionnel, vérifier qu’il peut être survolé par le pointeur de la souris sans disparaître ;
+3. Si c’est le cas pour chaque contenu additionnel, **le test est validé**.
+
+**Test 10.13.3 :**
+
+1. Retrouver dans le document les contenus additionnels devenant visible à la prise de focus ou au survol d’un composant d’interface, à l’exception :
+   - Des contenus additionnels contrôlés par l’agent utilisateur (par exemple, les infobulles associées à l’attribut `title` ou à la validation native d’un formulaire) ;
+   - Des contenus additionnels devenant visibles par une activation de l’utilisateur (par exemple, une fenêtre de dialogue).
+2. Pour chaque contenu additionnel, vérifier qu’il reste visible :
+   - Jusqu’à ce que l’utilisateur retire le pointeur souris ou le focus du contenu additionnel ou du composant d’interface ayant déclenché son apparition ;
+   - Jusqu’à ce l’utilisateur déclenche le mécanisme prévu pour faire disparaître le contenu additionnel ;
+   - Jusqu’à ce que l’information proposée par le contenu additionnel ne soit plus valide (par exemple un contenu additionnel signalant l’état “occupé” du composant d’interface que l’utilisateur souhaite activer ou encore un message d’erreur signalé sous la forme d’un contenu additionnel tant que l’utilisateur n’a pas rectifié sa saisie).
+3. Si c’est le cas pour chaque contenu additionnel, **le test est validé**.
+
+### Critère 10.14 — Dans chaque page web, les contenus additionnels apparaissant via les styles CSS uniquement peuvent-ils être rendus visibles au clavier et par tout dispositif de pointage ?
+
+**Test 10.14.1 :**
+
+1. Retrouver dans le document les contenus additionnels devenant visible au survol d’un composant d’interface au moyen d’un mécanisme CSS (`pseudo-classe :hover`) ;
+2. Pour chaque contenu additionnel, vérifier que les contenus additionnels apparaissent également :
+   - À l’activation du composant au moyen du clavier ou de tout autre dispositif de pointage ;
+   - À la prise de focus du composant ;
+   - À l’activation ou à la prise de focus d’un autre composant.
+3. Si c’est le cas pour chaque contenu additionnel, **le test est validé**.
+
+**Test 10.14.2 :**
+
+1. Retrouver dans le document les contenus additionnels devenant visible à la prise de focus d’un composant d’interface au moyen d’un mécanisme CSS (`pseudo-classe :focus`) ;
+2. Pour chaque contenu additionnel, vérifier que les contenus additionnels apparaissent également :
+
+- À l’activation du composant au moyen du clavier ou de tout autre dispositif de pointage ;
+- Au survol du composant ;
+- À l’activation ou du survol d’un autre composant.
+
+3. Si c’est le cas pour chaque contenu additionnel, **le test est validé**.
+
+## 11. Formulaires
+
+### Critère 11.1 — Chaque champ de formulaire a-t-il une étiquette ?
+
+**Test 11.1.1 :**
+
+1. Retrouver dans le document les champs de formulaire ;
+2. Pour chaque champ de formulaire, vérifier que le champ de formulaire :
+   - Possède un attribut WAI-ARIA `aria-labelledby` référençant un passage de texte identifié ;
+   - Possède un attribut WAI-ARIA `aria-label` ;
+   - Est associé à un élément `<label>` ayant un attribut `for` ;
+   - Possède un attribut `title` ;
+   - Un bouton adjacent au champ de formulaire lui fournit une étiquette visible et un élément `<label>` visuellement caché ou un attribut WAI-ARIA `aria-label`, `aria-labelledby` ou `title` lui fournit un nom accessible.
+3. Si c’est le cas pour champ de formulaire, **le test est validé**.
+
+**Test 11.1.2 :**
+
+1. Retrouver dans le document les champs de formulaire associé à un élément `<label>` ;
+2. Pour chaque champ de formulaire, vérifier que :
+   - Le champ de formulaire possède un attribut `id` ;
+   - La valeur de l’attribut `for` de l’élément `<label>` est égale à la valeur de l’attribut `id`.
+3. Si c’est le cas pour champ de formulaire, **le test est validé**.
+
+**Test 11.1.3 :**
+
+1. Retrouver dans le document les champs de formulaire dont l’étiquette n’est pas visible ou à proximité (masquée, utilisation de l’attribut aria-label) ou n’est pas accolée au champ (utilisation de l’attribut `aria-labelledby`) ;
+2. Pour chaque champ de formulaire, vérifier que le champ de formulaire :
+   - soit possède un attribut `title` dont le contenu permet de comprendre la nature de la saisie attendue ;
+   - est accompagné d’un passage de texte accolé au champ qui devient visible à la prise de focus permettant de comprendre la nature de la saisie attendue ;
+   - est accompagné d’un passage de texte visible accolé au champ permettant de comprendre la nature de la saisie attendue.
+
+### Critère 11.2 — Chaque étiquette associée à un champ de formulaire est-elle pertinente (hors cas particuliers) ?
+
+**Test 11.2.1 :**
+
+1. Retrouver dans le document les champs de formulaire dont l’étiquette est fournie par un élément `<label>` ;
+2. Pour chaque champ de formulaire, vérifier que le contenu de l’élément est pertinent ;
+3. Si c’est le cas pour chaque champ de formulaire, **le test est validé**.
+
+**Test 11.2.2 :**
+
+1. Retrouver dans le document les champs de formulaire dont l’étiquette est fournie par un attribut `title` ;
+2. Pour chaque champ de formulaire, vérifier que le contenu de l’attribut est pertinent ;
+3. Si c’est le cas pour chaque champ de formulaire, **le test est validé**.
+
+**Test 11.2.3 :**
+
+1. Retrouver dans le document les champs de formulaire dont l’étiquette est fournie par un attribut WAI-ARIA `aria-label` ;
+2. Pour chaque champ de formulaire, vérifier que le contenu de l’attribut est pertinent ;
+3. Si c’est le cas pour chaque champ de formulaire, **le test est validé**.
+
+**Test 11.2.4 :**
+
+1. Retrouver dans le document les champs de formulaire dont l’étiquette est fournie par un attribut WAI-ARIA `aria-labelledby` ;
+2. Pour chaque champ de formulaire, vérifier que le contenu du passage de texte référencé est pertinent ;
+3. Si c’est le cas pour chaque champ de formulaire, **le test est validé**.
+
+**Test 11.2.5 :**
+
+1. Retrouver dans le document les champs de formulaire dont l’étiquette est fournie à la fois par un intitulé visible et par le contenu soit d’un élément `<label>`, soit d’un attribut `title` ou d’un attribut `aria-label` ou d’un attribut `aria-labelledby` ;
+2. Pour chaque champ de formulaire, vérifier que le contenu de l’élément `<label>` ou de l’attribut `title` ou de l’attribut `aria-label` ou de l’attribut `aria-labelledby` contient l’intitulé visible ;
+3. Si c’est le cas pour chaque champ de formulaire, **le test est validé**.
+
+**Test 11.2.6 :**
+
+1. Retrouver dans le document les champs de formulaire dont l’étiquette visible est fournie par un bouton adjacent ;
+2. Pour chaque champ de formulaire, vérifier que le contenu visible du bouton est pertinent ;
+3. Si c’est le cas pour chaque champ de formulaire, **le test est validé**.
+
+### Critère 11.3 — Dans chaque formulaire, chaque étiquette associée à un champ de formulaire ayant la même fonction et répétée plusieurs fois dans une même page ou dans un ensemble de pages est-elle cohérente ?
+
+**Test 11.3.1 :**
+
+1. Retrouver dans le document les champs de formulaire ayant une même fonction (par exemple plusieurs champs d’adresse) ;
+2. Pour chaque champ de formulaire, vérifier que les étiquettes sont cohérentes (elles permettent de comprendre qu’il s’agit de saisies de natures identiques) ;
+3. Si c’est le cas pour chaque champ de formulaire, **le test est validé**.
+
+**Test 11.3.2 :**
+
+1. Retrouver dans l’ensemble des pages considérées les champs de formulaire ayant une même fonction (par exemple le champ de saisie d’un moteur de recherche ou le champ de saisie d’inscription à une newsletter) ;
+2. Pour chaque champ de formulaire, vérifier que les étiquettes sont cohérentes (elles permettent de comprendre qu’il s’agit de saisies de natures identiques) ;
+3. Si c’est le cas pour chaque champ de formulaire de l’ensemble des pages considérées, **le test est validé**.
+
+### Critère 11.4 — Dans chaque formulaire, chaque étiquette de champ et son champ associé sont-ils accolés (hors cas particuliers) ?
+
+**Test 11.4.1 :**
+
+1. Retrouver dans le document les champs de formulaire ;
+2. Pour chaque champ de formulaire, vérifier qu’il est accolé à son étiquette ;
+3. Si c’est le cas pour chaque champ de formulaire, **le test est validé**.
+
+**Test 11.4.2 :**
+
+1. Retrouver dans le document les champs de formulaire qui ne sont pas des éléments `<input>` de type `checkbox` ou de type `radio` ou des éléments ayant un attribut WAI-ARIA `role="checkbox"`, `role="radio"` ou `role="switch`";
+2. Pour chaque champ de formulaire, vérifier que l’étiquette est visuellement accolée :
+   - Immédiatement au-dessus ou à gauche du champ de formulaire lorsque le sens de lecture de la langue de l’étiquette est de gauche à droite ;
+   - Immédiatement au-dessus ou à droite du champ de formulaire lorsque le sens de lecture de la langue de l’étiquette est de droite à gauche.
+3. Si c’est le cas pour chaque champ de formulaire, **le test est validé**.
+
+**Test 11.4.3 :**
+
+1. Retrouver dans le document les champs de formulaire qui sont `<input>` de type `checkbox` ou de type `radio` ou des éléments ayant un attribut WAI-ARIA `role="checkbox"`, `role="radio"` ou `role="switch`";
+2. Pour chaque champ de formulaire, vérifier que l’étiquette est visuellement accolée :
+   - Immédiatement au-dessous ou à droite du champ de formulaire lorsque le sens de lecture de la langue de l’étiquette est de gauche à droite ;
+   - Immédiatement au-dessous ou à gauche du champ de formulaire lorsque le sens de lecture de la langue de l’étiquette est de droite à gauche.
+3. Si c’est le cas pour chaque champ de formulaire, **le test est validé**.
+
+### Critère 11.5 — Dans chaque formulaire, les champs de même nature sont-ils regroupés, si nécessaire ?
+
+**Test 11.5.1 :**
+
+1. Retrouver dans le document les champs de formulaire de même nature (par exemple un groupe de saisie d’informations d’identité, une série de cases à cocher, une saisie de date sur plusieurs champs successifs…) ;
+2. Pour chaque groupe de champs de formulaire de même nature, vérifier que ces champs de même nature sont regroupés :
+   - Soit dans un élément `<fieldset>` ;
+   - Soit dans un élément possédant un attribut WAI-ARIA `role="group"` ;
+   - Soit dans un élément possédant un attribut WAI-ARIA `role="radiogroup"` ou `"group"`, s’il s’agit d’éléments `<input>` de type `radio` ( ou d’éléments possédant un attribut WAI-ARIA `role="radio"`).
+3. Si c’est le cas pour chaque groupe de champs de formulaire de même nature, **le test est validé**.
+
+### Critère 11.6 — Dans chaque formulaire, chaque regroupement de champs de même nature a-t-il une légende ?
+
+**Test 11.6.1 :**
+
+1. Retrouver dans le document les groupes de champs de formulaire de même nature ;
+2. Pour chaque groupe de champs de formulaire de même nature, vérifier que :
+   - Si le regroupement utilise un élément `<fieldset>`, l’élément `<fieldset>` possède un élément `<legend>` ;
+   - Si l’élément de regroupement utilise un attribut WAI-ARIA `role="group"` ou `"radiogroup"`, il possède un attribut WAI-ARIA `aria-label` ou `aria-labelledby`.
+3. Sinon, pour chacun des champs de même nature, vérifier la présence :
+   - Soit d’un attribut title permettant de déterminer l’appartenance du champ au groupement de champ ;
+   - Soit d’un attribut `aria-label` permettant de déterminer l’appartenance du champ au groupement de champ ;
+   - Soit d’un attribut `aria-labelledby` qui référence un passage de texte permettant de déterminer l’appartenance du champ au groupement de champ ;
+   - Soit d’un attribut `aria-describedby` qui référence un passage de texte permettant de déterminer l’appartenance du champ au groupement de champ.
+4. Si c’est le cas pour chaque groupe de champs de formulaire ou pour chacun des champs de même nature, **le test est validé**.
+
+### Critère 11.7 — Dans chaque formulaire, chaque légende associée à un regroupement de champs de même nature est-elle pertinente ?
+
+**Test 11.7.1 :**
+
+1. Retrouver dans le document les groupes de champs de formulaire de même nature ;
+2. Pour chaque groupe de champs de formulaire de même nature ou pour chacun des champs de même nature qui dispose d’une légende, vérifier que le texte de cette légende est pertinent ;
+3. Si c’est le cas pour chaque groupe de champs de formulaire ou pour chacun des champs de même nature, **le test est validé**.
+
+### Critère 11.8 — Dans chaque formulaire, les items de même nature d’une liste de choix sont-ils regroupés de manière pertinente ?
+
+**Test 11.8.1 :**
+
+1. Retrouver dans le document les listes de sélection (élément `<select>`) ;
+2. Pour chaque liste de sélection proposant des groupes d’items de même nature, vérifier que ces items sont regroupés au moyen d’éléments `<optgroup>` ;
+3. Si c’est le cas pour chaque liste de sélection proposant des groupes d’items de même nature, **le test est validé**.
+
+**Test 11.8.2 :**
+
+1. Retrouver dans le document les listes de sélection (élément `<select>`) qui possèdent des éléments `<optgroup>` ;
+2. Pour chaque élément `<optgroup>`, vérifier qu’il possède un attribut `label` ;
+3. Si c’est le cas pour chaque élément `<optgroup>`, **le test est validé**.
+
+**Test 11.8.3 :**
+
+1. Retrouver dans le document les listes de sélection (élément `<select>`) qui possèdent des éléments `<optgroup>` pourvus d’un attribut `label` ;
+2. Pour chaque attribut `label`, vérifier que son contenu est pertinent ;
+3. Si c’est le cas pour chaque attribut `label`, **le test est validé**.
+
+### Critère 11.9 — Dans chaque formulaire, l’intitulé de chaque bouton est-il pertinent (hors cas particuliers) ?
+
+**Test 11.9.1 :**
+
+1. Retrouver dans le document les boutons présents au sein d’un formulaire ;
+2. Pour chaque bouton, vérifier que son intitulé visible et son nom accessible sont pertinents ;
+3. Si c’est le cas pour chaque bouton, **le test est validé**.
+
+**Test 11.9.2 :**
+
+1. Retrouver dans le document les boutons présents au sein d’un formulaire ;
+2. Pour chaque bouton, vérifier que son nom accessible contient au moins son intitulé visible ;
+3. Si c’est le cas pour chaque bouton, **le test est validé**.
+
+### Critère 11.10 — Dans chaque formulaire, le contrôle de saisie est-il utilisé de manière pertinente (hors cas particuliers) ?
+
+**Test 11.10.1 :**
+
+1. Retrouver dans le document les champs de formulaire obligatoires ;
+2. Pour chaque champ de formulaire, vérifier que préalablement à la validation du formulaire :
+   - Soit une indication de champ obligatoire est visible et permet d’identifier nommément le champ concerné ;
+   - Soit le champ possède un attribut `aria-required="true"` ou `required`.
+3. Si c’est le cas pour chaque champ de formulaire obligatoire, **le test est validé**.
+
+**Test 11.10.2 :**
+
+1. Retrouver dans le document les champs de formulaire obligatoires qui possèdent un attribut `aria-required="true"` ou `required` ;
+2. Pour chaque champ de formulaire, vérifier que préalablement à la validation du formulaire :
+   - Soit une indication de champ obligatoire est visible et située dans l’étiquette associée au champ ;
+   - Soit une indication de champ obligatoire est visible et située dans le passage de texte associé au champ.
+3. Si c’est le cas pour chaque champ de formulaire obligatoire qui possèdent un attribut `aria-required="true"` ou `required`, **le test est validé**.
+
+**Test 11.10.3 :**
+
+1. Retrouver dans le document les messages d’erreur indiquant l’absence de saisie d’un champ obligatoire ;
+2. Pour chaque message d’erreur, vérifier que :
+   - Soit le message d’erreur est visible et permet d’identifier nommément le champ concerné ;
+   - Soit le champ obligatoire associé au message d’erreur possède un attribut `aria-invalid="true"`.
+3. Si c’est le cas pour chaque message d’erreur indiquant l’absence de saisie d’un champ obligatoire, **le test est validé**.
+
+**Test 11.10.4 :**
+
+1. Retrouver dans le document les champs de formulaire obligatoires qui possèdent un attribut `aria-invalid="true"` ;
+2. Pour chaque champ de formulaire, vérifier que :
+   - Soit le message d’erreur indiquant le caractère invalide de la saisie est visible et situé dans l’étiquette associée au champ ;
+   - Soit le message d’erreur indiquant le caractère invalide de la saisie est visible et situé dans le passage de texte associé au champ.
+3. Si c’est le cas pour chaque champ de formulaire obligatoire qui possède un attribut `aria-invalid="true"`, **le test est validé**.
+
+**Test 11.10.5 :**
+
+1. Retrouver dans le document les champs de formulaire obligatoires auxquels est associée une instruction ou une indication du type de données et/ou de format obligatoire ;
+2. Pour chaque champ de formulaire, vérifier que l’instruction ou l’indication du type de données et/ou de format obligatoire est préalablement à la validation du formulaire :
+   - Soit visible et permet d’identifier nommément le champ concerné ;
+   - Soit visible dans l’étiquette ou le passage de texte associé au champ.
+3. Si c’est le cas pour chaque champ de formulaire obligatoire auquel est associée une instruction ou une indication du type de données et/ou de format obligatoire, **le test est validé**.
+
+**Test 11.10.6 :**
+
+1. Retrouver dans le document les messages d’erreur fournissant une instruction ou une indication du type de données et/ou de format obligatoire d’un champ ;
+2. Pour chaque message d’erreur, vérifier que :
+   - Soit le message d’erreur est visible et permet d’identifier nommément le champ concerné ;
+   - Soit le champ associé au message d’erreur possède un attribut `aria-invalid="true"`.
+3. Si c’est le cas pour chaque message d’erreur indiquant l’absence de saisie d’un champ obligatoire, **le test est validé**.
+
+**Test 11.10.7 :**
+
+1. Retrouver dans le document les champs de formulaire qui possèdent un attribut `aria-invalid="true"` ;
+2. Pour chaque champ de formulaire, vérifier que :
+   - Soit une instruction ou une indication du type de données et/ou de format obligatoire est visible et située dans l’élément `<label>` associé au champ ;
+   - Soit une instruction ou une indication du type de données et/ou de format obligatoire est visible et située dans le passage de texte associé au champ.
+3. Si c’est le cas pour chaque champ de formulaire qui possède un attribut `aria-invalid="true"`, **le test est validé**.
+
+### Critère 11.11 — Dans chaque formulaire, le contrôle de saisie est-il accompagné, si nécessaire, de suggestions facilitant la correction des erreurs de saisie ?
+
+**Test 11.11.1 :**
+
+1. Retrouver dans le document les messages d’erreur ;
+2. Pour chaque message d’erreur, vérifier que les types et les formats de données attendus sont suggérés ;
+3. Si c’est le cas pour chaque message d’erreur , **le test est validé**.
+
+**Test 11.11.2 :**
+
+1. Retrouver dans le document les messages d’erreur ;
+2. Pour chaque message d’erreur, vérifier que des exemples de valeurs attendues sont suggérés ;
+3. Si c’est le cas pour chaque message d’erreur , **le test est validé**.
+
+### Critère 11.12 — Pour chaque formulaire qui modifie ou supprime des données, ou qui transmet des réponses à un test ou à un examen, ou dont la validation a des conséquences financières ou juridiques, les données saisies peuvent-elles être modifiées, mises à jour ou récupérées par l’utilisateur ?
+
+**Test 11.12.1 :**
+
+1. Retrouver dans le document les formulaires qui modifient ou suppriment des données, ou qui transmettent des réponses à un test ou un examen, ou dont la validation a des conséquences financières ou juridiques ;
+2. Pour chaque formulaire, vérifier que l’utilisateur peut :
+   - Soit modifier ou annuler les données et les actions effectuées sur ces données après la validation du formulaire ;
+   - Soit vérifier et corriger les données avant la validation d’un formulaire en plusieurs étapes ;
+   - Soit disposer d’un mécanisme de confirmation explicite (par exemple, une case à cocher ou une étape supplémentaire).
+3. Si c’est le cas pour chaque formulaire retrouvé, **le test est validé**.
+
+**Test 11.12.2 :**
+
+1. Retrouver dans le document les formulaires qui modifient ou suppriment des données à caractère financier, juridique ou personnel ;
+2. Pour chaque formulaire, vérifier que l’utilisateur dispose :
+   - Soit d’un mécanisme qui permet de récupérer les données supprimées ou modifiées ;
+   - Soit d’un mécanisme de demande de confirmation explicite de la suppression ou de la modification (par exemple, une case à cocher ou une étape supplémentaire).
+3. Si c’est le cas pour chaque formulaire retrouvé, **le test est validé**.
+
+### Critère 11.13 — La finalité d’un champ de saisie peut-elle être déduite pour faciliter le remplissage automatique des champs avec les données de l’utilisateur ?
+
+**Test 11.13.1 :**
+
+1. Retrouver dans le document les champs de formulaire qui se rapportent à une information concernant l’utilisateur (nom, prénom, numéro de téléphone, etc.) ;
+2. Pour chaque champ de formulaire, vérifier que :
+   - Le champ de formulaire possède un attribut `autocomplete` ;
+   - L’attribut `autocomplete` est pourvu d’une valeur présente dans la <a rel="noreferrer noopener" target="_blank" title="liste des valeurs possibles - en anglais - nouvelle fenêtre" href="https://www.w3.org/TR/html52/sec-forms.html#autofill-processing-model">liste des valeurs possibles</a> ;
+   - La valeur indiquée pour l’attribut `autocomplete` est pertinente au regard du type d’information attendu.
+3. Si c’est le cas pour chaque champ de formulaire retrouvé, **le test est validé**.
+
+## 12. Navigation
+
+### Critère 12.1 — Chaque ensemble de pages dispose-t-il de deux systèmes de navigation différents, au moins (hors cas particuliers) ?
+
+**Test 12.1.1 :**
+
+1. Pour chaque ensemble de pages du site, vérifier la présence :
+   - Soit d’un menu de navigation et d’un plan du site ;
+   - Soit d’un menu de navigation et d’un moteur de recherche ;
+   - Soit d’un moteur de recherche et d’un plan du site.
+2. Si c’est le cas pour chaque ensemble de pages du site, **le test est validé**.
+
+### Critère 12.2 — Dans chaque ensemble de pages, le menu et les barres de navigation sont-ils toujours à la même place (hors cas particuliers) ?
+
+**Test 12.2.1 :**
+
+1. Choisir une page de l’échantillon appartenant au même ensemble que la page en cours d’audit ;
+2. Comparer visuellement les deux pages et vérifier que le menu ou les barres de navigation sont toujours à la même place dans la présentation ;
+3. Comparer le code source (généré côté client) des deux pages et vérifier que le menu ou les barres de navigation se présentent toujours dans le même ordre relatif dans la structure ;
+4. Si c’est le cas, **le test est validé**.
+
+Note : le critère est non applicable dans les situations où :
+
+- Les pages d'un ensemble de pages sont le résultat ou une partie d'un processus (un processus de paiement ou de prise de commande, par exemple) ;
+- La page est la page d'accueil ;
+- Le site web est constitué d'une seule page.
+
+### Critère 12.3 — La page « plan du site » est-elle pertinente ?
+
+**Test 12.3.1 :**
+
+1. Vérifier que le plan du site est représentatif de l’architecture générale du site (cf. note) ;
+2. Si c’est le cas, **le test est validé**.
+
+Note : Un plan du site trop complexe ou trop profond n'est pas recommandé pour aider à la navigation. Il n'est pas obligatoire que toutes les pages soient présentes dans le plan du site si elles peuvent être atteintes, par exemple, à partir de la page d'accueil d'une rubrique ou d'un catalogue.
+
+**Test 12.3.2 :**
+
+1. Pour tous les liens du plan du site, vérifier qu’ils sont fonctionnels ;
+2. Si c’est le cas, **le test est validé**.
+
+**Test 12.3.3 :**
+
+1. Pour tous les liens du plan du site, vérifier qu’ils sont à jour (ni obsolètes ni en erreur) et conduisent à la page indiquée par leur intitulé ;
+2. Si c’est le cas, **le test est validé**.
+
+### Critère 12.4 — Dans chaque ensemble de pages, la page « plan du site » est-elle accessible à partir d’une fonctionnalité identique ?
+
+**Test 12.4.1 :**
+
+1. Choisir une page de l’échantillon appartenant au même ensemble que la page en cours d’audit ;
+2. Comparer le code source (généré côté client) des deux pages et vérifier que le moyen d’accès au plan du site est toujours le même (un lien ou un bouton, par exemple) ;
+3. Si c’est le cas, **le test est validé**.
+
+**Test 12.4.2 :**
+
+1. Choisir une page de l’échantillon appartenant au même ensemble que la page en cours d’audit ;
+2. Comparer le code source (généré côté client) des deux pages et vérifier que le moyen d’accès au plan du site est toujours à la même place dans la structure (par rapport à l’ordre relatif des éléments de la page, par exemple il est toujours en haut de page) ;
+3. Si c’est le cas, **le test est validé**.
+
+**Test 12.4.3 :**
+
+1. Choisir une page de l’échantillon appartenant au même ensemble que la page en cours d’audit ;
+2. Comparer visuellement les deux pages et vérifier que le moyen d’accès au plan du site est toujours à la même place dans la présentation ;
+3. Si c’est le cas, **le test est validé**.
+
+### Critère 12.5 — Dans chaque ensemble de pages, le moteur de recherche est-il atteignable de manière identique ?
+
+**Test 12.5.1 :**
+
+1. Choisir une page de l’échantillon appartenant au même ensemble que la page en cours d’audit ;
+2. Comparer le code source (généré côté client) des deux pages et vérifier que le moyen d’accès au moteur de recherche est toujours le même (un champ de formulaire, par exemple) ;
+3. Si c’est le cas, **le test est validé**.
+
+**Test 12.5.2 :**
+
+1. Choisir une page de l’échantillon appartenant au même ensemble que la page en cours d’audit ;
+2. Comparer visuellement les deux pages et vérifier que le moyen d’accès au moteur de recherche est toujours à la même place dans la présentation ;
+3. Si c’est le cas, **le test est validé**.
+
+**Test 12.5.3 :**
+
+1. Choisir une page de l’échantillon appartenant au même ensemble que la page en cours d’audit ;
+2. Comparer le code source (généré côté client) des deux pages et vérifier que le moyen d’accès au moteur de recherche est toujours à la même place dans la structure (par rapport à l’ordre relatif des éléments de la page, par exemple il est toujours en haut de page) ;
+3. Si c’est le cas, **le test est validé**.
+
+### Critère 12.6 — Les zones de regroupement de contenus présentes dans plusieurs pages web (zones d’en-tête, de navigation principale, de contenu principal, de pied de page et de moteur de recherche) peuvent-elles être atteintes ou évitées ?
+
+**Test 12.6.1 :**
+
+1. Retrouver dans le document les zones de regroupement de contenus (zones d’en-tête, de navigation principale, de contenu principal, de pied de page et de moteur de recherche) ;
+2. Pour chaque zone, vérifier que la zone :
+   - Soit possède un rôle WAI-ARIA de type landmark correspondant à sa nature ;
+   - Soit possède un titre de hiérarchie dont le contenu permet de comprendre la nature du contenu de la zone ;
+   - Soit peut être masquée au moyen d’un bouton précédant directement la zone dans l’ordre du code source ;
+   - Soit peut être évitée au moyen d’un lien d’évitement précédant directement la zone dans l’ordre du code source ;
+   - Soit peut être atteinte au moyen d’un lien d’accès rapide soit visible par défaut, soit visible à la prise de focus lors d’une tabulation.
+3. Si c’est le cas pour chaque zone de regroupement de contenus, **le test est validé**.
+
+### Critère 12.7 — Dans chaque page web, un lien d’évitement ou d’accès rapide à la zone de contenu principal est-il présent (hors cas particuliers) ?
+
+**Test 12.7.1 :**
+
+1. Retrouver dans le document la zone de contenu principal (indiquée par l’élément main visible) ;
+2. Vérifier que la zone :
+   - Soit peut être évitée au moyen d’un lien d’évitement précédant directement la zone dans l’ordre du code source ;
+   - Soit peut être atteinte au moyen d’un lien d’accès rapide visible à la prise de focus lors d’une tabulation.
+3. Si c’est le cas, **le test est validé**.
+
+**Test 12.7.2 :**
+
+1. Retrouver dans le document la zone de contenu principal (indiquée par l’élément main visible) ;
+2. Vérifier que le lien d’évitement ou d’accès rapide à la zone est :
+   - Situé à la même place dans la présentation ;
+   - Présent toujours dans le même ordre relatif dans le code source (généré côté client) ;
+   - Visible à la prise de focus lors d’une tabulation ;
+   - Fonctionnel.
+3. Si c’est le cas, **le test est validé**.
+
+Note : lorsque le site web est constitué d'une seule page, l'obligation de la présence d'un lien d'accès rapide est liée au contexte de la page (présence ou absence de navigation ou de contenus additionnels, par exemple). Le critère peut être considéré comme non applicable lorsqu'il est avéré qu'un lien d'accès rapide est inutile.
+
+### Critère 12.8 — Dans chaque page web, l’ordre de tabulation est-il cohérent ?
+
+**Test 12.8.1 :**
+
+1. Parcourir dans le document l’ensemble des contenus au moyen de la touche de tabulation vers l’avant (touche Tab) et vers l’arrière (touches Maj+Tab) ;
+2. Vérifier que l’ordre de déplacement du focus reste cohérent relativement au contenu considéré (par exemple, l’ordre de tabulation dans une fenêtre modale ne doit considérer que les éléments d’interface présents au sein de cette fenêtre) ;
+3. Si c’est le cas, **le test est validé**.
+
+Note : il n'est pas obligatoire que la tabulation suive l'ordre de lecture naturel (de gauche à droite et de haut en bas par exemple) tant que les éléments sont accessibles dans un ordre cohérent.
+
+**Test 12.8.2 :**
+
+1. Retrouver dans le document l’ensemble des contenus insérés au moyen d’un script (affichage d’éléments masqués, mise jour de contenu via AJAX par exemple) ;
+2. Positionner la tabulation sur l’élément déclencheur et l’activer ;
+3. Après l’affichage du contenu mis à jour, vérifier que la tabulation reste cohérente (repositionnement correct du focus) ;
+4. Si c’est le cas, **le test est validé**.
+
+### Critère 12.9 — Dans chaque page web, la navigation ne doit pas contenir de piège au clavier. Cette règle est-elle respectée ?
+
+**Test 12.9.1 :**
+
+1. Retrouver dans le document l’ensemble des éléments d’interface susceptibles de recevoir le focus (au moyen de la tabulation ou au moyen d’un script) ;
+2. Pour chaque élément d’interface, vérifier que l’utilisateur peut atteindre l’élément suivant ou précédent pouvant recevoir le focus :
+   - Soit au moyen de la touche de tabulation (Tab ou Maj+Tab) ;
+   - Soit au moyen d’une autre interaction clavier dont l’utilisateur est informé (par exemple, les flèches de direction).
+3. Si c’est le cas pour chaque élément d’interface, **le test est validé**.
+
+Note : certains éléments d'interface complexes, comme un groupe de boutons radio, une liste de sélection et tous les composants développés avec WAI-ARIA font appel à des navigations optimisées qui utilisent généralement les flèches de direction pour passer d'une partie du composant à l'autre. Par exemple, dans un groupe de boutons radio les options sont navigables avec les flèches de direction. De même dans un système d'onglets l'utilisateur active les onglets avec les flèches de direction. Le test sur le piège au clavier se limite alors à vérifier que le composant est atteint avec la tabulation et qu'il est possible de passer au composant suivant ou revenir au composant précédent.
+
+### Critère 12.10 — Dans chaque page web, les raccourcis clavier n’utilisant qu’une seule touche (lettre minuscule ou majuscule, ponctuation, chiffre ou symbole) sont-ils contrôlables par l’utilisateur ?
+
+**Test 12.10.1 :**
+
+1. Retrouver dans le document l’ensemble des raccourcis clavier proposés à l’utilisateur ;
+2. Pour chaque raccourci clavier, vérifier que :
+   - Soit un mécanisme est disponible pour désactiver le raccourci clavier ;
+   - Soit un mécanisme est disponible pour configurer la touche de raccourci clavier au moyen des touches de modification (Ctrl, Alt, Maj, etc.) ;
+   - Soit, dans le cas d’un composant d’interface utilisateur, le raccourci clavier qui lui est associé ne peut être activé que si le focus clavier est sur ce composant.
+3. Si c’est le cas pour chaque raccourci clavier, **le test est validé**.
+
+### Critère 12.11 — Dans chaque page web, les contenus additionnels apparaissant au survol, à la prise de focus ou à l’activation d’un composant d’interface sont-ils si nécessaire atteignables au clavier ?
+
+**Test 12.11.1 :**
+
+1. Retrouver dans le document l’ensemble des contenus additionnels apparaissant au survol, à la prise de focus ou à l’activation d’un composant d’interface ;
+2. Pour chaque contenu additionnel, s’il contient des composants d’interface avec lesquels l’utilisateur peut interagir au clavier (par exemple, une infobulle personnalisée qui propose un lien dans son contenu), vérifier que ces composants d’interface sont atteignables au clavier ;
+3. Si c’est le cas pour chaque contenu additionnel, **le test est validé**.
+
+## 13. Consultation
+
+### Critère 13.1 — Pour chaque page web, l’utilisateur a-t-il le contrôle de chaque limite de temps modifiant le contenu (hors cas particuliers) ?
+
+**Test 13.1.1 :**
+
+1. Retrouver dans le document les rafraîchissements initiés dans le contenu par un élément `<object>`, `<embed>`, `<svg>`, `<canvas>` ou par un élément `<meta http-equiv="refresh" content="[compteur]">` (dans l’élément `<head>` de la page) ;
+2. Pour chaque rafraîchissement, vérifier que :
+   - Soit la présence d’un mécanisme permet à l’utilisateur de stopper et de relancer le rafraîchissement ;
+   - Soit la présence d’un mécanisme permet à l’utilisateur d’augmenter la limite de temps entre deux rafraîchissements de dix fois, au moins ;
+   - Soit la présence d’un mécanisme qui avertit l’utilisateur de l’imminence du rafraîchissement, laisse 20 secondes, au moins, à l’utilisateur, pour augmenter la limite de temps avant le prochain rafraîchissement ;
+   - Soit la limite de temps entre deux rafraîchissements est de vingt heures, au moins.
+3. Si c’est le cas, **le test est validé**.
+
+**Test 13.1.2 :**
+
+1. Retrouver dans le document une redirection automatique initiée par un élément `<meta http-equiv="refresh" content="0;URL='[URL ciblée]'" />` ;
+2. Vérifier que la redirection est immédiate ;
+3. Si c’est le cas, **le test est validé**.
+
+**Test 13.1.3 :**
+
+1. Retrouver dans le document les redirections automatiques initiées par un script (sous la forme d’un décompte par exemple) ;
+2. Pour chaque redirection automatique, vérifier que :
+   - Soit la présence d’un mécanisme permet à l’utilisateur de stopper et relancer la redirection ;
+   - Soit la présence d’un mécanisme permet à l’utilisateur d’augmenter la limite de temps avant le rafraîchissement de dix fois, au moins ;
+   - Soit la présence d’un mécanisme qui avertit l’utilisateur de l’imminence du rafraîchissement, laisse 20 secondes, au moins, à l’utilisateur, pour augmenter la limite de temps avant le prochain rafraîchissement ;
+   - Soit la limite de temps avant la redirection est de vingt heures, au moins.
+3. Si c’est le cas, **le test est validé**.
+
+**Test 13.1.4 :**
+
+1. Retrouver dans le document les procédés limitant le temps d’une session (par exemple, après une authentification) ;
+2. Pour chaque procédé, vérifier que :
+   - Soit la présence d’un mécanisme permet à l’utilisateur de supprimer la limite de temps ;
+   - Soit la présence d’un mécanisme permet à l’utilisateur d’augmenter la limite de temps ;
+   - Soit la limite de temps est de vingt heures, au moins.
+3. Si c’est le cas, **le test est validé**.
+
+Note : lorsque la limite de temps est essentielle, notamment lorsqu'elle ne pourrait pas être supprimée sans changer fondamentalement le contenu ou les fonctionnalités liées au contenu, le critère est non applicable. Par exemple, le rafraîchissement d'un flux RSS dans une page n'est pas une limite de temps essentielle ; le critère est applicable. En revanche, une redirection automatique qui amène vers la nouvelle version d'une page à partir d'une url obsolète est essentielle ; le critère est non applicable.
+
+### Critère 13.2 — Dans chaque page web, l’ouverture d’une nouvelle fenêtre ne doit pas être déclenchée sans action de l’utilisateur. Cette règle est-elle respectée ?
+
+**Test 13.2.1 :**
+
+1. Vérifier qu’à l’ouverture du document, aucune nouvelle fenêtre (pop-up ou pop-under, par exemple) n’est ouverte.
+2. Si c’est le cas, **le test est validé**.
+
+### Critère 13.3 — Dans chaque page web, chaque document bureautique en téléchargement possède-t-il, si nécessaire, une version accessible (hors cas particuliers) ?
+
+**Test 13.3.1 :**
+
+1. Retrouver dans le document les liens et les contrôles de formulaire (un bouton de formulaire ou un formulaire de téléchargement par exemple) permettant de télécharger un fichier au format bureautique ;
+2. Pour chaque fichier au format bureautique, vérifier la présence d’une version alternative présentée comme accessible :
+   - Pour les documents au format .pdf, analyser le fichier avec l’outil PAC (PDF Accessibility Checker) et vérifier l’absence d’erreur d’accessibilité dans le document (cf. note) ;
+   - Pour les documents au format .doc ou .docx, analyser le fichier avec l’outil de vérification d’accessibilité de Microsoft Office (à partir de la version 2010) et vérifier l’absence d’erreur d’accessibilité (cf. note) ;
+   - Pour les documents au format .odt, analyser le document avec l’éditeur OpenOffice et vérifier que l’ensemble des contenus est conforme avec la liste des critères « Liste document bureautique en téléchargement » (cf. note pour une méthode alternative) ;
+   - Pour les documents au format EPUB/DAISY, analyser le document avec un éditeur EPUB/DAISY et vérifier que l’ensemble des contenus est conforme avec la liste des critères « Liste document bureautique en téléchargement ».
+   - Pour les documents eux-mêmes au format .html, analyser l’accessibilité du document.
+3. Si c’est le cas pour chaque fichier au format bureautique, **le test est validé**.
+
+Note au sujet de l'outil PAC : l'outil analyse le document PDF du point de vue de l'accessibilité mais également de critères de qualité (par exemple la norme PDF/UA). Seules les erreurs relatives à des critères présents dans la liste des critères « Liste document bureautique en téléchargement » rendent le critère « Non conforme ». Par ailleurs, cet outil ne fonctionne que sur la plateforme Windows. Sur Mac, le contrôle doit se faire manuellement.
+
+Note au sujet Microsoft Office : le logiciel offre un vérificateur d'accessibilité en standard, (accessible via le menu « Fichier > Informations > Vérifier la présence de problèmes > Vérifier l'accessibilité »). Ce vérificateur peut être considérablement amélioré via le plugin Word Accessibility Plug-in (voir dans la section Outils). Ce plugin ne fonctionne que sur Windows. Sur Mac, le contrôle doit se faire manuellement.
+
+Note au sujet des documents au format .odt : OpenOffice et LibreOffice ne possèdent pas de vérificateur d'accessibilité. Une méthode plus rapide qu'une analyse manuelle peut consister à enregistrer le document au format .docx et le vérifier via le vérificateur d'accessibilité de Microsoft Office 2010. Attention cependant : cette méthode rapide est à réserver aux documents très simples car certaines informations liées à l'accessibilité ne sont pas correctement transcodées. C'est le cas des indications de langue, de certaines alternatives d'images ou d'en-têtes fusionnées sur les tableaux par exemple.
+
+Note au sujet du format EPUB : l'utilitaire Ace by DAISY App permet d'effectuer le travail de validation d'un fichier EPUB 3 de manière efficace.
+
+Note au sujet des documents dérogés : le référentiel propose un statut de dérogation dans certains cas (cf. guide d'accompagnement). Dans ce cas, les tests ne sont pas à réaliser, la version accessible étant fournie sur demande de l'utilisateur.
+
+Note à l'attention des personnes de droit privé mentionnées aux 2° à 4° du I de l’article 47 de la loi du 11 février 2005 : si les fichiers bureautiques (ex : PDF, documents Microsoft ou LibreOffice, etc.) ont été publiés avant le 23 septembre 2018 (sauf si ce sont des documents nécessaires pour accomplir une démarche administrative relevant des tâches effectuées par l'organisme concerné), ils sont exemptés de l’obligation d’accessibilité.
+
+### Critère 13.4 — Pour chaque document bureautique ayant une version accessible, cette version offre-t-elle la même information ?
+
+**Test 13.4.1 :**
+
+1. Retrouver dans le document les fichiers en téléchargement au format bureautique accompagné de leur version alternative accessible ;
+2. Pour chaque couple de fichiers, ouvrir les deux documents (le document d’origine et le document accessible) et vérifier que les deux documents apportent la même information ;
+3. Si c’est le cas pour chaque couple de fichiers, **le test est validé**.
+
+### Critère 13.5 — Dans chaque page web, chaque contenu cryptique (art ASCII, émoticône, syntaxe cryptique) a-t-il une alternative ?
+
+**Test 13.5.1 :**
+
+1. Retrouver dans le document les contenus cryptiques (art ASCII, émoticône, syntaxe cryptique) ;
+2. Pour chaque contenu cryptique, vérifier que :
+   - Soit une définition est disponible au moyen d’un attribut `title`, sur un lien, un contrôle de formulaire, une abréviation (élément `<abbr>`) par exemple ;
+   - Soit une définition est donnée dans le contexte adjacent (immédiatement avant ou après).
+3. Si c’est le cas pour chaque contenu cryptique, **le test est validé**.
+
+### Critère 13.6 — Dans chaque page web, pour chaque contenu cryptique (art ASCII, émoticône, syntaxe cryptique) ayant une alternative, cette alternative est-elle pertinente ?
+
+**Test 13.6.1 :**
+
+1. Retrouver dans le document les contenus cryptiques (art ASCII, émoticône, syntaxe cryptique) ;
+2. Pour chaque contenu cryptique, vérifier que la définition donnée est pertinente.
+3. Si c’est le cas pour chaque contenu cryptique, **le test est validé**.
+
+### Critère 13.7 — Dans chaque page web, les changements brusques de luminosité ou les effets de flash sont-ils correctement utilisés ?
+
+**Test 13.7.1 :**
+
+1. Retrouver dans le document les contenus clignotants ou qui provoquent des effets de flash de type image animée, vidéo (cf. note) ou animation (éléments `<img>`, `<svg>`, `<canvas>`, `<embed>`, `<object>` ou `<video>`) ;
+2. Pour chaque contenu clignotant ou provoquant des effets de flash, vérifier que :
+   - Soit la fréquence de l’effet est inférieur à 3 par seconde ;
+   - Soit la surface cumulée est inférieure à 21824 pixels.
+3. Si c’est le cas pour chaque contenu clignotant ou provoquant des effets de flash, **le test est validé**.
+
+Note : l'évaluation de ce critère peut être complexe. Lorsque l'effet est géré par un script ou au moyen de CSS, l'analyse du code est suffisante. L'outil PEAT permet d'analyser les vidéos au format .avi, par exemple. Un exemple de vidéo ayant provoqué des crises d'épilepsie peut être consulté ici : London 2012 Olympics Seizure (https://www.youtube.com/watch?v=vs0hfhSje9M).
+
+**Test 13.7.2 :**
+
+1. Retrouver dans le document les contenus clignotants ou qui provoquent des effets de flash obtenus au moyen d’un script ;
+2. Pour chaque contenu clignotant ou provoquant des effets de flash, vérifier que :
+   - Soit la fréquence de l’effet est inférieur à 3 par seconde ;
+   - Soit la surface cumulée est inférieure à 21824 pixels.
+3. Si c’est le cas pour chaque contenu clignotant ou provoquant des effets de flash, **le test est validé**.
+
+**Test 13.7.3 :**
+
+1. Retrouver dans le document les contenus clignotants ou qui provoquent des effets de flash obtenus au moyen d’une animation CSS ;
+2. Pour chaque contenu clignotant ou provoquant des effets de flash, vérifier que :
+   - Soit la fréquence de l’effet est inférieur à 3 par seconde ;
+   - Soit la surface cumulée est inférieure à 21824 pixels.
+3. Si c’est le cas pour chaque contenu clignotant ou provoquant des effets de flash, **le test est validé**.
+
+### Critère 13.8 — Dans chaque page web, chaque contenu en mouvement ou clignotant est-il contrôlable par l’utilisateur ?
+
+**Test 13.8.1 :**
+
+1. Retrouver dans le document les contenus en mouvement (obtenus au moyen d’une image, d’un script ou d’un effet CSS) déclenchés automatiquement au chargement de la page ou lors de l’affichage d’un contenu (cf. note) ;
+2. Pour chaque contenu, vérifier que :
+   - Soit la durée du mouvement est inférieure à 5 secondes ;
+   - Soit la présence d’un mécanisme (un bouton, par exemple) permet d’arrêter et de relancer le mouvement ;
+   - Soit la présence d’un mécanisme (un bouton, par exemple) permet de cacher et d’afficher à nouveau le contenu en mouvement ;
+   - Soit la présence d’un mécanisme (un bouton, par exemple) permet d’afficher la totalité du contenu sans mouvement.
+3. Si c’est le cas pour chaque contenu en mouvement, **le test est validé**.
+
+**Test 13.8.2 :**
+
+1. Retrouver dans le document les contenus clignotants (obtenus au moyen d’une image, d’un script ou d’un effet CSS) déclenchés automatiquement au chargement de la page ou lors de l’affichage d’un contenu (cf. note).
+2. Pour chaque contenu, vérifier que :
+   - Soit la durée du clignotement est inférieure à 5 secondes ;
+   - Soit la présence d’un mécanisme (un bouton, par exemple) permet d’arrêter et de relancer le clignotement ;
+   - Soit la présence d’un mécanisme (un bouton, par exemple) permet de cacher et d’afficher à nouveau le contenu clignotant ;
+   - Soit la présence d’un mécanisme (un bouton, par exemple) permet d’afficher la totalité du contenu clignotant.
+3. Si c’est le cas pour chaque contenu clignotant, **le test est validé**.
+
+Note : l'arrêt ou la mise en pause d'un contenu en mouvement ou clignotant au moyen de la prise de focus (par exemple, l'effet est suspendu uniquement pendant la prise de focus) n'est pas considéré comme un procédé conforme. Dans certains cas, le mouvement ne peut pas être arrêté, par exemple dans le cas d'une barre de progression, dans ce cas, le critère est non applicable.
+
+### Critère 13.9 — Dans chaque page web, le contenu proposé est-il consultable quelle que soit l’orientation de l’écran (portrait ou paysage) (hors cas particuliers) ?
+
+**Test 13.9.1 :**
+
+1. Consulter le document dans un mode d’orientation portrait puis dans un mode d’orientation paysage ;
+2. Vérifier que :
+   - La consultation est possible quel que soit le mode d’orientation de l’écran.
+   - Le contenu proposé reste le même quel que soit le mode d’orientation de l’écran utilisé même si sa présentation et le moyen d’y accéder peut différer.
+3. Si c’est le cas, **le test est validé**.
+
+Note : il existe des interfaces pour lesquelles l'orientation du périphérique est essentielle à leur utilisation. Dans ces situations, le critère est non applicable. Il peut s'agir d'interfaces de jeu, de piano, de dépôt de chèques bancaires, etc. Si l'interface est le seul moyen d'accéder au service proposé, une alternative devrait être mise en place pour pallier cette carence.
+
+### Critère 13.10 — Dans chaque page web, les fonctionnalités utilisables ou disponibles au moyen d’un geste complexe peuvent-elles être également disponibles au moyen d’un geste simple (hors cas particuliers) ?
+
+**Test 13.10.1 :**
+
+1. Retrouver dans le document les fonctionnalités utilisables ou disponibles au moyen d’une interaction au toucher de type contact multipoint ;
+2. Pour chaque fonctionnalité, vérifier qu’elle reste disponible au moyen d’une interaction au toucher de type contact en un point unique de l’écran (par exemple, la possibilité de consulter les éléments d’une liste par un mouvement de balayage horizontal droit ou gauche doit aussi être disponible au moyen de boutons “précédent” et “suivant” ou encore un geste de pincer et zoomer qui peut être alternativement réalisé au moyen de boutons “plus” et “moins”) ;
+3. Si c’est le cas pour chaque fonctionnalité utilisable ou disponible au moyen d’une interaction au toucher de type contact multipoint, **le test est validé**.
+
+**Test 13.10.2 :**
+
+1. Retrouver dans le document les fonctionnalités utilisables ou disponibles au moyen d’une interaction au toucher qui implique le suivi d’une trajectoire sur l’écran ;
+2. Pour chaque fonctionnalité, vérifier qu’elle reste disponible au moyen d’une interaction au toucher de type contact en un point unique de l’écran (par exemple, la possibilité de composer son mot de passe en suivant une trajectoire sur un clavier virtuel doit aussi être disponible au moyen de pressions successives sur les touches du clavier) ;
+3. Si c’est le cas pour chaque fonctionnalité utilisable ou disponible au moyen d’une interaction au toucher qui implique le suivi d’une trajectoire sur l’écran, **le test est validé**.
+
+Il existe une gestion de cas particuliers dans deux types de situation :
+
+- Le critère ne s'applique qu'à des fonctionnalités mises en place par l'auteur du site. Il ne concerne donc pas les gestes requis par l'agent utilisateur ou le système d'exploitation.
+- Le critère ne s'applique pas aux fonctionnalités dont la réalisation d'un geste complexe est essentielle (exécuter le tracé d'une signature, par exemple).
+
+### Critère 13.11 — Dans chaque page web, les actions déclenchées au moyen d’un dispositif de pointage sur un point unique de l’écran peuvent-elles faire l’objet d’une annulation (hors cas particuliers) ?
+
+**Test 13.11.1 :**
+
+1. Retrouver dans le document les actions déclenchées au moyen d’un dispositif de pointage sur un point unique de l’écran ;
+2. Pour chaque action, vérifier que :
+   - Soit l’action est déclenchée au moment où le dispositif de pointage est relâché ou relevé ;
+   - Soit l’action est déclenchée au moment où le dispositif de pointage est pressé ou posé puis annulée lorsque le dispositif de pointage est relâché ou relevé ;
+   - Soit il existe un mécanisme pour abandonner (avant achèvement de l’action) ou annuler (après achèvement) l’exécution de l’action ; par exemple, lors d’une interaction de type glisser-déposer un relâchement du dispositif de pointage doit permettre d’abandonner l’interaction en cours et une fois la zone de dépôt atteinte, l’utilisateur doit rester en mesure d’annuler son opération de dépôt au moyen d’un dialogue de confirmation (choix de confirmer ou d’annuler le dépôt) ou par le fait de pouvoir replacer l’élément déposé à sa position initiale.
+3. Si c’est le cas pour chaque action déclenchée au moyen d’un dispositif de pointage sur un point unique de l’écran, **le test est validé**.
+
+### Critère 13.12 — Dans chaque page web, les fonctionnalités qui impliquent un mouvement de l’appareil ou vers l’appareil peuvent-elles être satisfaites de manière alternative (hors cas particuliers) ?
+
+**Test 13.12.1 :**
+
+1. Retrouver dans le document les fonctionnalités disponibles en bougeant l’appareil ;
+2. Pour chaque fonctionnalité, vérifier qu’elle peut être accomplie au moyen de composants d’interface utilisateur ;
+3. Si c’est le cas pour chaque fonctionnalité disponible en bougeant l’appareil, **le test est validé**.
+
+**Test 13.12.2 :**
+
+1. Retrouver dans le document les fonctionnalités disponibles en faisant un geste en direction de l’appareil ;
+2. Pour chaque fonctionnalité, vérifier qu’elle peut être accomplie au moyen de composants d’interface utilisateur ;
+3. Si c’est le cas pour chaque fonctionnalité disponible en faisant un geste en direction de l’appareil, **le test est validé**.
+
+**Test 13.12.3 :**
+
+1. Retrouver dans le document les fonctionnalités disponibles en mettant en mouvement l’appareil ;
+2. Vérifier si l’utilisateur à la possibilité de désactiver la détection du mouvement ;
+3. Si c’est le cas, pour chaque fonctionnalité, vérifier qu’elle ne peut pas être déclenchée ;
+4. Si c’est le cas pour chaque fonctionnalité disponible en mettant en mouvement l’appareil, **le test est validé**.


### PR DESCRIPTION
## Summary

- Add a dedicated, non-negotiable RGAA (French WCAG 2.1 AA) accessibility mandate for all frontend work, since Zéro Logement Vacant is a public service.
- Add [.claude/rules/rgaa-accessibility.md](.claude/rules/rgaa-accessibility.md): the full official list of all 13 thematics / 106 criteria, source-verified byte-for-byte against the official [DISIC RGAA JSON dataset](https://github.com/DISIC/accessibilite.numerique.gouv.fr) (not a web-fetch summary, which proved inconsistent across attempts), plus per-criterion "application concrète" notes tailored to this repo's DSFR/MUI/React stack.
- Add [docs/rgaa/methodologie-tests.md](docs/rgaa/methodologie-tests.md): the exact official procedure for all 258 RGAA tests, kept as a separate on-demand reference (not auto-loaded) since embedding it directly would add ~34k tokens to every frontend task, even trivial ones.
- Define a mandatory, ordered self-check procedure: identify which criteria a given change touches (with a thematic mapping by change type), read the exact test procedure for those specific criteria, verify the implementation against it, and report the result in the response — including proactively flagging any suspected violation (`⚠️ RGAA (critère N.M — sujet)`) rather than shipping it silently.
- Link the new rule file from `AGENTS.md` (the `CLAUDE.md` symlink target) so it's impossible to miss when doing frontend work.
- Allowlist two Talisman false positives (long French documentation text tripping the secret-pattern heuristic) the same way other `docs/*.md` files already are in this repo.

## Why

The team wants an unambiguous, complete, and durable instruction so that all future frontend work is checked against the full RGAA reference — not just a best-effort summary — with the agent proactively raising accessibility concerns instead of waiting to be asked.

## Test plan

- [x] Programmatically diffed all 106 criteria titles and all 258 test procedures against the official DISIC JSON source — 0 mismatches after Unicode normalization.
- [x] Verified counts (13 thematics / 106 criteria / 258 tests) by direct computation on the source JSON, not estimation.
- [x] Confirmed pre-commit hooks (lint-staged, Talisman) pass on the new/changed files.
- N/A — documentation-only change, no runtime code affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)