### PR TITLE
Add zlv repair harness CLI (plan/apply workflow)

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -157,6 +157,8 @@ fileignoreconfig:
   checksum: 644044062362fa5da4d58e676e9b978d95d9b7e5ecc534733e69c5f270a80659
 - filename: server/src/scripts/repairs/lib/plan.ts
   checksum: 875c7afaf9b48ab4acefa485bc5c46068bed0dfbb256475e36992892023b6bd4
+- filename: server/src/scripts/repairs/lib/row-stream.ts
+  checksum: 3cbcb5a8a89cea040732055b3248de5aaa86920b30bf12ab9f7a1a05b6190a31
 - filename: server/src/scripts/repairs/lib/types.ts
   checksum: 540f2693f829a26060ea65edd3db1fe137de15e51d00c186f8ff7368bc91bcb8
 - filename: server/src/scripts/repairs/cli.ts

--- a/.talismanrc
+++ b/.talismanrc
@@ -149,6 +149,8 @@ fileignoreconfig:
   checksum: f08020ffee6beeda135a04955eeeb4a9be0a8e11cf98e8cd18327b67848ca7e2
 - filename: docs/superpowers/specs/2026-07-08-zlv-repair-harness-design.md
   checksum: 3b78f0af3737a4b295511ab8998d4a0b441dac861846f034bf2f674bd5cc3277
+- filename: docs/superpowers/plans/2026-07-08-zlv-repair-harness.md
+  checksum: d6a0c9d236c26ac927681537c778c9000b59b9da6d4ec26d10abf5424e34f255
 - filename: server/src/services/metabase/metabase-normalize.ts
   checksum: 1bd122150d2d7806ebf7cb708750814288d528fad4b3a1a3da0e1f9ae91f2f5d
 scopeconfig:

--- a/.talismanrc
+++ b/.talismanrc
@@ -154,7 +154,9 @@ fileignoreconfig:
 - filename: server/src/services/metabase/metabase-normalize.ts
   checksum: 1bd122150d2d7806ebf7cb708750814288d528fad4b3a1a3da0e1f9ae91f2f5d
 - filename: server/src/scripts/repairs/lib/apply.ts
-  checksum: 7490bef91def550bbb975b7196649bb5a59a1c4b2fa2b1f47461ea187b902bae
+  checksum: 644044062362fa5da4d58e676e9b978d95d9b7e5ecc534733e69c5f270a80659
+- filename: server/src/scripts/repairs/lib/plan.ts
+  checksum: 875c7afaf9b48ab4acefa485bc5c46068bed0dfbb256475e36992892023b6bd4
 - filename: server/src/scripts/repairs/lib/types.ts
   checksum: 540f2693f829a26060ea65edd3db1fe137de15e51d00c186f8ff7368bc91bcb8
 - filename: server/src/scripts/repairs/cli.ts

--- a/.talismanrc
+++ b/.talismanrc
@@ -153,6 +153,8 @@ fileignoreconfig:
   checksum: d6a0c9d236c26ac927681537c778c9000b59b9da6d4ec26d10abf5424e34f255
 - filename: server/src/services/metabase/metabase-normalize.ts
   checksum: 1bd122150d2d7806ebf7cb708750814288d528fad4b3a1a3da0e1f9ae91f2f5d
+- filename: server/src/scripts/repairs/lib/apply.ts
+  checksum: 9a452fee8152ce96f903c341e79dd8070b1765e34b70f49e5ccc75bf623cfc4d
 scopeconfig:
 - scope: node
 allowed_patterns:

--- a/.talismanrc
+++ b/.talismanrc
@@ -154,7 +154,17 @@ fileignoreconfig:
 - filename: server/src/services/metabase/metabase-normalize.ts
   checksum: 1bd122150d2d7806ebf7cb708750814288d528fad4b3a1a3da0e1f9ae91f2f5d
 - filename: server/src/scripts/repairs/lib/apply.ts
-  checksum: 9a452fee8152ce96f903c341e79dd8070b1765e34b70f49e5ccc75bf623cfc4d
+  checksum: 7490bef91def550bbb975b7196649bb5a59a1c4b2fa2b1f47461ea187b902bae
+- filename: server/src/scripts/repairs/lib/types.ts
+  checksum: 540f2693f829a26060ea65edd3db1fe137de15e51d00c186f8ff7368bc91bcb8
+- filename: server/src/scripts/repairs/cli.ts
+  checksum: e65f7bc1b35f9fd58e101304e593be01be75ff67dccf89a2d383325be50ffd65
+- filename: server/src/scripts/repairs/lib/test/apply.test.ts
+  checksum: 9742aa1c90380ffd7e296b4edaa006801094eb0a9b9fd9d7bcfd84dbbb8847d3
+- filename: server/src/scripts/repairs/test/cli.test.ts
+  checksum: b4f99dc53da779fdcf65042875b27bc9ea3cf5fb0c04b7aa8dffa4ec858aa83f
+- filename: server/src/scripts/repairs/README.md
+  checksum: fd6d108f192084b285fc12d99c3445e180ffa60b3b5dc0cf2e48d721f2af64b4
 scopeconfig:
 - scope: node
 allowed_patterns:

--- a/.talismanrc
+++ b/.talismanrc
@@ -166,7 +166,7 @@ fileignoreconfig:
 - filename: server/src/scripts/repairs/test/cli.test.ts
   checksum: f4ce3945b8c77a11f90ea9016d3f59e4465657b07c52f13a78a25b834451e30c
 - filename: server/src/scripts/repairs/README.md
-  checksum: fd6d108f192084b285fc12d99c3445e180ffa60b3b5dc0cf2e48d721f2af64b4
+  checksum: e94c840ab2212d1fe1d7e8060937abfce87401b97cf7dc1abda44aaf14a5d3e7
 scopeconfig:
 - scope: node
 allowed_patterns:

--- a/.talismanrc
+++ b/.talismanrc
@@ -164,7 +164,7 @@ fileignoreconfig:
 - filename: server/src/scripts/repairs/lib/test/apply.test.ts
   checksum: 9742aa1c90380ffd7e296b4edaa006801094eb0a9b9fd9d7bcfd84dbbb8847d3
 - filename: server/src/scripts/repairs/test/cli.test.ts
-  checksum: b4f99dc53da779fdcf65042875b27bc9ea3cf5fb0c04b7aa8dffa4ec858aa83f
+  checksum: f4ce3945b8c77a11f90ea9016d3f59e4465657b07c52f13a78a25b834451e30c
 - filename: server/src/scripts/repairs/README.md
   checksum: fd6d108f192084b285fc12d99c3445e180ffa60b3b5dc0cf2e48d721f2af64b4
 scopeconfig:

--- a/docs/superpowers/plans/2026-07-08-zlv-repair-harness.md
+++ b/docs/superpowers/plans/2026-07-08-zlv-repair-harness.md
@@ -1,0 +1,1033 @@
+# ZLV Repair Harness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a reusable `zlv repair` CLI that lets developers bulk-correct housing data (status, sub-status, events) through a typed `Repair<H>` interface with a Terraform-style `plan` → `apply` workflow.
+
+**Architecture:** Each repair is one TypeScript file implementing `query()` + `decide()`. A shared scaffold in `lib/` handles plan file generation (JSONL), atomic application (chunked transactions), and error/skipped collection. The `zlv` binary (commander) exposes `list | plan | stats | apply` commands.
+
+**Tech Stack:** TypeScript (ESM), commander 14, effect/Array (chunksOf), Knex (transactions), Vitest (tests), tsx (dev runner).
+
+## Global Constraints
+
+- All new files are ESM TypeScript (`"type": "module"` in server package.json).
+- Tests use Vitest — never Jest.
+- Integration tests hit a real test DB — never mock the DB (project convention).
+- Transactions: `startTransaction()` in the caller, `withinTransaction()` in repositories.
+- `chunksOf` is imported from `'effect/Array'`.
+- `commander` and `@commander-js/extra-typings` are already installed at `14.x`.
+- Run scripts with `NODE_OPTIONS='--import tsx/esm' tsx <file>` — no compile step needed in dev.
+- All imports inside `server/src/` use the `~/` alias (maps to `server/src/`).
+- Tests for scripts live at `server/src/scripts/repairs/lib/test/`.
+
+---
+
+## File Map
+
+| Path                                                                                  | Action | Responsibility                                                                                                                                |
+| ------------------------------------------------------------------------------------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `server/src/scripts/repairs/lib/types.ts`                                             | Create | Core interfaces: `Repair<H>`, `RepairAction`, `RepairSkip`, `RepairError`, `PlanRow`, `SkippedRow`, `ErrorRow`, `PlanSummary`, `ApplySummary` |
+| `server/src/repositories/eventRepository.ts`                                          | Modify | Add `deleteManyHousingEvents(ids: string[])`                                                                                                  |
+| `server/src/scripts/repairs/lib/plan.ts`                                              | Create | `plan(repair, options)` — query → decide → write plan/skipped/errors JSONL                                                                    |
+| `server/src/scripts/repairs/lib/apply.ts`                                             | Create | `apply(planFile)` — read plan.jsonl → group by payload → chunk → single transaction                                                           |
+| `server/src/scripts/repairs/lib/stats.ts`                                             | Create | `stats(planFile)` — count plan.jsonl rows without touching DB                                                                                 |
+| `server/src/scripts/repairs/index.ts`                                                 | Create | Repair registry: maps name → `Repair<any>`                                                                                                    |
+| `server/src/scripts/repairs/cli.ts`                                                   | Create | `repairCommand()` returning a commander `Command`                                                                                             |
+| `server/src/bin/zlv.ts`                                                               | Create | Top-level `zlv` binary entry point                                                                                                            |
+| `server/package.json`                                                                 | Modify | Add `"zlv"` script entry                                                                                                                      |
+| `server/src/scripts/repairs/lib/test/plan.test.ts`                                    | Create | Unit tests for `plan()`                                                                                                                       |
+| `server/src/scripts/repairs/lib/test/apply.test.ts`                                   | Create | Integration tests for `apply()`                                                                                                               |
+| `server/src/scripts/repairs/lib/test/eventRepository-deleteManyHousingEvents.test.ts` | Create | Integration test for `deleteManyHousingEvents()`                                                                                              |
+
+---
+
+## Task 1: Core types
+
+**Files:**
+
+- Create: `server/src/scripts/repairs/lib/types.ts`
+
+**Interfaces:**
+
+- Produces: `Repair<H>`, `RepairAction`, `RepairSkip`, `RepairError`, `PlanRow`, `SkippedRow`, `ErrorRow`, `PlanSummary`, `ApplySummary` — consumed by all subsequent tasks.
+
+- [ ] **Step 1: Create the types file**
+
+```typescript
+// server/src/scripts/repairs/lib/types.ts
+import type { HousingApi, HousingId } from '~/models/HousingApi';
+import type { HousingEventApi } from '~/models/EventApi';
+
+export type { HousingId };
+
+export interface Repair<H extends HousingApi = HousingApi> {
+  name: string;
+  query(): Promise<H[]>;
+  decide(housing: H): RepairAction | RepairSkip | RepairError;
+}
+
+export interface RepairAction {
+  update?: Partial<
+    Pick<HousingApi, 'status' | 'subStatus' | 'occupancy' | 'occupancyIntended'>
+  >;
+  createEvents?: HousingEventApi[];
+  deleteEventIds?: string[];
+}
+
+export interface RepairSkip {
+  action: 'skip';
+}
+
+export interface RepairError {
+  action: 'error';
+  reason: string;
+}
+
+export interface PlanRow {
+  housingId: string;
+  housingGeoCode: string;
+  update?: RepairAction['update'];
+  createEvents?: HousingEventApi[];
+  deleteEventIds?: string[];
+}
+
+export interface SkippedRow {
+  housingId: string;
+  housingGeoCode: string;
+}
+
+export interface ErrorRow {
+  housingId: string;
+  housingGeoCode: string;
+  reason: string;
+}
+
+export interface PlanSummary {
+  total: number;
+  planned: number;
+  skipped: number;
+  errors: number;
+  eventsToDelete: number;
+  eventsToCreate: number;
+}
+
+export interface ApplySummary {
+  updated: number;
+  eventsDeleted: number;
+  eventsCreated: number;
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add server/src/scripts/repairs/lib/types.ts
+git commit -m "feat(repairs): add core types for repair harness"
+```
+
+---
+
+## Task 2: `eventRepository.deleteManyHousingEvents()`
+
+**Files:**
+
+- Modify: `server/src/repositories/eventRepository.ts`
+- Test: `server/src/scripts/repairs/lib/test/eventRepository-deleteManyHousingEvents.test.ts`
+
+**Interfaces:**
+
+- Consumes: `Events`, `HousingEvents`, `EVENTS_TABLE`, `HOUSING_EVENTS_TABLE`, `withinTransaction` — all already in `eventRepository.ts`.
+- Produces: `eventRepository.deleteManyHousingEvents(ids: string[]): Promise<void>` — consumed by Task 4 (`apply.ts`).
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// server/src/scripts/repairs/lib/test/eventRepository-deleteManyHousingEvents.test.ts
+import { v4 as uuidv4 } from 'uuid';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  Events,
+  EVENTS_TABLE,
+  HousingEvents,
+  HOUSING_EVENTS_TABLE
+} from '~/repositories/eventRepository';
+import eventRepository from '~/repositories/eventRepository';
+import { genHousingApi } from '~/test/testFixtures';
+import { Housings } from '~/repositories/housingRepository';
+
+const housing = genHousingApi();
+
+beforeEach(async () => {
+  await Housings().insert({
+    /* minimal housing row */ id: housing.id,
+    geo_code: housing.geoCode
+  });
+});
+
+describe('deleteManyHousingEvents', () => {
+  it('hard-deletes the given event ids from events and housing_events', async () => {
+    const eventId = uuidv4();
+    await Events().insert({
+      id: eventId,
+      type: 'housing:status-updated',
+      next_old: null,
+      next_new: null,
+      created_at: new Date(),
+      created_by: uuidv4()
+    });
+    await HousingEvents().insert({
+      event_id: eventId,
+      housing_id: housing.id,
+      housing_geo_code: housing.geoCode
+    });
+
+    await eventRepository.deleteManyHousingEvents([eventId]);
+
+    const remainingEvents = await Events().where('id', eventId);
+    const remainingHousingEvents = await HousingEvents().where(
+      'event_id',
+      eventId
+    );
+    expect(remainingEvents).toHaveLength(0);
+    expect(remainingHousingEvents).toHaveLength(0);
+  });
+
+  it('is a no-op for an empty array', async () => {
+    await expect(
+      eventRepository.deleteManyHousingEvents([])
+    ).resolves.not.toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to confirm it fails**
+
+```bash
+yarn nx test server -- eventRepository-deleteManyHousingEvents
+```
+
+Expected: FAIL — `eventRepository.deleteManyHousingEvents is not a function`.
+
+- [ ] **Step 3: Implement `deleteManyHousingEvents` in eventRepository.ts**
+
+Add before the `export default` block (after `removeCampaignEvents`):
+
+```typescript
+async function deleteManyHousingEvents(ids: string[]): Promise<void> {
+  if (ids.length === 0) {
+    return;
+  }
+  logger.debug('Deleting housing events...', { count: ids.length });
+  await withinTransaction(async (transaction) => {
+    await HousingEvents(transaction).whereIn('event_id', ids).delete();
+    await Events(transaction).whereIn('id', ids).delete();
+  });
+  logger.debug('Housing events deleted', { count: ids.length });
+}
+```
+
+Add to the `export default` object at the bottom:
+
+```typescript
+export default {
+  // ...existing exports...
+  deleteManyHousingEvents
+};
+```
+
+- [ ] **Step 4: Run test to confirm it passes**
+
+```bash
+yarn nx test server -- eventRepository-deleteManyHousingEvents
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/repositories/eventRepository.ts \
+        server/src/scripts/repairs/lib/test/eventRepository-deleteManyHousingEvents.test.ts
+git commit -m "feat(repairs): add deleteManyHousingEvents to eventRepository"
+```
+
+---
+
+## Task 3: `plan()` function
+
+**Files:**
+
+- Create: `server/src/scripts/repairs/lib/plan.ts`
+- Test: `server/src/scripts/repairs/lib/test/plan.test.ts`
+
+**Interfaces:**
+
+- Consumes: `Repair<H>`, `RepairAction`, `RepairSkip`, `RepairError`, `PlanRow`, `SkippedRow`, `ErrorRow`, `PlanSummary` from `./types`.
+- Produces: `plan(repair: Repair<H>, options?: PlanOptions): Promise<PlanSummary>` — consumed by Task 5 (CLI).
+- Side effects: writes `plan.jsonl`, `skipped.jsonl`, `errors.jsonl` to `options.outDir` (default: `process.cwd()`).
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+// server/src/scripts/repairs/lib/test/plan.test.ts
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { HousingStatus } from '@zerologementvacant/models';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { genHousingApi } from '~/test/testFixtures';
+import { plan } from '../plan';
+import type { Repair } from '../types';
+
+let outDir: string;
+
+beforeEach(() => {
+  outDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zlv-repair-'));
+});
+
+afterEach(() => {
+  fs.rmSync(outDir, { recursive: true });
+});
+
+describe('plan()', () => {
+  it('writes RepairActions to plan.jsonl', async () => {
+    const housing = genHousingApi();
+    const repair: Repair = {
+      name: 'test',
+      query: async () => [housing],
+      decide: () => ({
+        update: { status: HousingStatus.NEVER_CONTACTED, subStatus: null }
+      })
+    };
+
+    const summary = await plan(repair, { outDir });
+
+    expect(summary.planned).toBe(1);
+    expect(summary.skipped).toBe(0);
+    expect(summary.errors).toBe(0);
+
+    const lines = fs
+      .readFileSync(path.join(outDir, 'plan.jsonl'), 'utf-8')
+      .trim()
+      .split('\n');
+    expect(lines).toHaveLength(1);
+    const row = JSON.parse(lines[0]);
+    expect(row).toMatchObject({
+      housingId: housing.id,
+      housingGeoCode: housing.geoCode,
+      update: { status: HousingStatus.NEVER_CONTACTED, subStatus: null }
+    });
+  });
+
+  it('writes RepairSkips to skipped.jsonl', async () => {
+    const housing = genHousingApi();
+    const repair: Repair = {
+      name: 'test',
+      query: async () => [housing],
+      decide: () => ({ action: 'skip' })
+    };
+
+    const summary = await plan(repair, { outDir });
+
+    expect(summary.skipped).toBe(1);
+    expect(summary.planned).toBe(0);
+
+    const lines = fs
+      .readFileSync(path.join(outDir, 'skipped.jsonl'), 'utf-8')
+      .trim()
+      .split('\n');
+    expect(JSON.parse(lines[0])).toMatchObject({
+      housingId: housing.id,
+      housingGeoCode: housing.geoCode
+    });
+  });
+
+  it('writes RepairErrors to errors.jsonl', async () => {
+    const housing = genHousingApi();
+    const repair: Repair = {
+      name: 'test',
+      query: async () => [housing],
+      decide: () => ({ action: 'error', reason: 'no restorable event' })
+    };
+
+    const summary = await plan(repair, { outDir });
+
+    expect(summary.errors).toBe(1);
+
+    const lines = fs
+      .readFileSync(path.join(outDir, 'errors.jsonl'), 'utf-8')
+      .trim()
+      .split('\n');
+    expect(JSON.parse(lines[0])).toMatchObject({
+      housingId: housing.id,
+      housingGeoCode: housing.geoCode,
+      reason: 'no restorable event'
+    });
+  });
+
+  it('counts events to delete and create in summary', async () => {
+    const housing = genHousingApi();
+    const repair: Repair = {
+      name: 'test',
+      query: async () => [housing],
+      decide: () => ({
+        update: { status: HousingStatus.NEVER_CONTACTED },
+        deleteEventIds: ['evt-1', 'evt-2'],
+        createEvents: []
+      })
+    };
+
+    const summary = await plan(repair, { outDir });
+
+    expect(summary.eventsToDelete).toBe(2);
+    expect(summary.eventsToCreate).toBe(0);
+  });
+
+  it('returns correct totals across all outcomes', async () => {
+    const [h1, h2, h3] = [genHousingApi(), genHousingApi(), genHousingApi()];
+    const repair: Repair = {
+      name: 'test',
+      query: async () => [h1, h2, h3],
+      decide: (h) => {
+        if (h.id === h1.id)
+          return { update: { status: HousingStatus.NEVER_CONTACTED } };
+        if (h.id === h2.id) return { action: 'skip' };
+        return { action: 'error', reason: 'test' };
+      }
+    };
+
+    const summary = await plan(repair, { outDir });
+
+    expect(summary).toEqual({
+      total: 3,
+      planned: 1,
+      skipped: 1,
+      errors: 1,
+      eventsToDelete: 0,
+      eventsToCreate: 0
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+yarn nx test server -- plan.test
+```
+
+Expected: FAIL — `Cannot find module '../plan'`.
+
+- [ ] **Step 3: Implement `plan.ts`**
+
+```typescript
+// server/src/scripts/repairs/lib/plan.ts
+import fs from 'node:fs';
+import path from 'node:path';
+
+import type { HousingApi } from '~/models/HousingApi';
+
+import type {
+  ErrorRow,
+  PlanRow,
+  PlanSummary,
+  Repair,
+  RepairAction,
+  RepairError,
+  RepairSkip,
+  SkippedRow
+} from './types';
+
+export interface PlanOptions {
+  outDir?: string;
+}
+
+export async function plan<H extends HousingApi>(
+  repair: Repair<H>,
+  options: PlanOptions = {}
+): Promise<PlanSummary> {
+  const outDir = options.outDir ?? process.cwd();
+
+  const planStream = fs.createWriteStream(path.join(outDir, 'plan.jsonl'));
+  const skippedStream = fs.createWriteStream(
+    path.join(outDir, 'skipped.jsonl')
+  );
+  const errorsStream = fs.createWriteStream(path.join(outDir, 'errors.jsonl'));
+
+  const housings = await repair.query();
+  let planned = 0,
+    skipped = 0,
+    errors = 0,
+    eventsToDelete = 0,
+    eventsToCreate = 0;
+
+  for (const housing of housings) {
+    const decision = repair.decide(housing);
+
+    if (isSkip(decision)) {
+      const row: SkippedRow = {
+        housingId: housing.id,
+        housingGeoCode: housing.geoCode
+      };
+      skippedStream.write(JSON.stringify(row) + '\n');
+      skipped++;
+    } else if (isError(decision)) {
+      const row: ErrorRow = {
+        housingId: housing.id,
+        housingGeoCode: housing.geoCode,
+        reason: decision.reason
+      };
+      errorsStream.write(JSON.stringify(row) + '\n');
+      errors++;
+    } else {
+      const row: PlanRow = {
+        housingId: housing.id,
+        housingGeoCode: housing.geoCode,
+        ...decision
+      };
+      planStream.write(JSON.stringify(row) + '\n');
+      planned++;
+      eventsToDelete += decision.deleteEventIds?.length ?? 0;
+      eventsToCreate += decision.createEvents?.length ?? 0;
+    }
+  }
+
+  await Promise.all([
+    streamEnd(planStream),
+    streamEnd(skippedStream),
+    streamEnd(errorsStream)
+  ]);
+
+  return {
+    total: housings.length,
+    planned,
+    skipped,
+    errors,
+    eventsToDelete,
+    eventsToCreate
+  };
+}
+
+function isSkip(d: RepairAction | RepairSkip | RepairError): d is RepairSkip {
+  return 'action' in d && d.action === 'skip';
+}
+
+function isError(d: RepairAction | RepairSkip | RepairError): d is RepairError {
+  return 'action' in d && d.action === 'error';
+}
+
+function streamEnd(stream: fs.WriteStream): Promise<void> {
+  return new Promise((resolve, reject) =>
+    stream.end((err) => (err ? reject(err) : resolve()))
+  );
+}
+```
+
+- [ ] **Step 4: Run tests to confirm they pass**
+
+```bash
+yarn nx test server -- plan.test
+```
+
+Expected: PASS (all 5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/scripts/repairs/lib/plan.ts \
+        server/src/scripts/repairs/lib/test/plan.test.ts
+git commit -m "feat(repairs): add plan() function"
+```
+
+---
+
+## Task 4: `apply()` and `stats()` functions
+
+**Files:**
+
+- Create: `server/src/scripts/repairs/lib/apply.ts`
+- Create: `server/src/scripts/repairs/lib/stats.ts`
+- Test: `server/src/scripts/repairs/lib/test/apply.test.ts`
+
+**Interfaces:**
+
+- Consumes:
+  - `housingRepository.updateMany(housings: ReadonlyArray<HousingId>, payload)` from `~/repositories/housingRepository`
+  - `eventRepository.deleteManyHousingEvents(ids: string[])` from Task 2
+  - `eventRepository.insertManyHousingEvents(events: HousingEventApi[])` from `~/repositories/eventRepository`
+  - `startTransaction()` from `~/infra/database/transaction`
+  - `chunksOf` from `'effect/Array'`
+  - `PlanRow`, `ApplySummary`, `PlanSummary` from `./types`
+- Produces:
+  - `apply(planFile: string): Promise<ApplySummary>`
+  - `stats(planFile: string): Promise<Pick<PlanSummary, 'planned' | 'eventsToDelete' | 'eventsToCreate'>>`
+
+- [ ] **Step 1: Write the failing integration tests for `apply()`**
+
+```typescript
+// server/src/scripts/repairs/lib/test/apply.test.ts
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { HousingStatus } from '@zerologementvacant/models';
+import { v4 as uuidv4 } from 'uuid';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { Housings } from '~/repositories/housingRepository';
+import { Events, HousingEvents } from '~/repositories/eventRepository';
+import { genHousingApi } from '~/test/testFixtures';
+import { apply } from '../apply';
+import type { PlanRow } from '../types';
+
+let outDir: string;
+
+beforeEach(() => {
+  outDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zlv-apply-'));
+});
+
+function writePlan(rows: PlanRow[]): string {
+  const planFile = path.join(outDir, 'plan.jsonl');
+  fs.writeFileSync(
+    planFile,
+    rows.map((r) => JSON.stringify(r)).join('\n') + '\n'
+  );
+  return planFile;
+}
+
+describe('apply()', () => {
+  it('updates housing fields from plan rows', async () => {
+    const housing = genHousingApi({
+      status: HousingStatus.WAITING,
+      subStatus: 'En attente de réponse'
+    });
+    await Housings().insert(formatHousingForDb(housing));
+
+    const planFile = writePlan([
+      {
+        housingId: housing.id,
+        housingGeoCode: housing.geoCode,
+        update: { status: HousingStatus.NEVER_CONTACTED, subStatus: null }
+      }
+    ]);
+
+    const summary = await apply(planFile);
+
+    expect(summary.updated).toBe(1);
+    const [row] = await Housings().where({ id: housing.id });
+    expect(row.status).toBe(HousingStatus.NEVER_CONTACTED);
+    expect(row.sub_status).toBeNull();
+  });
+
+  it('hard-deletes event ids listed in plan rows', async () => {
+    const housing = genHousingApi();
+    await Housings().insert(formatHousingForDb(housing));
+
+    const eventId = uuidv4();
+    await Events().insert({
+      id: eventId,
+      type: 'housing:status-updated',
+      next_old: null,
+      next_new: null,
+      created_at: new Date(),
+      created_by: uuidv4()
+    });
+    await HousingEvents().insert({
+      event_id: eventId,
+      housing_id: housing.id,
+      housing_geo_code: housing.geoCode
+    });
+
+    const planFile = writePlan([
+      {
+        housingId: housing.id,
+        housingGeoCode: housing.geoCode,
+        deleteEventIds: [eventId]
+      }
+    ]);
+
+    const summary = await apply(planFile);
+
+    expect(summary.eventsDeleted).toBe(1);
+    expect(await Events().where('id', eventId)).toHaveLength(0);
+    expect(await HousingEvents().where('event_id', eventId)).toHaveLength(0);
+  });
+
+  it('returns correct summary', async () => {
+    const [h1, h2] = [genHousingApi(), genHousingApi()];
+    await Housings().insert([formatHousingForDb(h1), formatHousingForDb(h2)]);
+
+    const planFile = writePlan([
+      {
+        housingId: h1.id,
+        housingGeoCode: h1.geoCode,
+        update: { status: HousingStatus.NEVER_CONTACTED }
+      },
+      {
+        housingId: h2.id,
+        housingGeoCode: h2.geoCode,
+        update: { status: HousingStatus.NEVER_CONTACTED }
+      }
+    ]);
+
+    const summary = await apply(planFile);
+
+    expect(summary).toEqual({ updated: 2, eventsDeleted: 0, eventsCreated: 0 });
+  });
+
+  it('does nothing for an empty plan file', async () => {
+    const planFile = writePlan([]);
+    const summary = await apply(planFile);
+    expect(summary).toEqual({ updated: 0, eventsDeleted: 0, eventsCreated: 0 });
+  });
+});
+
+function formatHousingForDb(housing: ReturnType<typeof genHousingApi>) {
+  return {
+    id: housing.id,
+    geo_code: housing.geoCode,
+    status: housing.status,
+    sub_status: housing.subStatus ?? null
+    // add other non-nullable columns as needed from your test DB setup
+  };
+}
+```
+
+> **Note:** `formatHousingForDb` may need additional required columns depending on the housings table schema. Check `genHousingApi()` output and the Housings table DDL to fill in any missing non-nullable fields.
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+yarn nx test server -- apply.test
+```
+
+Expected: FAIL — `Cannot find module '../apply'`.
+
+- [ ] **Step 3: Implement `apply.ts`**
+
+```typescript
+// server/src/scripts/repairs/lib/apply.ts
+import fs from 'node:fs';
+import readline from 'node:readline';
+
+import { chunksOf } from 'effect/Array';
+
+import { startTransaction } from '~/infra/database/transaction';
+import eventRepository from '~/repositories/eventRepository';
+import housingRepository from '~/repositories/housingRepository';
+
+import type { ApplySummary, PlanRow } from './types';
+
+export async function apply(planFile: string): Promise<ApplySummary> {
+  const rows = await readPlan(planFile);
+
+  if (rows.length === 0) {
+    return { updated: 0, eventsDeleted: 0, eventsCreated: 0 };
+  }
+
+  const groups = groupByPayload(rows);
+  const allDeleteIds = rows.flatMap((r) => r.deleteEventIds ?? []);
+  const allCreateEvents = rows.flatMap((r) => r.createEvents ?? []);
+
+  let updated = 0;
+
+  await startTransaction(async () => {
+    for (const group of groups) {
+      if (!group.payload) continue;
+      for (const chunk of chunksOf(group.rows, 1000)) {
+        await housingRepository.updateMany(
+          chunk.map((r) => ({ id: r.housingId, geoCode: r.housingGeoCode })),
+          group.payload
+        );
+        updated += chunk.length;
+      }
+    }
+
+    if (allDeleteIds.length > 0) {
+      await eventRepository.deleteManyHousingEvents(allDeleteIds);
+    }
+
+    if (allCreateEvents.length > 0) {
+      await eventRepository.insertManyHousingEvents(allCreateEvents);
+    }
+  });
+
+  return {
+    updated,
+    eventsDeleted: allDeleteIds.length,
+    eventsCreated: allCreateEvents.length
+  };
+}
+
+async function readPlan(planFile: string): Promise<PlanRow[]> {
+  const rows: PlanRow[] = [];
+  const rl = readline.createInterface({
+    input: fs.createReadStream(planFile),
+    crlfDelay: Infinity
+  });
+  for await (const line of rl) {
+    if (line.trim()) rows.push(JSON.parse(line) as PlanRow);
+  }
+  return rows;
+}
+
+interface PayloadGroup {
+  payload: PlanRow['update'];
+  rows: PlanRow[];
+}
+
+function groupByPayload(rows: PlanRow[]): PayloadGroup[] {
+  const map = new Map<string, PayloadGroup>();
+  for (const row of rows) {
+    const key = JSON.stringify(row.update ?? null);
+    if (!map.has(key)) {
+      map.set(key, { payload: row.update, rows: [] });
+    }
+    map.get(key)!.rows.push(row);
+  }
+  return Array.from(map.values());
+}
+```
+
+- [ ] **Step 4: Implement `stats.ts`**
+
+```typescript
+// server/src/scripts/repairs/lib/stats.ts
+import fs from 'node:fs';
+import readline from 'node:readline';
+
+import type { PlanRow, PlanSummary } from './types';
+
+export async function stats(
+  planFile: string
+): Promise<Pick<PlanSummary, 'planned' | 'eventsToDelete' | 'eventsToCreate'>> {
+  const rl = readline.createInterface({
+    input: fs.createReadStream(planFile),
+    crlfDelay: Infinity
+  });
+  let planned = 0,
+    eventsToDelete = 0,
+    eventsToCreate = 0;
+
+  for await (const line of rl) {
+    if (!line.trim()) continue;
+    const row = JSON.parse(line) as PlanRow;
+    planned++;
+    eventsToDelete += row.deleteEventIds?.length ?? 0;
+    eventsToCreate += row.createEvents?.length ?? 0;
+  }
+
+  return { planned, eventsToDelete, eventsToCreate };
+}
+```
+
+- [ ] **Step 5: Run tests to confirm they pass**
+
+```bash
+yarn nx test server -- apply.test
+```
+
+Expected: PASS (all 4 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/src/scripts/repairs/lib/apply.ts \
+        server/src/scripts/repairs/lib/stats.ts \
+        server/src/scripts/repairs/lib/test/apply.test.ts
+git commit -m "feat(repairs): add apply() and stats() functions"
+```
+
+---
+
+## Task 5: CLI, registry, and `zlv` binary
+
+**Files:**
+
+- Create: `server/src/scripts/repairs/index.ts`
+- Create: `server/src/scripts/repairs/cli.ts`
+- Create: `server/src/bin/zlv.ts`
+- Modify: `server/package.json`
+
+**Interfaces:**
+
+- Consumes:
+  - `plan()` from `./lib/plan`
+  - `apply()` from `./lib/apply`
+  - `stats()` from `./lib/stats`
+  - `Repair<any>` from `./lib/types`
+  - `Command` from `@commander-js/extra-typings`
+- Produces: `zlv repair list|plan|stats|apply` CLI commands.
+
+- [ ] **Step 1: Create the repair registry**
+
+```typescript
+// server/src/scripts/repairs/index.ts
+import type { Repair } from './lib/types';
+
+// Register new repairs here — one line per repair:
+// import { myRepair } from './my-repair';
+
+export const repairs: Record<string, Repair<any>> = {
+  // 'my-repair': myRepair,
+};
+```
+
+- [ ] **Step 2: Create the repair subcommand**
+
+```typescript
+// server/src/scripts/repairs/cli.ts
+import { Command } from '@commander-js/extra-typings';
+
+import { apply } from './lib/apply';
+import { plan } from './lib/plan';
+import { stats } from './lib/stats';
+import { repairs } from './index';
+
+export function repairCommand(): Command {
+  const cmd = new Command('repair').description(
+    'Bulk housing data repair commands'
+  );
+
+  cmd
+    .command('list')
+    .description('List all registered repairs')
+    .action(() => {
+      const names = Object.keys(repairs);
+      if (names.length === 0) {
+        console.log('No repairs registered.');
+        return;
+      }
+      names.forEach((name) => console.log(name));
+    });
+
+  cmd
+    .command('plan')
+    .description(
+      'Generate plan.jsonl, skipped.jsonl, errors.jsonl for a repair'
+    )
+    .argument('<name>', 'repair name (see: zlv repair list)')
+    .option('--out <dir>', 'output directory', process.cwd())
+    .action(async (name, options) => {
+      const repair = repairs[name];
+      if (!repair) {
+        console.error(
+          `Unknown repair: "${name}". Run "zlv repair list" to see available repairs.`
+        );
+        process.exit(1);
+      }
+      const summary = await plan(repair, { outDir: options.out });
+      console.log(`Total:    ${summary.total}`);
+      console.log(`Planned:  ${summary.planned}`);
+      console.log(`Skipped:  ${summary.skipped}`);
+      console.log(`Errors:   ${summary.errors}`);
+      console.log(`Events to delete: ${summary.eventsToDelete}`);
+      console.log(`Events to create: ${summary.eventsToCreate}`);
+      console.log(`\nFiles written to: ${options.out}`);
+      console.log('  plan.jsonl, skipped.jsonl, errors.jsonl');
+    });
+
+  cmd
+    .command('stats')
+    .description('Summarise a plan file without touching the DB')
+    .argument('<plan-file>', 'path to plan.jsonl')
+    .action(async (planFile) => {
+      const summary = await stats(planFile);
+      console.log(`Planned:  ${summary.planned}`);
+      console.log(`Events to delete: ${summary.eventsToDelete}`);
+      console.log(`Events to create: ${summary.eventsToCreate}`);
+    });
+
+  cmd
+    .command('apply')
+    .description(
+      'Apply a plan file atomically (single transaction, full rollback on failure)'
+    )
+    .argument('<plan-file>', 'path to plan.jsonl')
+    .action(async (planFile) => {
+      const summary = await apply(planFile);
+      console.log(`Updated:         ${summary.updated}`);
+      console.log(`Events deleted:  ${summary.eventsDeleted}`);
+      console.log(`Events created:  ${summary.eventsCreated}`);
+    });
+
+  return cmd;
+}
+```
+
+- [ ] **Step 3: Create the `zlv` binary entry point**
+
+```typescript
+// server/src/bin/zlv.ts
+import { Command } from '@commander-js/extra-typings';
+
+import { repairCommand } from '../scripts/repairs/cli';
+
+const program = new Command('zlv')
+  .description('ZLV developer CLI')
+  .version('0.1.0');
+
+program.addCommand(repairCommand());
+
+program.parseAsync(process.argv).finally(() => process.exit());
+```
+
+- [ ] **Step 4: Add the `zlv` script to `server/package.json`**
+
+In `server/package.json`, add to the `"scripts"` object:
+
+```json
+"zlv": "NODE_OPTIONS='--import tsx/esm' tsx src/bin/zlv.ts"
+```
+
+- [ ] **Step 5: Smoke-test the CLI**
+
+```bash
+yarn workspace @zerologementvacant/server zlv repair list
+```
+
+Expected output:
+
+```
+No repairs registered.
+```
+
+```bash
+yarn workspace @zerologementvacant/server zlv repair --help
+```
+
+Expected: help text with `list`, `plan`, `stats`, `apply` subcommands listed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/src/scripts/repairs/index.ts \
+        server/src/scripts/repairs/cli.ts \
+        server/src/bin/zlv.ts \
+        server/package.json
+git commit -m "feat(repairs): add zlv CLI with repair subcommand"
+```
+
+---
+
+## Self-Review Notes
+
+After writing: spec coverage checked.
+
+- ✅ `Repair<H>` generic interface with `query()` + `decide()` → Task 1
+- ✅ `RepairAction` with optional `update`, `createEvents`, `deleteEventIds` → Task 1
+- ✅ `RepairSkip` → `skipped.jsonl` (not silently omitted) → Tasks 1, 3
+- ✅ `RepairError` → `errors.jsonl` → Tasks 1, 3
+- ✅ `plan` command writes 3 JSONL files + prints summary → Tasks 3, 5
+- ✅ `apply` groups by payload, chunks to 1000, single transaction → Task 4
+- ✅ Hard-delete of events via `deleteManyHousingEvents` → Task 2
+- ✅ Optional `createEvents` → Task 4 (`insertManyHousingEvents`)
+- ✅ `stats` command reads plan file without DB → Tasks 4, 5
+- ✅ `list` command shows registered repairs → Task 5
+- ✅ Repair registry in `index.ts` → Task 5
+- ✅ `zlv` binary with commander → Task 5
+- ✅ `--out` option for `plan` command → Task 5
+- ✅ No streaming (deferred) — load whole file, single transaction → Task 4

--- a/docs/superpowers/plans/2026-07-08-zlv-repair-harness.md
+++ b/docs/superpowers/plans/2026-07-08-zlv-repair-harness.md
@@ -24,20 +24,18 @@
 
 ## File Map
 
-| Path                                                                                  | Action | Responsibility                                                                                                                                |
-| ------------------------------------------------------------------------------------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| `server/src/scripts/repairs/lib/types.ts`                                             | Create | Core interfaces: `Repair<H>`, `RepairAction`, `RepairSkip`, `RepairError`, `PlanRow`, `SkippedRow`, `ErrorRow`, `PlanSummary`, `ApplySummary` |
-| `server/src/repositories/eventRepository.ts`                                          | Modify | Add `deleteManyHousingEvents(ids: string[])`                                                                                                  |
-| `server/src/scripts/repairs/lib/plan.ts`                                              | Create | `plan(repair, options)` — query → decide → write plan/skipped/errors JSONL                                                                    |
-| `server/src/scripts/repairs/lib/apply.ts`                                             | Create | `apply(planFile)` — read plan.jsonl → group by payload → chunk → single transaction                                                           |
-| `server/src/scripts/repairs/lib/stats.ts`                                             | Create | `stats(planFile)` — count plan.jsonl rows without touching DB                                                                                 |
-| `server/src/scripts/repairs/index.ts`                                                 | Create | Repair registry: maps name → `Repair<any>`                                                                                                    |
-| `server/src/scripts/repairs/cli.ts`                                                   | Create | `repairCommand()` returning a commander `Command`                                                                                             |
-| `server/src/bin/zlv.ts`                                                               | Create | Top-level `zlv` binary entry point                                                                                                            |
-| `server/package.json`                                                                 | Modify | Add `"zlv"` script entry                                                                                                                      |
-| `server/src/scripts/repairs/lib/test/plan.test.ts`                                    | Create | Unit tests for `plan()`                                                                                                                       |
-| `server/src/scripts/repairs/lib/test/apply.test.ts`                                   | Create | Integration tests for `apply()`                                                                                                               |
-| `server/src/scripts/repairs/lib/test/eventRepository-deleteManyHousingEvents.test.ts` | Create | Integration test for `deleteManyHousingEvents()`                                                                                              |
+| Path                                                | Action | Responsibility                                                                                                                                |
+| --------------------------------------------------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `server/src/scripts/repairs/lib/types.ts`           | Create | Core interfaces: `Repair<H>`, `RepairAction`, `RepairSkip`, `RepairError`, `PlanRow`, `SkippedRow`, `ErrorRow`, `PlanSummary`, `ApplySummary` |
+| `server/src/scripts/repairs/lib/plan.ts`            | Create | `plan(repair, options)` — query → decide → write plan/skipped/errors JSONL                                                                    |
+| `server/src/scripts/repairs/lib/apply.ts`           | Create | `apply(planFile)` — read plan.jsonl → group by payload → chunk → single transaction; inlines event deletion via `Events()`/`HousingEvents()`  |
+| `server/src/scripts/repairs/lib/stats.ts`           | Create | `stats(planFile)` — count plan.jsonl rows without touching DB                                                                                 |
+| `server/src/scripts/repairs/index.ts`               | Create | Repair registry: maps name → `Repair<any>`                                                                                                    |
+| `server/src/scripts/repairs/cli.ts`                 | Create | `repairCommand()` returning a commander `Command`                                                                                             |
+| `server/src/bin/zlv.ts`                             | Create | Top-level `zlv` binary entry point                                                                                                            |
+| `server/package.json`                               | Modify | Add `"zlv"` script entry                                                                                                                      |
+| `server/src/scripts/repairs/lib/test/plan.test.ts`  | Create | Unit tests for `plan()`                                                                                                                       |
+| `server/src/scripts/repairs/lib/test/apply.test.ts` | Create | Integration tests for `apply()`                                                                                                               |
 
 ---
 
@@ -127,134 +125,7 @@ git commit -m "feat(repairs): add core types for repair harness"
 
 ---
 
-## Task 2: `eventRepository.deleteManyHousingEvents()`
-
-**Files:**
-
-- Modify: `server/src/repositories/eventRepository.ts`
-- Test: `server/src/scripts/repairs/lib/test/eventRepository-deleteManyHousingEvents.test.ts`
-
-**Interfaces:**
-
-- Consumes: `Events`, `HousingEvents`, `EVENTS_TABLE`, `HOUSING_EVENTS_TABLE`, `withinTransaction` — all already in `eventRepository.ts`.
-- Produces: `eventRepository.deleteManyHousingEvents(ids: string[]): Promise<void>` — consumed by Task 4 (`apply.ts`).
-
-- [ ] **Step 1: Write the failing test**
-
-```typescript
-// server/src/scripts/repairs/lib/test/eventRepository-deleteManyHousingEvents.test.ts
-import { v4 as uuidv4 } from 'uuid';
-import { beforeEach, describe, expect, it } from 'vitest';
-
-import {
-  Events,
-  EVENTS_TABLE,
-  HousingEvents,
-  HOUSING_EVENTS_TABLE
-} from '~/repositories/eventRepository';
-import eventRepository from '~/repositories/eventRepository';
-import { genHousingApi } from '~/test/testFixtures';
-import { Housings } from '~/repositories/housingRepository';
-
-const housing = genHousingApi();
-
-beforeEach(async () => {
-  await Housings().insert({
-    /* minimal housing row */ id: housing.id,
-    geo_code: housing.geoCode
-  });
-});
-
-describe('deleteManyHousingEvents', () => {
-  it('hard-deletes the given event ids from events and housing_events', async () => {
-    const eventId = uuidv4();
-    await Events().insert({
-      id: eventId,
-      type: 'housing:status-updated',
-      next_old: null,
-      next_new: null,
-      created_at: new Date(),
-      created_by: uuidv4()
-    });
-    await HousingEvents().insert({
-      event_id: eventId,
-      housing_id: housing.id,
-      housing_geo_code: housing.geoCode
-    });
-
-    await eventRepository.deleteManyHousingEvents([eventId]);
-
-    const remainingEvents = await Events().where('id', eventId);
-    const remainingHousingEvents = await HousingEvents().where(
-      'event_id',
-      eventId
-    );
-    expect(remainingEvents).toHaveLength(0);
-    expect(remainingHousingEvents).toHaveLength(0);
-  });
-
-  it('is a no-op for an empty array', async () => {
-    await expect(
-      eventRepository.deleteManyHousingEvents([])
-    ).resolves.not.toThrow();
-  });
-});
-```
-
-- [ ] **Step 2: Run test to confirm it fails**
-
-```bash
-yarn nx test server -- eventRepository-deleteManyHousingEvents
-```
-
-Expected: FAIL — `eventRepository.deleteManyHousingEvents is not a function`.
-
-- [ ] **Step 3: Implement `deleteManyHousingEvents` in eventRepository.ts**
-
-Add before the `export default` block (after `removeCampaignEvents`):
-
-```typescript
-async function deleteManyHousingEvents(ids: string[]): Promise<void> {
-  if (ids.length === 0) {
-    return;
-  }
-  logger.debug('Deleting housing events...', { count: ids.length });
-  await withinTransaction(async (transaction) => {
-    await HousingEvents(transaction).whereIn('event_id', ids).delete();
-    await Events(transaction).whereIn('id', ids).delete();
-  });
-  logger.debug('Housing events deleted', { count: ids.length });
-}
-```
-
-Add to the `export default` object at the bottom:
-
-```typescript
-export default {
-  // ...existing exports...
-  deleteManyHousingEvents
-};
-```
-
-- [ ] **Step 4: Run test to confirm it passes**
-
-```bash
-yarn nx test server -- eventRepository-deleteManyHousingEvents
-```
-
-Expected: PASS.
-
-- [ ] **Step 5: Commit**
-
-```bash
-git add server/src/repositories/eventRepository.ts \
-        server/src/scripts/repairs/lib/test/eventRepository-deleteManyHousingEvents.test.ts
-git commit -m "feat(repairs): add deleteManyHousingEvents to eventRepository"
-```
-
----
-
-## Task 3: `plan()` function
+## Task 2: `plan()` function
 
 **Files:**
 
@@ -544,7 +415,7 @@ git commit -m "feat(repairs): add plan() function"
 
 ---
 
-## Task 4: `apply()` and `stats()` functions
+## Task 3: `apply()` and `stats()` functions
 
 **Files:**
 
@@ -556,9 +427,9 @@ git commit -m "feat(repairs): add plan() function"
 
 - Consumes:
   - `housingRepository.updateMany(housings: ReadonlyArray<HousingId>, payload)` from `~/repositories/housingRepository`
-  - `eventRepository.deleteManyHousingEvents(ids: string[])` from Task 2
   - `eventRepository.insertManyHousingEvents(events: HousingEventApi[])` from `~/repositories/eventRepository`
-  - `startTransaction()` from `~/infra/database/transaction`
+  - `Events`, `HousingEvents` table accessors from `~/repositories/eventRepository` (used directly for event deletion — not a promoted repository method)
+  - `startTransaction()`, `withinTransaction()` from `~/infra/database/transaction`
   - `chunksOf` from `'effect/Array'`
   - `PlanRow`, `ApplySummary`, `PlanSummary` from `./types`
 - Produces:
@@ -715,7 +586,11 @@ import readline from 'node:readline';
 
 import { chunksOf } from 'effect/Array';
 
-import { startTransaction } from '~/infra/database/transaction';
+import {
+  startTransaction,
+  withinTransaction
+} from '~/infra/database/transaction';
+import { Events, HousingEvents } from '~/repositories/eventRepository';
 import eventRepository from '~/repositories/eventRepository';
 import housingRepository from '~/repositories/housingRepository';
 
@@ -747,7 +622,12 @@ export async function apply(planFile: string): Promise<ApplySummary> {
     }
 
     if (allDeleteIds.length > 0) {
-      await eventRepository.deleteManyHousingEvents(allDeleteIds);
+      await withinTransaction(async (transaction) => {
+        await HousingEvents(transaction)
+          .whereIn('event_id', allDeleteIds)
+          .delete();
+        await Events(transaction).whereIn('id', allDeleteIds).delete();
+      });
     }
 
     if (allCreateEvents.length > 0) {
@@ -843,7 +723,7 @@ git commit -m "feat(repairs): add apply() and stats() functions"
 
 ---
 
-## Task 5: CLI, registry, and `zlv` binary
+## Task 4: CLI, registry, and `zlv` binary
 
 **Files:**
 
@@ -855,9 +735,8 @@ git commit -m "feat(repairs): add apply() and stats() functions"
 **Interfaces:**
 
 - Consumes:
-  - `plan()` from `./lib/plan`
-  - `apply()` from `./lib/apply`
-  - `stats()` from `./lib/stats`
+  - `plan()` from Task 2 (`./lib/plan`)
+  - `apply()`, `stats()` from Task 3 (`./lib/apply`, `./lib/stats`)
   - `Repair<any>` from `./lib/types`
   - `Command` from `@commander-js/extra-typings`
 - Produces: `zlv repair list|plan|stats|apply` CLI commands.
@@ -1023,8 +902,8 @@ After writing: spec coverage checked.
 - ✅ `RepairError` → `errors.jsonl` → Tasks 1, 3
 - ✅ `plan` command writes 3 JSONL files + prints summary → Tasks 3, 5
 - ✅ `apply` groups by payload, chunks to 1000, single transaction → Task 4
-- ✅ Hard-delete of events via `deleteManyHousingEvents` → Task 2
-- ✅ Optional `createEvents` → Task 4 (`insertManyHousingEvents`)
+- ✅ Hard-delete of events inlined in `apply.ts` via `Events()`/`HousingEvents()` — not promoted as a repository method → Task 3
+- ✅ Optional `createEvents` → Task 3 (`insertManyHousingEvents`)
 - ✅ `stats` command reads plan file without DB → Tasks 4, 5
 - ✅ `list` command shows registered repairs → Task 5
 - ✅ Repair registry in `index.ts` → Task 5

--- a/docs/superpowers/plans/2026-07-08-zlv-repair-harness.md
+++ b/docs/superpowers/plans/2026-07-08-zlv-repair-harness.md
@@ -135,7 +135,7 @@ git commit -m "feat(repairs): add core types for repair harness"
 **Interfaces:**
 
 - Consumes: `Repair<H>`, `RepairAction`, `RepairSkip`, `RepairError`, `PlanRow`, `SkippedRow`, `ErrorRow`, `PlanSummary` from `./types`.
-- Produces: `plan(repair: Repair<H>, options?: PlanOptions): Promise<PlanSummary>` — consumed by Task 5 (CLI).
+- Produces: `plan(repair: Repair<H>, options?: PlanOptions): Promise<PlanSummary>` — consumed by Task 4 (CLI).
 - Side effects: writes `plan.jsonl`, `skipped.jsonl`, `errors.jsonl` to `options.outDir` (default: `process.cwd()`).
 
 - [ ] **Step 1: Write the failing tests**

--- a/server/package.json
+++ b/server/package.json
@@ -7,7 +7,8 @@
     "test:migrations": "vitest run --config vitest.database.config.ts",
     "db": "NODE_OPTIONS='--import tsx/esm' knex --knexfile=src/infra/database/knexfile.ts",
     "migrate": "yarn db migrate:latest",
-    "seed": "yarn db seed:run"
+    "seed": "yarn db seed:run",
+    "zlv": "NODE_OPTIONS='--import tsx/esm' tsx src/bin/zlv.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "3.1045.0",

--- a/server/src/bin/zlv.ts
+++ b/server/src/bin/zlv.ts
@@ -1,0 +1,11 @@
+import { Command } from '@commander-js/extra-typings';
+
+import { repairCommand } from '../scripts/repairs/cli';
+
+const program = new Command('zlv')
+  .description('ZLV developer CLI')
+  .version('0.1.0');
+
+program.addCommand(repairCommand());
+
+program.parseAsync(process.argv).finally(() => process.exit());

--- a/server/src/bin/zlv.ts
+++ b/server/src/bin/zlv.ts
@@ -8,4 +8,10 @@ const program = new Command('zlv')
 
 program.addCommand(repairCommand());
 
-program.parseAsync(process.argv).finally(() => process.exit());
+program.parseAsync(process.argv).then(
+  () => process.exit(0),
+  (e) => {
+    console.error(e);
+    process.exit(1);
+  }
+);

--- a/server/src/scripts/import-lovac/infra/housings-counts-maintenance.ts
+++ b/server/src/scripts/import-lovac/infra/housings-counts-maintenance.ts
@@ -1,3 +1,5 @@
+import type { Knex } from 'knex';
+
 import db from '~/infra/database';
 import { createLogger } from '~/infra/logger';
 
@@ -83,9 +85,11 @@ interface PgTriggerRow {
   table: string;
 }
 
-export async function ensureKnownHousingsTriggers(): Promise<void> {
+export async function ensureKnownHousingsTriggers(
+  executor: Knex = db
+): Promise<void> {
   const placeholders = MANAGED_TABLES.map(() => '?').join(', ');
-  const { rows } = await db.raw<{ rows: PgTriggerRow[] }>(
+  const { rows } = await executor.raw<{ rows: PgTriggerRow[] }>(
     `
     SELECT t.tgname    AS name,
            c.relname   AS table
@@ -109,25 +113,31 @@ export async function ensureKnownHousingsTriggers(): Promise<void> {
   }
 }
 
-export async function disableHousingsTriggers(): Promise<void> {
+export async function disableHousingsTriggers(
+  executor: Knex = db
+): Promise<void> {
   for (const table of MANAGED_TABLES) {
     logger.info(`Disabling user triggers on ${table}`);
-    await db.raw(`ALTER TABLE ?? DISABLE TRIGGER USER`, [table]);
+    await executor.raw(`ALTER TABLE ?? DISABLE TRIGGER USER`, [table]);
   }
 }
 
-export async function enableHousingsTriggers(): Promise<void> {
+export async function enableHousingsTriggers(
+  executor: Knex = db
+): Promise<void> {
   for (const table of MANAGED_TABLES) {
     logger.info(`Enabling user triggers on ${table}`);
-    await db.raw(`ALTER TABLE ?? ENABLE TRIGGER USER`, [table]);
+    await executor.raw(`ALTER TABLE ?? ENABLE TRIGGER USER`, [table]);
   }
 }
 
-export async function recomputeHousingsCounts(): Promise<void> {
+export async function recomputeHousingsCounts(
+  executor: Knex = db
+): Promise<void> {
   for (const [name, sql] of Object.entries(RECOMPUTES)) {
     const start = Date.now();
     logger.info(`Recomputing ${name}`);
-    await db.raw(sql);
+    await executor.raw(sql);
     logger.info(`Recomputed ${name} in ${Date.now() - start}ms`);
   }
 }

--- a/server/src/scripts/repairs/README.md
+++ b/server/src/scripts/repairs/README.md
@@ -62,9 +62,10 @@ import type { Repair } from '../lib/types';
 
 export const myRepair: Repair = {
   name: 'my-repair',
-  // Stream the housings in scope — a Knex `.stream()` (a Node object-mode
-  // Readable), so `plan` never holds them all in memory.
-  query: () => Housing().where({ /* ... */ }).stream(),
+  // Stream the housings in scope. `rows<H>()` tags a Knex `.stream()` with its
+  // element type, so `plan` never holds them all in memory and `query()` is
+  // tied to `decide()` at compile time.
+  query: () => rows<HousingApi>(Housing().where({ /* ... */ }).stream()),
   // Decide, per housing, what to do — pure, no side effects.
   decide: (housing) => {
     if (/* nothing to do */) {
@@ -82,8 +83,10 @@ export const myRepair: Repair = {
 };
 ```
 
-- `query()` returns a Node object-mode stream of the candidate housings (e.g. a
-  Knex `.stream()`); `plan` streams it, so the whole set never sits in memory.
+- `query()` returns a `RowStream<H>` of the candidate housings — build it with
+  `rows<H>(knexStream)` (or `rows([...])` for in-memory sources). `plan` streams
+  it, so the whole set never sits in memory, and the compiler ties its element
+  type to `decide`'s parameter.
 - `decide(housing)` returns exactly one of:
   - a `RepairAction` — an optional field `update`, plus optional
     `deleteEventIds` / `createEvents`;
@@ -110,7 +113,7 @@ export const restoreStatus: Repair<HousingWithEvents> = {
   name: 'restore-status',
   // A Knex stream whose query JOINs + aggregates the events onto each row
   // (e.g. `json_agg(...) as "statusEvents"` + `groupBy`).
-  query: () => housingWithEventsQuery().stream(),
+  query: () => rows<HousingWithEvents>(housingWithEventsQuery().stream()),
   // pure: reads housing.statusEvents, no I/O
   decide: (housing) => {
     const restorable = housing.statusEvents.find(/* ... */);
@@ -210,11 +213,13 @@ export const restoreStatus: Repair = {
   name: 'restore-status',
   bypassTriggers: true, // large, status-changing repair
   query: () =>
-    Housing()
-      .where({
-        /* ... */
-      })
-      .stream(),
+    rows<HousingApi>(
+      Housing()
+        .where({
+          /* ... */
+        })
+        .stream()
+    ),
   decide: (housing) => ({ update: { status: HousingStatus.NEVER_CONTACTED } })
 };
 ```

--- a/server/src/scripts/repairs/README.md
+++ b/server/src/scripts/repairs/README.md
@@ -62,8 +62,9 @@ import type { Repair } from '../lib/types';
 
 export const myRepair: Repair = {
   name: 'my-repair',
-  // Pull the housings in scope from the DB.
-  query: () => housingRepository.find({ filters: { /* ... */ } }),
+  // Stream the housings in scope — a Knex `.stream()` (a Node object-mode
+  // Readable), so `plan` never holds them all in memory.
+  query: () => Housing().where({ /* ... */ }).stream(),
   // Decide, per housing, what to do — pure, no side effects.
   decide: (housing) => {
     if (/* nothing to do */) {
@@ -81,7 +82,8 @@ export const myRepair: Repair = {
 };
 ```
 
-- `query()` returns the candidate housings.
+- `query()` returns a Node object-mode stream of the candidate housings (e.g. a
+  Knex `.stream()`); `plan` streams it, so the whole set never sits in memory.
 - `decide(housing)` returns exactly one of:
   - a `RepairAction` — an optional field `update`, plus optional
     `deleteEventIds` / `createEvents`;
@@ -93,11 +95,11 @@ export const myRepair: Repair = {
 
 ### Needing related data in `decide`
 
-When a decision depends on other entities (a housing's events, its owner, a
-value from an external API), **do not fetch inside `decide`** — that would break
-its purity and make `plan` do per-housing I/O (N+1). Instead, fetch in bulk
-inside `query()` and attach the result to each item. The `H extends HousingApi`
-generic on `Repair` exists for exactly this:
+When a decision depends on other entities (a housing's events, its owner), **do
+not fetch inside `decide`** — that breaks its purity and makes `plan` do
+per-housing I/O (N+1). Because `query()` is a stream, enrich it _there_ so each
+emitted housing already carries what `decide` needs. Widen the item type (the
+`H extends HousingApi` generic) to hold the extra fields:
 
 ```ts
 interface HousingWithEvents extends HousingApi {
@@ -106,29 +108,9 @@ interface HousingWithEvents extends HousingApi {
 
 export const restoreStatus: Repair<HousingWithEvents> = {
   name: 'restore-status',
-
-  async query() {
-    const housings = await housingRepository.find({
-      filters: {
-        /* ... */
-      }
-    });
-
-    // ONE bulk fetch for all housings — never one call per housing
-    const events = await eventRepository.find({
-      filters: {
-        types: ['housing:status-updated'],
-        housings: housings.map(({ id, geoCode }) => ({ id, geoCode }))
-      }
-    });
-    const byHousing = groupBy(events, (event) => event.housingId);
-
-    return housings.map((housing) => ({
-      ...housing,
-      statusEvents: byHousing[housing.id] ?? []
-    }));
-  },
-
+  // A Knex stream whose query JOINs + aggregates the events onto each row
+  // (e.g. `json_agg(...) as "statusEvents"` + `groupBy`).
+  query: () => housingWithEventsQuery().stream(),
   // pure: reads housing.statusEvents, no I/O
   decide: (housing) => {
     const restorable = housing.statusEvents.find(/* ... */);
@@ -143,17 +125,18 @@ export const restoreStatus: Repair<HousingWithEvents> = {
 };
 ```
 
-This is the same **Enrich (bulk SELECT) → Transform (pure)** split as the
-`import-lovac` pipeline. The enriched fields (`statusEvents` here) are transient
-inputs to `decide` — they are never serialized into `plan.jsonl`, so the plan
-output stays clean.
+Two ways to enrich, both inside `query()`:
 
-- **External API:** same rule. Batch endpoint → call it once in `query()`.
-  Per-item only → still pre-fetch in `query()` with bounded concurrency (chunked
-  `Promise.all`) and build a `Map` keyed by the lookup field.
-- Make `decide` async only as a last resort — a per-item source with no batch
-  path _and_ a set too large to pre-fetch. It costs you the purity, the
-  N+1 guarantee, and the mock-free `plan` tests.
+- **JOIN in the query (preferred).** Aggregate the related rows in SQL so each
+  streamed housing carries them — no extra round trips.
+- **A Transform stage.** When the data can't be joined (an external API, an odd
+  key), return `source.pipe(enrich)` where `enrich` is an object-mode `Transform`
+  that buffers a **bounded** batch, bulk-fetches their related data, and pushes
+  enriched housings. That keeps the N+1 out _and_ memory flat.
+
+Either way the enriched fields are transient inputs to `decide` — never
+serialized into `plan.jsonl`, so the plan output stays clean. Don't fall back to
+a per-item fetch in `decide`.
 
 ## Registering a repair
 
@@ -227,11 +210,11 @@ export const restoreStatus: Repair = {
   name: 'restore-status',
   bypassTriggers: true, // large, status-changing repair
   query: () =>
-    housingRepository.find({
-      filters: {
+    Housing()
+      .where({
         /* ... */
-      }
-    }),
+      })
+      .stream(),
   decide: (housing) => ({ update: { status: HousingStatus.NEVER_CONTACTED } })
 };
 ```

--- a/server/src/scripts/repairs/README.md
+++ b/server/src/scripts/repairs/README.md
@@ -1,0 +1,245 @@
+# Repairs
+
+A CLI for **bulk, one-off repairs of housing data**: fixing a status that a
+migration got wrong, restoring events a bad batch deleted, resetting a
+sub-status, etc.
+
+The design separates **deciding what to do** from **doing it**, in three steps:
+
+```
+query + decide  →  plan.jsonl        (read-only, no DB writes)
+                →  review by hand     (diff, count, sanity-check)
+apply           →  single transaction (atomic, rolls back on any failure)
+```
+
+You always inspect the plan before touching the database, and every apply runs
+in one transaction — either the whole repair lands or nothing does.
+
+## Commands
+
+Run from the `server` workspace via the `zlv` entrypoint:
+
+```bash
+# List registered repairs
+yarn workspace @zerologementvacant/server zlv repair list
+
+# Generate plan.jsonl, skipped.jsonl, errors.jsonl (no DB writes)
+yarn workspace @zerologementvacant/server zlv repair plan <name> --out ./tmp
+
+# Summarise a plan file without touching the DB
+yarn workspace @zerologementvacant/server zlv repair stats ./tmp/plan.jsonl
+
+# Apply a plan file atomically
+yarn workspace @zerologementvacant/server zlv repair apply <name> ./tmp/plan.jsonl
+
+# ...forcing the count-trigger bypass on (or off) for this run
+yarn workspace @zerologementvacant/server zlv repair apply <name> ./tmp/plan.jsonl --bypass-triggers
+yarn workspace @zerologementvacant/server zlv repair apply <name> ./tmp/plan.jsonl --no-bypass-triggers
+```
+
+`apply` takes the repair `<name>` as well as the plan file: the name resolves
+the repair so its `bypassTriggers` default can be honoured (see
+[Large repairs](#large-repairs-bypassing-count-triggers)).
+
+`plan` writes three JSONL files to `--out` (defaults to the current directory):
+
+| File            | Contents                                                     |
+| --------------- | ------------------------------------------------------------ |
+| `plan.jsonl`    | Rows to apply — one housing per line, with its update/events |
+| `skipped.jsonl` | Housings the repair chose not to touch                       |
+| `errors.jsonl`  | Housings the repair could not decide, with a `reason`        |
+
+Only `plan.jsonl` is fed to `apply`. Keep all three: `skipped`/`errors` are the
+audit trail for what was left out.
+
+## Writing a repair
+
+A repair is a plain object implementing the `Repair` interface
+([`lib/types.ts`](lib/types.ts)):
+
+```ts
+import type { Repair } from '../lib/types';
+
+export const myRepair: Repair = {
+  name: 'my-repair',
+  // Pull the housings in scope from the DB.
+  query: () => housingRepository.find({ filters: { /* ... */ } }),
+  // Decide, per housing, what to do — pure, no side effects.
+  decide: (housing) => {
+    if (/* nothing to do */) {
+      return { action: 'skip' };
+    }
+    if (/* cannot decide safely */) {
+      return { action: 'error', reason: 'no restorable event' };
+    }
+    return {
+      update: { status: HousingStatus.NEVER_CONTACTED, subStatus: null },
+      deleteEventIds: [/* event ids */],
+      createEvents: [/* HousingEventApi[] */]
+    };
+  }
+};
+```
+
+- `query()` returns the candidate housings.
+- `decide(housing)` returns exactly one of:
+  - a `RepairAction` — an optional field `update`, plus optional
+    `deleteEventIds` / `createEvents`;
+  - `{ action: 'skip' }` — leave the housing untouched;
+  - `{ action: 'error', reason }` — flag it for manual follow-up.
+
+`decide` must stay **pure**: no DB writes, no I/O. All side effects happen in
+`apply`, which lets `plan` be a safe read-only dry run.
+
+### Needing related data in `decide`
+
+When a decision depends on other entities (a housing's events, its owner, a
+value from an external API), **do not fetch inside `decide`** — that would break
+its purity and make `plan` do per-housing I/O (N+1). Instead, fetch in bulk
+inside `query()` and attach the result to each item. The `H extends HousingApi`
+generic on `Repair` exists for exactly this:
+
+```ts
+interface HousingWithEvents extends HousingApi {
+  statusEvents: EventUnion<'housing:status-updated'>[];
+}
+
+export const restoreStatus: Repair<HousingWithEvents> = {
+  name: 'restore-status',
+
+  async query() {
+    const housings = await housingRepository.find({
+      filters: {
+        /* ... */
+      }
+    });
+
+    // ONE bulk fetch for all housings — never one call per housing
+    const events = await eventRepository.find({
+      filters: {
+        types: ['housing:status-updated'],
+        housings: housings.map(({ id, geoCode }) => ({ id, geoCode }))
+      }
+    });
+    const byHousing = groupBy(events, (event) => event.housingId);
+
+    return housings.map((housing) => ({
+      ...housing,
+      statusEvents: byHousing[housing.id] ?? []
+    }));
+  },
+
+  // pure: reads housing.statusEvents, no I/O
+  decide: (housing) => {
+    const restorable = housing.statusEvents.find(/* ... */);
+    if (!restorable) return { action: 'error', reason: 'no restorable event' };
+    return {
+      deleteEventIds: [restorable.id],
+      createEvents: [
+        /* ... */
+      ]
+    };
+  }
+};
+```
+
+This is the same **Enrich (bulk SELECT) → Transform (pure)** split as the
+`import-lovac` pipeline. The enriched fields (`statusEvents` here) are transient
+inputs to `decide` — they are never serialized into `plan.jsonl`, so the plan
+output stays clean.
+
+- **External API:** same rule. Batch endpoint → call it once in `query()`.
+  Per-item only → still pre-fetch in `query()` with bounded concurrency (chunked
+  `Promise.all`) and build a `Map` keyed by the lookup field.
+- Make `decide` async only as a last resort — a per-item source with no batch
+  path _and_ a set too large to pre-fetch. It costs you the purity, the
+  N+1 guarantee, and the mock-free `plan` tests.
+
+## Registering a repair
+
+Add one line to [`index.ts`](index.ts):
+
+```ts
+import { myRepair } from './my-repair';
+
+export const repairs: Record<string, Repair<any>> = {
+  'my-repair': myRepair
+};
+```
+
+Registration is deliberately manual — see
+[Why manual registration?](#why-manual-registration).
+
+## How `apply` stays safe
+
+- **Atomic.** The whole plan runs inside one `startTransaction`; any error rolls
+  everything back.
+- **Chunked.** Updates, deletes and inserts are batched in groups of 1000 so a
+  large plan doesn't blow up a single query.
+- **Grouped updates.** Rows sharing the same `update` payload are updated
+  together, so N housings with the same fix cost one `UPDATE` per chunk instead
+  of N.
+- **Reported counts are requested counts.** `eventsCreated` / `eventsDeleted`
+  report what the plan asked for. Inserts use `ON CONFLICT … IGNORE`, so if an
+  event id already exists the row is skipped without changing the count.
+
+## Large repairs (bypassing count triggers)
+
+`fast_housing` carries `FOR EACH ROW` triggers that recompute derived counts
+whenever `status` or `occupancy` changes (`campaigns.return_count`, buildings'
+rent/vacant counts); `housing_events` has one too. For a big repair — the
+canonical one _is_ a status change — those per-row fires dominate the runtime.
+
+Partition pruning is **not** the concern: PostgreSQL prunes the
+`WHERE (geo_code, id) IN (…)` that `apply` emits down to just the departments
+touched. The triggers are.
+
+Set `bypassTriggers` to disable those triggers, apply the plan, recompute the
+counts **once**, then re-enable them — **all inside the transaction** (reusing
+`import-lovac`'s `housings-counts-maintenance`). It's opt-in because
+`ALTER TABLE … DISABLE TRIGGER` takes ACCESS EXCLUSIVE on `fast_housing`
+(concurrent writers block until the repair finishes) and it forces a full counts
+recompute — worth it for tens of thousands of rows, wasteful for a few hundred.
+
+Doing the disable **inside** the transaction is deliberate: it's what makes an
+interrupt safe. Because `ALTER TABLE … DISABLE TRIGGER` is transactional, an
+early exit — Ctrl-C, SIGTERM, SIGKILL, a crash, a dropped connection — rolls the
+whole transaction back and the triggers are **never left disabled**. No signal
+handler is involved (SIGKILL can't be caught anyway); the database guarantees
+it. A committed-then-disabled approach would strand the triggers off on any of
+those exits, silently breaking count maintenance for every later write.
+
+**Resolution precedence** (highest wins):
+
+1. CLI flag — `--bypass-triggers` / `--no-bypass-triggers`
+2. `repair.bypassTriggers` — the author's declared default
+3. `false` — flat default
+
+The default is a **flat `false`, not row-count-based**: the cost tracks trigger
+fires on the watched columns, not row count (a 50 000-row `subStatus`-only
+repair fires none of them; a 2 000-row `occupancy` repair does), so a
+`query().length` threshold would both over- and under-trigger. The repair author
+knows the scale and which columns change, so they declare it; the operator can
+override per run.
+
+```ts
+export const restoreStatus: Repair = {
+  name: 'restore-status',
+  bypassTriggers: true, // large, status-changing repair
+  query: () =>
+    housingRepository.find({
+      filters: {
+        /* ... */
+      }
+    }),
+  decide: (housing) => ({ update: { status: HousingStatus.NEVER_CONTACTED } })
+};
+```
+
+## Why manual registration?
+
+Repairs are rare, deliberate, destructive operations. The registry in
+`index.ts` is the audit surface (`repair list` reads it) and keeps the whole set
+type-checked and greppable. Auto-discovery by globbing would trade that away for
+convenience we don't need — adding a repair is not a hot path, and requiring an
+explicit line is a feature, not a chore.

--- a/server/src/scripts/repairs/cli.ts
+++ b/server/src/scripts/repairs/cli.ts
@@ -1,0 +1,76 @@
+import { Command } from '@commander-js/extra-typings';
+
+import { repairs } from './index';
+import { apply } from './lib/apply';
+import { plan } from './lib/plan';
+import { stats } from './lib/stats';
+
+export function repairCommand(): Command {
+  const cmd = new Command('repair').description(
+    'Bulk housing data repair commands'
+  );
+
+  cmd
+    .command('list')
+    .description('List all registered repairs')
+    .action(() => {
+      const names = Object.keys(repairs);
+      if (names.length === 0) {
+        console.log('No repairs registered.');
+        return;
+      }
+      names.forEach((name) => console.log(name));
+    });
+
+  cmd
+    .command('plan')
+    .description(
+      'Generate plan.jsonl, skipped.jsonl, errors.jsonl for a repair'
+    )
+    .argument('<name>', 'repair name (see: zlv repair list)')
+    .option('--out <dir>', 'output directory', process.cwd())
+    .action(async (name, options) => {
+      const repair = repairs[name];
+      if (!repair) {
+        console.error(
+          `Unknown repair: "${name}". Run "zlv repair list" to see available repairs.`
+        );
+        process.exit(1);
+      }
+      const summary = await plan(repair, { outDir: options.out });
+      console.log(`Total:    ${summary.total}`);
+      console.log(`Planned:  ${summary.planned}`);
+      console.log(`Skipped:  ${summary.skipped}`);
+      console.log(`Errors:   ${summary.errors}`);
+      console.log(`Events to delete: ${summary.eventsToDelete}`);
+      console.log(`Events to create: ${summary.eventsToCreate}`);
+      console.log(`\nFiles written to: ${options.out}`);
+      console.log('  plan.jsonl, skipped.jsonl, errors.jsonl');
+    });
+
+  cmd
+    .command('stats')
+    .description('Summarise a plan file without touching the DB')
+    .argument('<plan-file>', 'path to plan.jsonl')
+    .action(async (planFile) => {
+      const summary = await stats(planFile);
+      console.log(`Planned:  ${summary.planned}`);
+      console.log(`Events to delete: ${summary.eventsToDelete}`);
+      console.log(`Events to create: ${summary.eventsToCreate}`);
+    });
+
+  cmd
+    .command('apply')
+    .description(
+      'Apply a plan file atomically (single transaction, full rollback on failure)'
+    )
+    .argument('<plan-file>', 'path to plan.jsonl')
+    .action(async (planFile) => {
+      const summary = await apply(planFile);
+      console.log(`Updated:         ${summary.updated}`);
+      console.log(`Events deleted:  ${summary.eventsDeleted}`);
+      console.log(`Events created:  ${summary.eventsCreated}`);
+    });
+
+  return cmd;
+}

--- a/server/src/scripts/repairs/cli.ts
+++ b/server/src/scripts/repairs/cli.ts
@@ -1,9 +1,13 @@
 import { Command } from '@commander-js/extra-typings';
 
+import { createLogger } from '~/infra/logger';
+
 import { repairs } from './index';
 import { apply } from './lib/apply';
 import { plan } from './lib/plan';
 import { stats } from './lib/stats';
+
+const logger = createLogger('repair');
 
 export function repairCommand(): Command {
   const cmd = new Command('repair').description(
@@ -16,10 +20,10 @@ export function repairCommand(): Command {
     .action(() => {
       const names = Object.keys(repairs);
       if (names.length === 0) {
-        console.log('No repairs registered.');
+        logger.info('No repairs registered.');
         return;
       }
-      names.forEach((name) => console.log(name));
+      names.forEach((name) => logger.info(name));
     });
 
   cmd
@@ -32,20 +36,16 @@ export function repairCommand(): Command {
     .action(async (name, options) => {
       const repair = repairs[name];
       if (!repair) {
-        console.error(
+        logger.error(
           `Unknown repair: "${name}". Run "zlv repair list" to see available repairs.`
         );
         process.exit(1);
       }
       const summary = await plan(repair, { outDir: options.out });
-      console.log(`Total:    ${summary.total}`);
-      console.log(`Planned:  ${summary.planned}`);
-      console.log(`Skipped:  ${summary.skipped}`);
-      console.log(`Errors:   ${summary.errors}`);
-      console.log(`Events to delete: ${summary.eventsToDelete}`);
-      console.log(`Events to create: ${summary.eventsToCreate}`);
-      console.log(`\nFiles written to: ${options.out}`);
-      console.log('  plan.jsonl, skipped.jsonl, errors.jsonl');
+      logger.info('Plan generated (plan.jsonl, skipped.jsonl, errors.jsonl)', {
+        ...summary,
+        outDir: options.out
+      });
     });
 
   cmd
@@ -54,9 +54,7 @@ export function repairCommand(): Command {
     .argument('<plan-file>', 'path to plan.jsonl')
     .action(async (planFile) => {
       const summary = await stats(planFile);
-      console.log(`Planned:  ${summary.planned}`);
-      console.log(`Events to delete: ${summary.eventsToDelete}`);
-      console.log(`Events to create: ${summary.eventsToCreate}`);
+      logger.info('Plan stats', summary);
     });
 
   cmd
@@ -77,7 +75,7 @@ export function repairCommand(): Command {
     .action(async (name, planFile, options) => {
       const repair = repairs[name];
       if (!repair) {
-        console.error(
+        logger.error(
           `Unknown repair: "${name}". Run "zlv repair list" to see available repairs.`
         );
         process.exit(1);
@@ -85,11 +83,8 @@ export function repairCommand(): Command {
       // Precedence: CLI flag > repair.bypassTriggers > false.
       const bypassTriggers =
         options.bypassTriggers ?? repair.bypassTriggers ?? false;
-      console.log(`Bypass triggers: ${bypassTriggers}`);
       const summary = await apply(planFile, { bypassTriggers });
-      console.log(`Updated:         ${summary.updated}`);
-      console.log(`Events deleted:  ${summary.eventsDeleted}`);
-      console.log(`Events created:  ${summary.eventsCreated}`);
+      logger.info('Plan applied', { ...summary, bypassTriggers });
     });
 
   return cmd;

--- a/server/src/scripts/repairs/cli.ts
+++ b/server/src/scripts/repairs/cli.ts
@@ -64,9 +64,29 @@ export function repairCommand(): Command {
     .description(
       'Apply a plan file atomically (single transaction, full rollback on failure)'
     )
+    .argument('<name>', 'repair name (see: zlv repair list)')
     .argument('<plan-file>', 'path to plan.jsonl')
-    .action(async (planFile) => {
-      const summary = await apply(planFile);
+    .option(
+      '--bypass-triggers',
+      'disable fast_housing count triggers and recompute once (for large repairs)'
+    )
+    .option(
+      '--no-bypass-triggers',
+      "keep count triggers enabled, overriding the repair's default"
+    )
+    .action(async (name, planFile, options) => {
+      const repair = repairs[name];
+      if (!repair) {
+        console.error(
+          `Unknown repair: "${name}". Run "zlv repair list" to see available repairs.`
+        );
+        process.exit(1);
+      }
+      // Precedence: CLI flag > repair.bypassTriggers > false.
+      const bypassTriggers =
+        options.bypassTriggers ?? repair.bypassTriggers ?? false;
+      console.log(`Bypass triggers: ${bypassTriggers}`);
+      const summary = await apply(planFile, { bypassTriggers });
       console.log(`Updated:         ${summary.updated}`);
       console.log(`Events deleted:  ${summary.eventsDeleted}`);
       console.log(`Events created:  ${summary.eventsCreated}`);

--- a/server/src/scripts/repairs/index.ts
+++ b/server/src/scripts/repairs/index.ts
@@ -1,0 +1,8 @@
+import type { Repair } from './lib/types';
+
+// Register new repairs here — one line per repair:
+// import { myRepair } from './my-repair';
+
+export const repairs: Record<string, Repair<any>> = {
+  // 'my-repair': myRepair,
+};

--- a/server/src/scripts/repairs/lib/apply.ts
+++ b/server/src/scripts/repairs/lib/apply.ts
@@ -30,7 +30,7 @@ export async function apply(planFile: string): Promise<ApplySummary> {
 
   await startTransaction(async () => {
     for (const group of groups) {
-      if (!group.payload) continue;
+      if (!group.payload || Object.keys(group.payload).length === 0) continue;
       for (const chunk of chunksOf(group.rows, 1000)) {
         await housingRepository.updateMany(
           chunk.map((r) => ({ id: r.housingId, geoCode: r.housingGeoCode })),
@@ -41,16 +41,18 @@ export async function apply(planFile: string): Promise<ApplySummary> {
     }
 
     if (allDeleteIds.length > 0) {
-      await withinTransaction(async (transaction) => {
-        await HousingEvents(transaction)
-          .whereIn('event_id', allDeleteIds)
-          .delete();
-        await Events(transaction).whereIn('id', allDeleteIds).delete();
-      });
+      for (const chunk of chunksOf(allDeleteIds, 1000)) {
+        await withinTransaction(async (transaction) => {
+          await HousingEvents(transaction).whereIn('event_id', chunk).delete();
+          await Events(transaction).whereIn('id', chunk).delete();
+        });
+      }
     }
 
     if (allCreateEvents.length > 0) {
-      await eventRepository.insertManyHousingEvents(allCreateEvents);
+      for (const chunk of chunksOf(allCreateEvents, 1000)) {
+        await eventRepository.insertManyHousingEvents(chunk);
+      }
     }
   });
 

--- a/server/src/scripts/repairs/lib/apply.ts
+++ b/server/src/scripts/repairs/lib/apply.ts
@@ -1,21 +1,42 @@
 import fs from 'node:fs';
 import readline from 'node:readline';
 
+import { compactUndefined } from '@zerologementvacant/utils';
 import { chunksOf } from 'effect/Array';
 
+import db from '~/infra/database';
 import {
-  startTransaction,
-  withinTransaction
-} from '~/infra/database/transaction';
-import eventRepository, {
   Events,
+  formatEventApi,
+  formatHousingEventApi,
   HousingEvents
 } from '~/repositories/eventRepository';
-import housingRepository from '~/repositories/housingRepository';
+import { Housing } from '~/repositories/housingRepository';
+import {
+  disableHousingsTriggers,
+  enableHousingsTriggers,
+  ensureKnownHousingsTriggers,
+  recomputeHousingsCounts
+} from '~/scripts/import-lovac/infra/housings-counts-maintenance';
 
 import type { ApplySummary, PlanRow } from './types';
 
-export async function apply(planFile: string): Promise<ApplySummary> {
+export interface ApplyOptions {
+  /**
+   * Bypass the `fast_housing` / `housing_events` count triggers: disable them,
+   * apply the plan, recompute the counts once, then re-enable them — all inside
+   * the transaction. Skips the per-row trigger fires that dominate large
+   * repairs, at the cost of holding an exclusive lock on `fast_housing` and a
+   * full counts recompute. Defaults to `false`.
+   */
+  bypassTriggers?: boolean;
+}
+
+export async function apply(
+  planFile: string,
+  options: ApplyOptions = {}
+): Promise<ApplySummary> {
+  const bypassTriggers = options.bypassTriggers ?? false;
   const rows = await readPlan(planFile);
 
   if (rows.length === 0) {
@@ -23,36 +44,78 @@ export async function apply(planFile: string): Promise<ApplySummary> {
   }
 
   const groups = groupByPayload(rows);
-  const allDeleteIds = rows.flatMap((r) => r.deleteEventIds ?? []);
-  const allCreateEvents = rows.flatMap((r) => r.createEvents ?? []);
+  const allDeleteIds = rows.flatMap((row) => row.deleteEventIds ?? []);
+  const allCreateEvents = rows.flatMap((row) => row.createEvents ?? []);
+
+  // Fail fast (before taking any lock) if a trigger we can't compensate for
+  // appeared on the managed tables.
+  if (bypassTriggers) {
+    await ensureKnownHousingsTriggers();
+  }
 
   let updated = 0;
+  // A repair is a reviewed, point-in-time operation. The writes below use the
+  // table accessors and pure formatters directly — never the repository
+  // *methods* — so a future change to a repository method (a new filter, a side
+  // effect, a different onConflict) cannot silently alter what an applied plan
+  // does. For the same reason the script owns its transaction with
+  // `db.transaction` rather than the app's AsyncLocalStorage helpers.
+  await db.transaction(async (transaction) => {
+    // Disabling the triggers *inside* the transaction is what makes an early
+    // exit safe. `ALTER TABLE ... DISABLE TRIGGER` is transactional, so if the
+    // process is interrupted (Ctrl-C / SIGINT, SIGTERM, even SIGKILL, a crash
+    // or the DB connection dropping) the whole transaction — including the
+    // disable — rolls back and the triggers are never left off. It also holds
+    // ACCESS EXCLUSIVE on fast_housing, so concurrent writers block rather than
+    // silently skipping the triggers. Both are impossible if the disable is a
+    // separate, already-committed statement.
+    if (bypassTriggers) {
+      await disableHousingsTriggers(transaction);
+    }
 
-  await startTransaction(async () => {
     for (const group of groups) {
-      if (!group.payload || Object.keys(group.payload).length === 0) continue;
+      if (!group.payload) continue;
+      const fields = toHousingColumns(group.payload);
+      if (Object.keys(fields).length === 0) continue;
+
       for (const chunk of chunksOf(group.rows, 1000)) {
-        await housingRepository.updateMany(
-          chunk.map((r) => ({ id: r.housingId, geoCode: r.housingGeoCode })),
-          group.payload
-        );
+        // Tuple WHERE on the (geo_code, id) primary key — PostgreSQL prunes it
+        // to the touched partitions.
+        await Housing(transaction)
+          .whereIn(
+            ['geo_code', 'id'],
+            chunk.map((row) => [row.housingGeoCode, row.housingId])
+          )
+          .update(fields);
         updated += chunk.length;
       }
     }
 
     if (allDeleteIds.length > 0) {
       for (const chunk of chunksOf(allDeleteIds, 1000)) {
-        await withinTransaction(async (transaction) => {
-          await HousingEvents(transaction).whereIn('event_id', chunk).delete();
-          await Events(transaction).whereIn('id', chunk).delete();
-        });
+        await HousingEvents(transaction).whereIn('event_id', chunk).delete();
+        await Events(transaction).whereIn('id', chunk).delete();
       }
     }
 
     if (allCreateEvents.length > 0) {
       for (const chunk of chunksOf(allCreateEvents, 1000)) {
-        await eventRepository.insertManyHousingEvents(chunk);
+        await Events(transaction)
+          .insert(chunk.map(formatEventApi))
+          .onConflict('id')
+          .ignore();
+        await HousingEvents(transaction)
+          .insert(chunk.map(formatHousingEventApi))
+          .onConflict('event_id')
+          .ignore();
       }
+    }
+
+    // Recompute the derived counts once, then re-enable before commit so the
+    // committed catalog state has the triggers back on.
+    if (bypassTriggers) {
+      await recomputeHousingsCounts(transaction);
+      await enableHousingsTriggers(transaction);
     }
   });
 
@@ -61,6 +124,21 @@ export async function apply(planFile: string): Promise<ApplySummary> {
     eventsDeleted: allDeleteIds.length,
     eventsCreated: allCreateEvents.length
   };
+}
+
+/**
+ * Map the plan's API-shaped update to explicit `fast_housing` columns, dropping
+ * undefined so only the fields the plan set are written. Owned here rather than
+ * delegated to `housingRepository.updateMany` so a repository change cannot
+ * silently alter what a reviewed repair writes.
+ */
+function toHousingColumns(update: NonNullable<PlanRow['update']>) {
+  return compactUndefined({
+    status: update.status,
+    sub_status: update.subStatus,
+    occupancy: update.occupancy,
+    occupancy_intended: update.occupancyIntended
+  });
 }
 
 async function readPlan(planFile: string): Promise<PlanRow[]> {

--- a/server/src/scripts/repairs/lib/apply.ts
+++ b/server/src/scripts/repairs/lib/apply.ts
@@ -1,0 +1,91 @@
+import fs from 'node:fs';
+import readline from 'node:readline';
+
+import { chunksOf } from 'effect/Array';
+
+import {
+  startTransaction,
+  withinTransaction
+} from '~/infra/database/transaction';
+import eventRepository, {
+  Events,
+  HousingEvents
+} from '~/repositories/eventRepository';
+import housingRepository from '~/repositories/housingRepository';
+
+import type { ApplySummary, PlanRow } from './types';
+
+export async function apply(planFile: string): Promise<ApplySummary> {
+  const rows = await readPlan(planFile);
+
+  if (rows.length === 0) {
+    return { updated: 0, eventsDeleted: 0, eventsCreated: 0 };
+  }
+
+  const groups = groupByPayload(rows);
+  const allDeleteIds = rows.flatMap((r) => r.deleteEventIds ?? []);
+  const allCreateEvents = rows.flatMap((r) => r.createEvents ?? []);
+
+  let updated = 0;
+
+  await startTransaction(async () => {
+    for (const group of groups) {
+      if (!group.payload) continue;
+      for (const chunk of chunksOf(group.rows, 1000)) {
+        await housingRepository.updateMany(
+          chunk.map((r) => ({ id: r.housingId, geoCode: r.housingGeoCode })),
+          group.payload
+        );
+        updated += chunk.length;
+      }
+    }
+
+    if (allDeleteIds.length > 0) {
+      await withinTransaction(async (transaction) => {
+        await HousingEvents(transaction)
+          .whereIn('event_id', allDeleteIds)
+          .delete();
+        await Events(transaction).whereIn('id', allDeleteIds).delete();
+      });
+    }
+
+    if (allCreateEvents.length > 0) {
+      await eventRepository.insertManyHousingEvents(allCreateEvents);
+    }
+  });
+
+  return {
+    updated,
+    eventsDeleted: allDeleteIds.length,
+    eventsCreated: allCreateEvents.length
+  };
+}
+
+async function readPlan(planFile: string): Promise<PlanRow[]> {
+  const rows: PlanRow[] = [];
+  const rl = readline.createInterface({
+    input: fs.createReadStream(planFile),
+    crlfDelay: Infinity
+  });
+  for await (const line of rl) {
+    if (line.trim()) rows.push(JSON.parse(line) as PlanRow);
+  }
+  return rows;
+}
+
+interface PayloadGroup {
+  payload: PlanRow['update'];
+  rows: PlanRow[];
+}
+
+function groupByPayload(rows: PlanRow[]): PayloadGroup[] {
+  const map = new Map<string, PayloadGroup>();
+  for (const row of rows) {
+    const key = JSON.stringify(row.update ?? null);
+    if (!map.has(key)) {
+      map.set(key, { payload: row.update, rows: [] });
+    }
+    map.get(key)!.rows.push(row);
+  }
+  return Array.from(map.values());
+}

--- a/server/src/scripts/repairs/lib/apply.ts
+++ b/server/src/scripts/repairs/lib/apply.ts
@@ -1,10 +1,10 @@
-import fs from 'node:fs';
-import readline from 'node:readline';
+import { stat } from 'node:fs/promises';
+import { Writable } from 'node:stream';
 
 import { compactUndefined } from '@zerologementvacant/utils';
-import { chunksOf } from 'effect/Array';
 
 import db from '~/infra/database';
+import type { HousingEventApi } from '~/models/EventApi';
 import {
   Events,
   formatEventApi,
@@ -19,7 +19,10 @@ import {
   recomputeHousingsCounts
 } from '~/scripts/import-lovac/infra/housings-counts-maintenance';
 
+import { readPlan } from './read-plan';
 import type { ApplySummary, PlanRow } from './types';
+
+const CHUNK_SIZE = 1000;
 
 export interface ApplyOptions {
   /**
@@ -37,15 +40,12 @@ export async function apply(
   options: ApplyOptions = {}
 ): Promise<ApplySummary> {
   const bypassTriggers = options.bypassTriggers ?? false;
-  const rows = await readPlan(planFile);
 
-  if (rows.length === 0) {
+  // Empty plan: short-circuit before opening a transaction or recomputing.
+  const { size } = await stat(planFile);
+  if (size === 0) {
     return { updated: 0, eventsDeleted: 0, eventsCreated: 0 };
   }
-
-  const groups = groupByPayload(rows);
-  const allDeleteIds = rows.flatMap((row) => row.deleteEventIds ?? []);
-  const allCreateEvents = rows.flatMap((row) => row.createEvents ?? []);
 
   // Fail fast (before taking any lock) if a trigger we can't compensate for
   // appeared on the managed tables.
@@ -53,7 +53,12 @@ export async function apply(
     await ensureKnownHousingsTriggers();
   }
 
-  let updated = 0;
+  const summary: ApplySummary = {
+    updated: 0,
+    eventsDeleted: 0,
+    eventsCreated: 0
+  };
+
   // A repair is a reviewed, point-in-time operation. The writes below use the
   // table accessors and pure formatters directly — never the repository
   // *methods* — so a future change to a repository method (a new filter, a side
@@ -65,51 +70,118 @@ export async function apply(
     // exit safe. `ALTER TABLE ... DISABLE TRIGGER` is transactional, so if the
     // process is interrupted (Ctrl-C / SIGINT, SIGTERM, even SIGKILL, a crash
     // or the DB connection dropping) the whole transaction — including the
-    // disable — rolls back and the triggers are never left off. It also holds
-    // ACCESS EXCLUSIVE on fast_housing, so concurrent writers block rather than
-    // silently skipping the triggers. Both are impossible if the disable is a
-    // separate, already-committed statement.
+    // disable — rolls back and the triggers are never left off.
     if (bypassTriggers) {
       await disableHousingsTriggers(transaction);
     }
 
-    for (const group of groups) {
-      if (!group.payload) continue;
-      const fields = toHousingColumns(group.payload);
-      if (Object.keys(fields).length === 0) continue;
+    // Rows sharing an update payload arrive contiguously (plan.jsonl is ordered
+    // by payload), so we buffer a run and flush one UPDATE per CHUNK_SIZE rows.
+    // Correctness does not depend on the ordering; a misordered plan just
+    // flushes more often. Deletes and inserts buffer independently. The
+    // Writable's callback gates the parser, so memory stays bounded.
+    let currentPayload: NonNullable<PlanRow['update']> | null = null;
+    let currentKey: string | null = null;
+    const updateBuffer: PlanRow[] = [];
+    const deleteBuffer: string[] = [];
+    const createBuffer: HousingEventApi[] = [];
 
-      for (const chunk of chunksOf(group.rows, 1000)) {
+    const flushUpdates = async () => {
+      if (!currentPayload) {
+        return;
+      }
+      const fields = toHousingColumns(currentPayload);
+      if (Object.keys(fields).length === 0) {
+        updateBuffer.length = 0;
+        return;
+      }
+      while (updateBuffer.length > 0) {
+        const chunk = updateBuffer.splice(0, CHUNK_SIZE);
         // Tuple WHERE on the (geo_code, id) primary key — PostgreSQL prunes it
-        // to the touched partitions.
-        await Housing(transaction)
+        // to the touched partitions. `.update()` returns the rows it actually
+        // matched, which may be fewer than planned (a housing deleted between
+        // plan and apply), so count that.
+        summary.updated += await Housing(transaction)
           .whereIn(
             ['geo_code', 'id'],
             chunk.map((row) => [row.housingGeoCode, row.housingId])
           )
           .update(fields);
-        updated += chunk.length;
       }
-    }
+    };
 
-    if (allDeleteIds.length > 0) {
-      for (const chunk of chunksOf(allDeleteIds, 1000)) {
+    const flushDeletes = async () => {
+      while (deleteBuffer.length > 0) {
+        const chunk = deleteBuffer.splice(0, CHUNK_SIZE);
         await HousingEvents(transaction).whereIn('event_id', chunk).delete();
-        await Events(transaction).whereIn('id', chunk).delete();
+        // Count rows the DB actually removed, not the ids requested.
+        summary.eventsDeleted += await Events(transaction)
+          .whereIn('id', chunk)
+          .delete();
       }
-    }
+    };
 
-    if (allCreateEvents.length > 0) {
-      for (const chunk of chunksOf(allCreateEvents, 1000)) {
-        await Events(transaction)
+    const flushCreates = async () => {
+      while (createBuffer.length > 0) {
+        const chunk = createBuffer.splice(0, CHUNK_SIZE);
+        // onConflict(...).ignore() skips events that already exist, so RETURNING
+        // yields only the rows actually inserted — count those, so a re-applied
+        // plan reports 0 instead of overstating.
+        const inserted = await Events(transaction)
           .insert(chunk.map(formatEventApi))
           .onConflict('id')
-          .ignore();
+          .ignore()
+          .returning('id');
         await HousingEvents(transaction)
           .insert(chunk.map(formatHousingEventApi))
           .onConflict('event_id')
           .ignore();
+        summary.eventsCreated += inserted.length;
       }
-    }
+    };
+
+    const processRow = async (row: PlanRow) => {
+      if (row.update && Object.keys(row.update).length > 0) {
+        const key = JSON.stringify(row.update);
+        if (key !== currentKey) {
+          await flushUpdates();
+          currentKey = key;
+          currentPayload = row.update;
+        }
+        updateBuffer.push(row);
+        if (updateBuffer.length >= CHUNK_SIZE) {
+          await flushUpdates();
+        }
+      }
+
+      if (row.deleteEventIds?.length) {
+        deleteBuffer.push(...row.deleteEventIds);
+        if (deleteBuffer.length >= CHUNK_SIZE) {
+          await flushDeletes();
+        }
+      }
+
+      if (row.createEvents?.length) {
+        createBuffer.push(...row.createEvents);
+        if (createBuffer.length >= CHUNK_SIZE) {
+          await flushCreates();
+        }
+      }
+    };
+
+    await readPlan(
+      planFile,
+      new Writable({
+        objectMode: true,
+        write(row: PlanRow, _encoding, callback) {
+          processRow(row).then(() => callback(), callback);
+        }
+      })
+    );
+
+    await flushUpdates();
+    await flushDeletes();
+    await flushCreates();
 
     // Recompute the derived counts once, then re-enable before commit so the
     // committed catalog state has the triggers back on.
@@ -119,11 +191,7 @@ export async function apply(
     }
   });
 
-  return {
-    updated,
-    eventsDeleted: allDeleteIds.length,
-    eventsCreated: allCreateEvents.length
-  };
+  return summary;
 }
 
 /**
@@ -139,33 +207,4 @@ function toHousingColumns(update: NonNullable<PlanRow['update']>) {
     occupancy: update.occupancy,
     occupancy_intended: update.occupancyIntended
   });
-}
-
-async function readPlan(planFile: string): Promise<PlanRow[]> {
-  const rows: PlanRow[] = [];
-  const rl = readline.createInterface({
-    input: fs.createReadStream(planFile),
-    crlfDelay: Infinity
-  });
-  for await (const line of rl) {
-    if (line.trim()) rows.push(JSON.parse(line) as PlanRow);
-  }
-  return rows;
-}
-
-interface PayloadGroup {
-  payload: PlanRow['update'];
-  rows: PlanRow[];
-}
-
-function groupByPayload(rows: PlanRow[]): PayloadGroup[] {
-  const map = new Map<string, PayloadGroup>();
-  for (const row of rows) {
-    const key = JSON.stringify(row.update ?? null);
-    if (!map.has(key)) {
-      map.set(key, { payload: row.update, rows: [] });
-    }
-    map.get(key)!.rows.push(row);
-  }
-  return Array.from(map.values());
 }

--- a/server/src/scripts/repairs/lib/plan.ts
+++ b/server/src/scripts/repairs/lib/plan.ts
@@ -1,0 +1,101 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import type { HousingApi } from '~/models/HousingApi';
+
+import type {
+  ErrorRow,
+  PlanRow,
+  PlanSummary,
+  Repair,
+  RepairAction,
+  RepairError,
+  RepairSkip,
+  SkippedRow
+} from './types';
+
+export interface PlanOptions {
+  outDir?: string;
+}
+
+export async function plan<H extends HousingApi>(
+  repair: Repair<H>,
+  options: PlanOptions = {}
+): Promise<PlanSummary> {
+  const outDir = options.outDir ?? process.cwd();
+
+  const planStream = fs.createWriteStream(path.join(outDir, 'plan.jsonl'));
+  const skippedStream = fs.createWriteStream(
+    path.join(outDir, 'skipped.jsonl')
+  );
+  const errorsStream = fs.createWriteStream(path.join(outDir, 'errors.jsonl'));
+
+  const housings = await repair.query();
+  let planned = 0,
+    skipped = 0,
+    errors = 0,
+    eventsToDelete = 0,
+    eventsToCreate = 0;
+
+  for (const housing of housings) {
+    const decision = repair.decide(housing);
+
+    if (isSkip(decision)) {
+      const row: SkippedRow = {
+        housingId: housing.id,
+        housingGeoCode: housing.geoCode
+      };
+      skippedStream.write(JSON.stringify(row) + '\n');
+      skipped++;
+    } else if (isError(decision)) {
+      const row: ErrorRow = {
+        housingId: housing.id,
+        housingGeoCode: housing.geoCode,
+        reason: decision.reason
+      };
+      errorsStream.write(JSON.stringify(row) + '\n');
+      errors++;
+    } else {
+      const row: PlanRow = {
+        housingId: housing.id,
+        housingGeoCode: housing.geoCode,
+        ...decision
+      };
+      planStream.write(JSON.stringify(row) + '\n');
+      planned++;
+      eventsToDelete += decision.deleteEventIds?.length ?? 0;
+      eventsToCreate += decision.createEvents?.length ?? 0;
+    }
+  }
+
+  await Promise.all([
+    streamEnd(planStream),
+    streamEnd(skippedStream),
+    streamEnd(errorsStream)
+  ]);
+
+  return {
+    total: housings.length,
+    planned,
+    skipped,
+    errors,
+    eventsToDelete,
+    eventsToCreate
+  };
+}
+
+function isSkip(d: RepairAction | RepairSkip | RepairError): d is RepairSkip {
+  return 'action' in d && d.action === 'skip';
+}
+
+function isError(d: RepairAction | RepairSkip | RepairError): d is RepairError {
+  return 'action' in d && d.action === 'error';
+}
+
+function streamEnd(stream: fs.WriteStream): Promise<void> {
+  return new Promise((resolve, reject) =>
+    stream.end((err: Error | null | undefined) =>
+      err ? reject(err) : resolve()
+    )
+  );
+}

--- a/server/src/scripts/repairs/lib/plan.ts
+++ b/server/src/scripts/repairs/lib/plan.ts
@@ -37,42 +37,44 @@ export async function plan<H extends HousingApi>(
     eventsToDelete = 0,
     eventsToCreate = 0;
 
-  for (const housing of housings) {
-    const decision = repair.decide(housing);
+  try {
+    for (const housing of housings) {
+      const decision = repair.decide(housing);
 
-    if (isSkip(decision)) {
-      const row: SkippedRow = {
-        housingId: housing.id,
-        housingGeoCode: housing.geoCode
-      };
-      skippedStream.write(JSON.stringify(row) + '\n');
-      skipped++;
-    } else if (isError(decision)) {
-      const row: ErrorRow = {
-        housingId: housing.id,
-        housingGeoCode: housing.geoCode,
-        reason: decision.reason
-      };
-      errorsStream.write(JSON.stringify(row) + '\n');
-      errors++;
-    } else {
-      const row: PlanRow = {
-        housingId: housing.id,
-        housingGeoCode: housing.geoCode,
-        ...decision
-      };
-      planStream.write(JSON.stringify(row) + '\n');
-      planned++;
-      eventsToDelete += decision.deleteEventIds?.length ?? 0;
-      eventsToCreate += decision.createEvents?.length ?? 0;
+      if (isSkip(decision)) {
+        const row: SkippedRow = {
+          housingId: housing.id,
+          housingGeoCode: housing.geoCode
+        };
+        skippedStream.write(JSON.stringify(row) + '\n');
+        skipped++;
+      } else if (isError(decision)) {
+        const row: ErrorRow = {
+          housingId: housing.id,
+          housingGeoCode: housing.geoCode,
+          reason: decision.reason
+        };
+        errorsStream.write(JSON.stringify(row) + '\n');
+        errors++;
+      } else {
+        const row: PlanRow = {
+          housingId: housing.id,
+          housingGeoCode: housing.geoCode,
+          ...decision
+        };
+        planStream.write(JSON.stringify(row) + '\n');
+        planned++;
+        eventsToDelete += decision.deleteEventIds?.length ?? 0;
+        eventsToCreate += decision.createEvents?.length ?? 0;
+      }
     }
+  } finally {
+    await Promise.all([
+      streamEnd(planStream),
+      streamEnd(skippedStream),
+      streamEnd(errorsStream)
+    ]);
   }
-
-  await Promise.all([
-    streamEnd(planStream),
-    streamEnd(skippedStream),
-    streamEnd(errorsStream)
-  ]);
 
   return {
     total: housings.length,

--- a/server/src/scripts/repairs/lib/plan.ts
+++ b/server/src/scripts/repairs/lib/plan.ts
@@ -31,11 +31,11 @@ export async function plan<H extends HousingApi>(
   const errorsStream = fs.createWriteStream(path.join(outDir, 'errors.jsonl'));
 
   const housings = await repair.query();
-  let planned = 0,
-    skipped = 0,
-    errors = 0,
-    eventsToDelete = 0,
-    eventsToCreate = 0;
+  let planned = 0;
+  let skipped = 0;
+  let errors = 0;
+  let eventsToDelete = 0;
+  let eventsToCreate = 0;
 
   try {
     for (const housing of housings) {
@@ -86,12 +86,16 @@ export async function plan<H extends HousingApi>(
   };
 }
 
-function isSkip(d: RepairAction | RepairSkip | RepairError): d is RepairSkip {
-  return 'action' in d && d.action === 'skip';
+function isSkip(
+  decision: RepairAction | RepairSkip | RepairError
+): decision is RepairSkip {
+  return 'action' in decision && decision.action === 'skip';
 }
 
-function isError(d: RepairAction | RepairSkip | RepairError): d is RepairError {
-  return 'action' in d && d.action === 'error';
+function isError(
+  decision: RepairAction | RepairSkip | RepairError
+): decision is RepairError {
+  return 'action' in decision && decision.action === 'error';
 }
 
 function streamEnd(stream: fs.WriteStream): Promise<void> {

--- a/server/src/scripts/repairs/lib/plan.ts
+++ b/server/src/scripts/repairs/lib/plan.ts
@@ -24,21 +24,26 @@ export async function plan<H extends HousingApi>(
 ): Promise<PlanSummary> {
   const outDir = options.outDir ?? process.cwd();
 
+  // Query before opening the output files: `createWriteStream` truncates in
+  // 'w' mode, so opening first would wipe a previously reviewed plan if
+  // `query()` then throws.
+  const housings = await repair.query();
+
   const planStream = fs.createWriteStream(path.join(outDir, 'plan.jsonl'));
   const skippedStream = fs.createWriteStream(
     path.join(outDir, 'skipped.jsonl')
   );
   const errorsStream = fs.createWriteStream(path.join(outDir, 'errors.jsonl'));
 
-  const housings = await repair.query();
   let planned = 0;
   let skipped = 0;
   let errors = 0;
   let eventsToDelete = 0;
   let eventsToCreate = 0;
+  const planRows: PlanRow[] = [];
 
   try {
-    for (const housing of housings) {
+    housings.forEach((housing) => {
       const decision = repair.decide(housing);
 
       if (isSkip(decision)) {
@@ -57,17 +62,28 @@ export async function plan<H extends HousingApi>(
         errorsStream.write(JSON.stringify(row) + '\n');
         errors++;
       } else {
-        const row: PlanRow = {
+        planRows.push({
           housingId: housing.id,
           housingGeoCode: housing.geoCode,
           ...decision
-        };
-        planStream.write(JSON.stringify(row) + '\n');
+        });
         planned++;
         eventsToDelete += decision.deleteEventIds?.length ?? 0;
         eventsToCreate += decision.createEvents?.length ?? 0;
       }
-    }
+    });
+
+    // Order plan.jsonl by update payload so same-payload rows are contiguous:
+    // `apply` streams the file and batches one UPDATE per payload run, so it
+    // never has to hold the whole plan in memory to group it.
+    planRows.sort((a, b) => {
+      const keyA = payloadKey(a);
+      const keyB = payloadKey(b);
+      return keyA < keyB ? -1 : keyA > keyB ? 1 : 0;
+    });
+    planRows.forEach((row) => {
+      planStream.write(JSON.stringify(row) + '\n');
+    });
   } finally {
     await Promise.all([
       streamEnd(planStream),
@@ -84,6 +100,10 @@ export async function plan<H extends HousingApi>(
     eventsToDelete,
     eventsToCreate
   };
+}
+
+function payloadKey(row: PlanRow): string {
+  return JSON.stringify(row.update ?? null);
 }
 
 function isSkip(

--- a/server/src/scripts/repairs/lib/plan.ts
+++ b/server/src/scripts/repairs/lib/plan.ts
@@ -1,5 +1,8 @@
 import fs from 'node:fs';
+import { rename, unlink } from 'node:fs/promises';
 import path from 'node:path';
+import { Writable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
 
 import type { HousingApi } from '~/models/HousingApi';
 
@@ -24,28 +27,39 @@ export async function plan<H extends HousingApi>(
 ): Promise<PlanSummary> {
   const outDir = options.outDir ?? process.cwd();
 
-  // Query before opening the output files: `createWriteStream` truncates in
-  // 'w' mode, so opening first would wipe a previously reviewed plan if
-  // `query()` then throws.
-  const housings = await repair.query();
+  // Write to temp files and promote them only once everything succeeds, so a
+  // query that errors (or a mid-stream failure) never clobbers a previously
+  // reviewed plan — `query()` now returns a stream, so there is no pre-open
+  // point at which we know it will succeed.
+  const targets = {
+    plan: path.join(outDir, 'plan.jsonl'),
+    skipped: path.join(outDir, 'skipped.jsonl'),
+    errors: path.join(outDir, 'errors.jsonl')
+  };
+  const temps = {
+    plan: `${targets.plan}.tmp`,
+    skipped: `${targets.skipped}.tmp`,
+    errors: `${targets.errors}.tmp`
+  };
+  const planStream = fs.createWriteStream(temps.plan);
+  const skippedStream = fs.createWriteStream(temps.skipped);
+  const errorsStream = fs.createWriteStream(temps.errors);
 
-  const planStream = fs.createWriteStream(path.join(outDir, 'plan.jsonl'));
-  const skippedStream = fs.createWriteStream(
-    path.join(outDir, 'skipped.jsonl')
-  );
-  const errorsStream = fs.createWriteStream(path.join(outDir, 'errors.jsonl'));
-
+  let total = 0;
   let planned = 0;
   let skipped = 0;
   let errors = 0;
   let eventsToDelete = 0;
   let eventsToCreate = 0;
-  const planRows: PlanRow[] = [];
 
-  try {
-    housings.forEach((housing) => {
+  // Stream the candidate housings through a decider: no sort, so the plan is in
+  // query order (`apply` batches contiguous same-payload runs and is correct
+  // regardless of ordering).
+  const decider = new Writable({
+    objectMode: true,
+    write(housing: H, _encoding, callback) {
+      total++;
       const decision = repair.decide(housing);
-
       if (isSkip(decision)) {
         const row: SkippedRow = {
           housingId: housing.id,
@@ -62,48 +76,52 @@ export async function plan<H extends HousingApi>(
         errorsStream.write(JSON.stringify(row) + '\n');
         errors++;
       } else {
-        planRows.push({
+        const row: PlanRow = {
           housingId: housing.id,
           housingGeoCode: housing.geoCode,
           ...decision
-        });
+        };
+        planStream.write(JSON.stringify(row) + '\n');
         planned++;
         eventsToDelete += decision.deleteEventIds?.length ?? 0;
         eventsToCreate += decision.createEvents?.length ?? 0;
       }
-    });
+      callback();
+    }
+  });
 
-    // Order plan.jsonl by update payload so same-payload rows are contiguous:
-    // `apply` streams the file and batches one UPDATE per payload run, so it
-    // never has to hold the whole plan in memory to group it.
-    planRows.sort((a, b) => {
-      const keyA = payloadKey(a);
-      const keyB = payloadKey(b);
-      return keyA < keyB ? -1 : keyA > keyB ? 1 : 0;
-    });
-    planRows.forEach((row) => {
-      planStream.write(JSON.stringify(row) + '\n');
-    });
-  } finally {
+  try {
+    await pipeline(repair.query(), decider);
     await Promise.all([
       streamEnd(planStream),
       streamEnd(skippedStream),
       streamEnd(errorsStream)
     ]);
+    await Promise.all([
+      rename(temps.plan, targets.plan),
+      rename(temps.skipped, targets.skipped),
+      rename(temps.errors, targets.errors)
+    ]);
+  } catch (error) {
+    planStream.destroy();
+    skippedStream.destroy();
+    errorsStream.destroy();
+    await Promise.allSettled([
+      unlink(temps.plan),
+      unlink(temps.skipped),
+      unlink(temps.errors)
+    ]);
+    throw error;
   }
 
   return {
-    total: housings.length,
+    total,
     planned,
     skipped,
     errors,
     eventsToDelete,
     eventsToCreate
   };
-}
-
-function payloadKey(row: PlanRow): string {
-  return JSON.stringify(row.update ?? null);
 }
 
 function isSkip(

--- a/server/src/scripts/repairs/lib/read-plan.ts
+++ b/server/src/scripts/repairs/lib/read-plan.ts
@@ -1,0 +1,16 @@
+import fs from 'node:fs';
+import type { Writable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+
+import { parse as parseJSONL } from 'jsonlines';
+
+/**
+ * Stream a plan file's rows into `sink`. Shared by `apply` and `stats` so the
+ * JSONL parsing lives in one place, and so neither has to hold the whole plan
+ * in memory — the `bypassTriggers` path targets very large repairs. Node
+ * streams give us backpressure: the parser only reads ahead as fast as the sink
+ * drains.
+ */
+export function readPlan(planFile: string, sink: Writable): Promise<void> {
+  return pipeline(fs.createReadStream(planFile), parseJSONL(), sink);
+}

--- a/server/src/scripts/repairs/lib/row-stream.ts
+++ b/server/src/scripts/repairs/lib/row-stream.ts
@@ -1,0 +1,33 @@
+import { Readable } from 'node:stream';
+
+declare const rowType: unique symbol;
+
+/**
+ * A Node object-mode `Readable` known to emit `T`. `Readable` is not generic,
+ * so we brand it with a phantom element type: a plain `Readable` is **not**
+ * assignable to `RowStream<T>`, which forces every repair to declare what its
+ * `query()` stream emits — once, through {@link rows} — and lets `plan` consume
+ * it type-safely, tied to the repair's `decide(housing: T)`.
+ */
+export interface RowStream<T> extends Readable {
+  /** Phantom marker — carries the element type, never present at runtime. */
+  readonly [rowType]: T;
+}
+
+/**
+ * Tag a source as a `RowStream<T>`.
+ *
+ * - A raw Node/Knex stream (`Readable`) is passed through untouched. Knex
+ *   `.stream()` is untyped, so this is the single, explicit boundary assertion —
+ *   pass the type argument: `rows<HousingApi>(db(...).stream())`.
+ * - An in-memory `Iterable` / `AsyncIterable` is wrapped with `Readable.from`,
+ *   and its element type is **inferred and checked**: `rows([housing])`.
+ */
+export function rows<T>(source: Readable): RowStream<T>;
+export function rows<T>(source: Iterable<T> | AsyncIterable<T>): RowStream<T>;
+export function rows<T>(
+  source: Readable | Iterable<T> | AsyncIterable<T>
+): RowStream<T> {
+  const stream = source instanceof Readable ? source : Readable.from(source);
+  return stream as RowStream<T>;
+}

--- a/server/src/scripts/repairs/lib/stats.ts
+++ b/server/src/scripts/repairs/lib/stats.ts
@@ -1,26 +1,27 @@
-import fs from 'node:fs';
-import readline from 'node:readline';
+import { Writable } from 'node:stream';
 
+import { readPlan } from './read-plan';
 import type { PlanRow, PlanSummary } from './types';
 
 export async function stats(
   planFile: string
 ): Promise<Pick<PlanSummary, 'planned' | 'eventsToDelete' | 'eventsToCreate'>> {
-  const rl = readline.createInterface({
-    input: fs.createReadStream(planFile),
-    crlfDelay: Infinity
-  });
   let planned = 0;
   let eventsToDelete = 0;
   let eventsToCreate = 0;
 
-  for await (const line of rl) {
-    if (!line.trim()) continue;
-    const row = JSON.parse(line) as PlanRow;
-    planned++;
-    eventsToDelete += row.deleteEventIds?.length ?? 0;
-    eventsToCreate += row.createEvents?.length ?? 0;
-  }
+  await readPlan(
+    planFile,
+    new Writable({
+      objectMode: true,
+      write(row: PlanRow, _encoding, callback) {
+        planned++;
+        eventsToDelete += row.deleteEventIds?.length ?? 0;
+        eventsToCreate += row.createEvents?.length ?? 0;
+        callback();
+      }
+    })
+  );
 
   return { planned, eventsToDelete, eventsToCreate };
 }

--- a/server/src/scripts/repairs/lib/stats.ts
+++ b/server/src/scripts/repairs/lib/stats.ts
@@ -1,0 +1,26 @@
+import fs from 'node:fs';
+import readline from 'node:readline';
+
+import type { PlanRow, PlanSummary } from './types';
+
+export async function stats(
+  planFile: string
+): Promise<Pick<PlanSummary, 'planned' | 'eventsToDelete' | 'eventsToCreate'>> {
+  const rl = readline.createInterface({
+    input: fs.createReadStream(planFile),
+    crlfDelay: Infinity
+  });
+  let planned = 0,
+    eventsToDelete = 0,
+    eventsToCreate = 0;
+
+  for await (const line of rl) {
+    if (!line.trim()) continue;
+    const row = JSON.parse(line) as PlanRow;
+    planned++;
+    eventsToDelete += row.deleteEventIds?.length ?? 0;
+    eventsToCreate += row.createEvents?.length ?? 0;
+  }
+
+  return { planned, eventsToDelete, eventsToCreate };
+}

--- a/server/src/scripts/repairs/lib/stats.ts
+++ b/server/src/scripts/repairs/lib/stats.ts
@@ -10,9 +10,9 @@ export async function stats(
     input: fs.createReadStream(planFile),
     crlfDelay: Infinity
   });
-  let planned = 0,
-    eventsToDelete = 0,
-    eventsToCreate = 0;
+  let planned = 0;
+  let eventsToDelete = 0;
+  let eventsToCreate = 0;
 
   for await (const line of rl) {
     if (!line.trim()) continue;

--- a/server/src/scripts/repairs/lib/test/apply.test.ts
+++ b/server/src/scripts/repairs/lib/test/apply.test.ts
@@ -1,0 +1,150 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { HousingStatus } from '@zerologementvacant/models';
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  Establishments,
+  formatEstablishmentApi
+} from '~/repositories/establishmentRepository';
+import {
+  Events,
+  formatEventApi,
+  formatHousingEventApi,
+  HousingEvents
+} from '~/repositories/eventRepository';
+import {
+  formatHousingRecordApi,
+  Housing
+} from '~/repositories/housingRepository';
+import { toUserDBO, Users } from '~/repositories/userRepository';
+import {
+  genEstablishmentApi,
+  genEventApi,
+  genHousingApi,
+  genUserApi
+} from '~/test/testFixtures';
+
+import { apply } from '../apply';
+import type { PlanRow } from '../types';
+
+let outDir: string;
+
+const establishment = genEstablishmentApi();
+const creator = genUserApi(establishment.id);
+
+beforeAll(async () => {
+  await Establishments().insert(formatEstablishmentApi(establishment));
+  await Users().insert(toUserDBO(creator));
+});
+
+beforeEach(() => {
+  outDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zlv-apply-'));
+});
+
+function writePlan(rows: PlanRow[]): string {
+  const planFile = path.join(outDir, 'plan.jsonl');
+  fs.writeFileSync(
+    planFile,
+    rows.map((r) => JSON.stringify(r)).join('\n') +
+      (rows.length > 0 ? '\n' : '')
+  );
+  return planFile;
+}
+
+describe('apply()', () => {
+  it('updates housing fields from plan rows', async () => {
+    const housing = genHousingApi();
+    await Housing().insert(
+      formatHousingRecordApi({
+        ...housing,
+        status: HousingStatus.WAITING,
+        subStatus: 'En attente de réponse'
+      })
+    );
+
+    const planFile = writePlan([
+      {
+        housingId: housing.id,
+        housingGeoCode: housing.geoCode,
+        update: { status: HousingStatus.NEVER_CONTACTED, subStatus: null }
+      }
+    ]);
+
+    const summary = await apply(planFile);
+
+    expect(summary.updated).toBe(1);
+    const [row] = await Housing().where({ id: housing.id });
+    expect(row.status).toBe(HousingStatus.NEVER_CONTACTED);
+    expect(row.sub_status).toBeNull();
+  });
+
+  it('hard-deletes event ids listed in plan rows', async () => {
+    const housing = genHousingApi();
+    await Housing().insert(formatHousingRecordApi(housing));
+
+    const event = genEventApi({
+      creator,
+      type: 'housing:status-updated',
+      nextOld: { status: 'never-contacted' },
+      nextNew: { status: 'blocked' }
+    });
+    const eventId = event.id;
+    await Events().insert(formatEventApi(event));
+    await HousingEvents().insert(
+      formatHousingEventApi({
+        ...event,
+        housingGeoCode: housing.geoCode,
+        housingId: housing.id
+      })
+    );
+
+    const planFile = writePlan([
+      {
+        housingId: housing.id,
+        housingGeoCode: housing.geoCode,
+        deleteEventIds: [eventId]
+      }
+    ]);
+
+    const summary = await apply(planFile);
+
+    expect(summary.eventsDeleted).toBe(1);
+    expect(await Events().where('id', eventId)).toHaveLength(0);
+    expect(await HousingEvents().where('event_id', eventId)).toHaveLength(0);
+  });
+
+  it('returns correct summary', async () => {
+    const h1 = genHousingApi();
+    const h2 = genHousingApi();
+    await Housing().insert([
+      formatHousingRecordApi(h1),
+      formatHousingRecordApi(h2)
+    ]);
+
+    const planFile = writePlan([
+      {
+        housingId: h1.id,
+        housingGeoCode: h1.geoCode,
+        update: { status: HousingStatus.NEVER_CONTACTED }
+      },
+      {
+        housingId: h2.id,
+        housingGeoCode: h2.geoCode,
+        update: { status: HousingStatus.NEVER_CONTACTED }
+      }
+    ]);
+
+    const summary = await apply(planFile);
+
+    expect(summary).toEqual({ updated: 2, eventsDeleted: 0, eventsCreated: 0 });
+  });
+
+  it('does nothing for an empty plan file', async () => {
+    const planFile = writePlan([]);
+    const summary = await apply(planFile);
+    expect(summary).toEqual({ updated: 0, eventsDeleted: 0, eventsCreated: 0 });
+  });
+});

--- a/server/src/scripts/repairs/lib/test/apply.test.ts
+++ b/server/src/scripts/repairs/lib/test/apply.test.ts
@@ -147,4 +147,35 @@ describe('apply()', () => {
     const summary = await apply(planFile);
     expect(summary).toEqual({ updated: 0, eventsDeleted: 0, eventsCreated: 0 });
   });
+
+  it('inserts createEvents into events and housing_events tables', async () => {
+    const housing = genHousingApi();
+    await Housing().insert(formatHousingRecordApi(housing));
+
+    const event = genEventApi({
+      creator,
+      type: 'housing:status-updated',
+      nextOld: { status: 'never-contacted' },
+      nextNew: { status: 'waiting' }
+    });
+    const housingEvent = {
+      ...event,
+      housingGeoCode: housing.geoCode,
+      housingId: housing.id
+    };
+
+    const planFile = writePlan([
+      {
+        housingId: housing.id,
+        housingGeoCode: housing.geoCode,
+        createEvents: [housingEvent]
+      }
+    ]);
+
+    const summary = await apply(planFile);
+
+    expect(summary.eventsCreated).toBe(1);
+    expect(await Events().where('id', event.id)).toHaveLength(1);
+    expect(await HousingEvents().where('event_id', event.id)).toHaveLength(1);
+  });
 });

--- a/server/src/scripts/repairs/lib/test/apply.test.ts
+++ b/server/src/scripts/repairs/lib/test/apply.test.ts
@@ -251,4 +251,77 @@ describe('apply()', () => {
     const [row] = await Housing().where({ id: housing.id });
     expect(row.status).toBe(HousingStatus.WAITING);
   });
+
+  it('counts only rows the update actually matched', async () => {
+    const existing = genHousingApi();
+    await Housing().insert(
+      formatHousingRecordApi({ ...existing, status: HousingStatus.WAITING })
+    );
+    const missing = genHousingApi(); // never inserted
+
+    const planFile = writePlan([
+      {
+        housingId: existing.id,
+        housingGeoCode: existing.geoCode,
+        update: { status: HousingStatus.NEVER_CONTACTED }
+      },
+      {
+        housingId: missing.id,
+        housingGeoCode: missing.geoCode,
+        update: { status: HousingStatus.NEVER_CONTACTED }
+      }
+    ]);
+
+    const summary = await apply(planFile);
+
+    // Only the row that exists was matched, not both planned rows.
+    expect(summary.updated).toBe(1);
+  });
+
+  it('counts only events actually deleted', async () => {
+    const housing = genHousingApi();
+    await Housing().insert(formatHousingRecordApi(housing));
+
+    const planFile = writePlan([
+      {
+        housingId: housing.id,
+        housingGeoCode: housing.geoCode,
+        deleteEventIds: ['00000000-0000-0000-0000-000000000000']
+      }
+    ]);
+
+    const summary = await apply(planFile);
+
+    expect(summary.eventsDeleted).toBe(0);
+  });
+
+  it('counts only events actually inserted (re-apply is a no-op)', async () => {
+    const housing = genHousingApi();
+    await Housing().insert(formatHousingRecordApi(housing));
+    const event = genEventApi({
+      creator,
+      type: 'housing:status-updated',
+      nextOld: { status: 'never-contacted' },
+      nextNew: { status: 'waiting' }
+    });
+    const housingEvent = {
+      ...event,
+      housingGeoCode: housing.geoCode,
+      housingId: housing.id
+    };
+    const planFile = writePlan([
+      {
+        housingId: housing.id,
+        housingGeoCode: housing.geoCode,
+        createEvents: [housingEvent]
+      }
+    ]);
+
+    const first = await apply(planFile);
+    expect(first.eventsCreated).toBe(1);
+
+    // Re-applying the same plan inserts nothing (onConflict ignore).
+    const second = await apply(planFile);
+    expect(second.eventsCreated).toBe(0);
+  });
 });

--- a/server/src/scripts/repairs/lib/test/apply.test.ts
+++ b/server/src/scripts/repairs/lib/test/apply.test.ts
@@ -16,15 +16,12 @@ import {
   formatHousingEventApi,
   HousingEvents
 } from '~/repositories/eventRepository';
-import {
-  formatHousingRecordApi,
-  Housing
-} from '~/repositories/housingRepository';
+import { Housing } from '~/repositories/housingRepository';
 import { toUserDBO, Users } from '~/repositories/userRepository';
+import { factories } from '~/test/factories';
 import {
   genEstablishmentApi,
   genEventApi,
-  genHousingApi,
   genUserApi
 } from '~/test/testFixtures';
 
@@ -57,14 +54,10 @@ function writePlan(rows: PlanRow[]): string {
 
 describe('apply()', () => {
   it('updates housing fields from plan rows', async () => {
-    const housing = genHousingApi();
-    await Housing().insert(
-      formatHousingRecordApi({
-        ...housing,
-        status: HousingStatus.WAITING,
-        subStatus: 'En attente de réponse'
-      })
-    );
+    const housing = await factories.housing.create({
+      status: HousingStatus.WAITING,
+      subStatus: 'En attente de réponse'
+    });
 
     const planFile = writePlan([
       {
@@ -83,8 +76,7 @@ describe('apply()', () => {
   });
 
   it('hard-deletes event ids listed in plan rows', async () => {
-    const housing = genHousingApi();
-    await Housing().insert(formatHousingRecordApi(housing));
+    const housing = await factories.housing.create();
 
     const event = genEventApi({
       creator,
@@ -118,12 +110,8 @@ describe('apply()', () => {
   });
 
   it('returns correct summary', async () => {
-    const h1 = genHousingApi();
-    const h2 = genHousingApi();
-    await Housing().insert([
-      formatHousingRecordApi(h1),
-      formatHousingRecordApi(h2)
-    ]);
+    const h1 = await factories.housing.create();
+    const h2 = await factories.housing.create();
 
     const planFile = writePlan([
       {
@@ -150,8 +138,7 @@ describe('apply()', () => {
   });
 
   it('inserts createEvents into events and housing_events tables', async () => {
-    const housing = genHousingApi();
-    await Housing().insert(formatHousingRecordApi(housing));
+    const housing = await factories.housing.create();
 
     const event = genEventApi({
       creator,
@@ -181,10 +168,9 @@ describe('apply()', () => {
   });
 
   it('applies with bypassTriggers and re-enables triggers afterwards', async () => {
-    const housing = genHousingApi();
-    await Housing().insert(
-      formatHousingRecordApi({ ...housing, status: HousingStatus.WAITING })
-    );
+    const housing = await factories.housing.create({
+      status: HousingStatus.WAITING
+    });
 
     const planFile = writePlan([
       {
@@ -210,15 +196,14 @@ describe('apply()', () => {
   });
 
   it('rolls back and re-enables triggers when the bypass transaction fails', async () => {
-    const housing = genHousingApi();
-    await Housing().insert(
-      formatHousingRecordApi({ ...housing, status: HousingStatus.WAITING })
-    );
+    const housing = await factories.housing.create({
+      status: HousingStatus.WAITING
+    });
 
     // A housing event pointing at a housing that does not exist violates the
     // housing_events -> fast_housing FK, so the transaction aborts *after* the
     // triggers were disabled inside it.
-    const ghost = genHousingApi();
+    const ghost = factories.housing.build();
     const event = genEventApi({
       creator,
       type: 'housing:status-updated',
@@ -253,11 +238,10 @@ describe('apply()', () => {
   });
 
   it('counts only rows the update actually matched', async () => {
-    const existing = genHousingApi();
-    await Housing().insert(
-      formatHousingRecordApi({ ...existing, status: HousingStatus.WAITING })
-    );
-    const missing = genHousingApi(); // never inserted
+    const existing = await factories.housing.create({
+      status: HousingStatus.WAITING
+    });
+    const missing = factories.housing.build(); // never persisted
 
     const planFile = writePlan([
       {
@@ -279,8 +263,7 @@ describe('apply()', () => {
   });
 
   it('counts only events actually deleted', async () => {
-    const housing = genHousingApi();
-    await Housing().insert(formatHousingRecordApi(housing));
+    const housing = await factories.housing.create();
 
     const planFile = writePlan([
       {
@@ -296,8 +279,7 @@ describe('apply()', () => {
   });
 
   it('counts only events actually inserted (re-apply is a no-op)', async () => {
-    const housing = genHousingApi();
-    await Housing().insert(formatHousingRecordApi(housing));
+    const housing = await factories.housing.create();
     const event = genEventApi({
       creator,
       type: 'housing:status-updated',

--- a/server/src/scripts/repairs/lib/test/apply.test.ts
+++ b/server/src/scripts/repairs/lib/test/apply.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { HousingStatus } from '@zerologementvacant/models';
 import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
 
+import db from '~/infra/database';
 import {
   Establishments,
   formatEstablishmentApi
@@ -177,5 +178,77 @@ describe('apply()', () => {
     expect(summary.eventsCreated).toBe(1);
     expect(await Events().where('id', event.id)).toHaveLength(1);
     expect(await HousingEvents().where('event_id', event.id)).toHaveLength(1);
+  });
+
+  it('applies with bypassTriggers and re-enables triggers afterwards', async () => {
+    const housing = genHousingApi();
+    await Housing().insert(
+      formatHousingRecordApi({ ...housing, status: HousingStatus.WAITING })
+    );
+
+    const planFile = writePlan([
+      {
+        housingId: housing.id,
+        housingGeoCode: housing.geoCode,
+        update: { status: HousingStatus.NEVER_CONTACTED }
+      }
+    ]);
+
+    const summary = await apply(planFile, { bypassTriggers: true });
+
+    expect(summary.updated).toBe(1);
+    const [row] = await Housing().where({ id: housing.id });
+    expect(row.status).toBe(HousingStatus.NEVER_CONTACTED);
+
+    // The commit must leave the triggers enabled (tgenabled 'O' = enabled).
+    const { rows } = await db.raw(
+      `SELECT tgenabled FROM pg_trigger
+       WHERE tgrelid = 'fast_housing'::regclass
+         AND tgname = 'trg_recompute_return_count_on_housing_status_change'`
+    );
+    expect(rows[0].tgenabled).toBe('O');
+  });
+
+  it('rolls back and re-enables triggers when the bypass transaction fails', async () => {
+    const housing = genHousingApi();
+    await Housing().insert(
+      formatHousingRecordApi({ ...housing, status: HousingStatus.WAITING })
+    );
+
+    // A housing event pointing at a housing that does not exist violates the
+    // housing_events -> fast_housing FK, so the transaction aborts *after* the
+    // triggers were disabled inside it.
+    const ghost = genHousingApi();
+    const event = genEventApi({
+      creator,
+      type: 'housing:status-updated',
+      nextOld: { status: 'waiting' },
+      nextNew: { status: 'never-contacted' }
+    });
+
+    const planFile = writePlan([
+      {
+        housingId: housing.id,
+        housingGeoCode: housing.geoCode,
+        update: { status: HousingStatus.NEVER_CONTACTED },
+        createEvents: [
+          { ...event, housingGeoCode: ghost.geoCode, housingId: ghost.id }
+        ]
+      }
+    ]);
+
+    await expect(apply(planFile, { bypassTriggers: true })).rejects.toThrow();
+
+    // Rollback must have restored the triggers...
+    const { rows } = await db.raw(
+      `SELECT tgenabled FROM pg_trigger
+       WHERE tgrelid = 'fast_housing'::regclass
+         AND tgname = 'trg_recompute_return_count_on_housing_status_change'`
+    );
+    expect(rows[0].tgenabled).toBe('O');
+
+    // ...and reverted the status update.
+    const [row] = await Housing().where({ id: housing.id });
+    expect(row.status).toBe(HousingStatus.WAITING);
   });
 });

--- a/server/src/scripts/repairs/lib/test/plan.test.ts
+++ b/server/src/scripts/repairs/lib/test/plan.test.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { Readable } from 'node:stream';
 
 import { HousingStatus } from '@zerologementvacant/models';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -25,7 +26,7 @@ describe('plan()', () => {
     const housing = factories.housing.build();
     const repair: Repair = {
       name: 'test',
-      query: async () => [housing],
+      query: () => Readable.from([housing]),
       decide: () => ({
         update: { status: HousingStatus.NEVER_CONTACTED, subStatus: null }
       })
@@ -54,7 +55,7 @@ describe('plan()', () => {
     const housing = factories.housing.build();
     const repair: Repair = {
       name: 'test',
-      query: async () => [housing],
+      query: () => Readable.from([housing]),
       decide: () => ({ action: 'skip' })
     };
 
@@ -77,7 +78,7 @@ describe('plan()', () => {
     const housing = factories.housing.build();
     const repair: Repair = {
       name: 'test',
-      query: async () => [housing],
+      query: () => Readable.from([housing]),
       decide: () => ({ action: 'error', reason: 'no restorable event' })
     };
 
@@ -100,7 +101,7 @@ describe('plan()', () => {
     const housing = factories.housing.build();
     const repair: Repair = {
       name: 'test',
-      query: async () => [housing],
+      query: () => Readable.from([housing]),
       decide: () => ({
         update: { status: HousingStatus.NEVER_CONTACTED },
         deleteEventIds: ['evt-1', 'evt-2'],
@@ -122,7 +123,7 @@ describe('plan()', () => {
     ];
     const repair: Repair = {
       name: 'test',
-      query: async () => [h1, h2, h3],
+      query: () => Readable.from([h1, h2, h3]),
       decide: (h) => {
         if (h.id === h1.id)
           return { update: { status: HousingStatus.NEVER_CONTACTED } };
@@ -152,8 +153,10 @@ describe('plan()', () => {
 
     const repair: Repair = {
       name: 'test',
-      query: async () => {
-        throw new Error('db unavailable');
+      query: () => {
+        const stream = new Readable({ objectMode: true, read() {} });
+        stream.destroy(new Error('db unavailable'));
+        return stream;
       },
       decide: () => ({ action: 'skip' })
     };

--- a/server/src/scripts/repairs/lib/test/plan.test.ts
+++ b/server/src/scripts/repairs/lib/test/plan.test.ts
@@ -138,4 +138,26 @@ describe('plan()', () => {
       eventsToCreate: 0
     });
   });
+
+  it('does not truncate an existing plan when query() fails', async () => {
+    const planFile = path.join(outDir, 'plan.jsonl');
+    fs.writeFileSync(
+      planFile,
+      '{"housingId":"keep","housingGeoCode":"01001"}\n'
+    );
+
+    const repair: Repair = {
+      name: 'test',
+      query: async () => {
+        throw new Error('db unavailable');
+      },
+      decide: () => ({ action: 'skip' })
+    };
+
+    await expect(plan(repair, { outDir })).rejects.toThrow('db unavailable');
+    // A failed query must leave a previously reviewed plan untouched.
+    expect(fs.readFileSync(planFile, 'utf-8')).toBe(
+      '{"housingId":"keep","housingGeoCode":"01001"}\n'
+    );
+  });
 });

--- a/server/src/scripts/repairs/lib/test/plan.test.ts
+++ b/server/src/scripts/repairs/lib/test/plan.test.ts
@@ -5,7 +5,7 @@ import path from 'node:path';
 import { HousingStatus } from '@zerologementvacant/models';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { genHousingApi } from '~/test/testFixtures';
+import { factories } from '~/test/factories';
 
 import { plan } from '../plan';
 import type { Repair } from '../types';
@@ -22,7 +22,7 @@ afterEach(() => {
 
 describe('plan()', () => {
   it('writes RepairActions to plan.jsonl', async () => {
-    const housing = genHousingApi();
+    const housing = factories.housing.build();
     const repair: Repair = {
       name: 'test',
       query: async () => [housing],
@@ -51,7 +51,7 @@ describe('plan()', () => {
   });
 
   it('writes RepairSkips to skipped.jsonl', async () => {
-    const housing = genHousingApi();
+    const housing = factories.housing.build();
     const repair: Repair = {
       name: 'test',
       query: async () => [housing],
@@ -74,7 +74,7 @@ describe('plan()', () => {
   });
 
   it('writes RepairErrors to errors.jsonl', async () => {
-    const housing = genHousingApi();
+    const housing = factories.housing.build();
     const repair: Repair = {
       name: 'test',
       query: async () => [housing],
@@ -97,7 +97,7 @@ describe('plan()', () => {
   });
 
   it('counts events to delete and create in summary', async () => {
-    const housing = genHousingApi();
+    const housing = factories.housing.build();
     const repair: Repair = {
       name: 'test',
       query: async () => [housing],
@@ -115,7 +115,11 @@ describe('plan()', () => {
   });
 
   it('returns correct totals across all outcomes', async () => {
-    const [h1, h2, h3] = [genHousingApi(), genHousingApi(), genHousingApi()];
+    const [h1, h2, h3] = [
+      factories.housing.build(),
+      factories.housing.build(),
+      factories.housing.build()
+    ];
     const repair: Repair = {
       name: 'test',
       query: async () => [h1, h2, h3],

--- a/server/src/scripts/repairs/lib/test/plan.test.ts
+++ b/server/src/scripts/repairs/lib/test/plan.test.ts
@@ -1,0 +1,141 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { HousingStatus } from '@zerologementvacant/models';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { genHousingApi } from '~/test/testFixtures';
+
+import { plan } from '../plan';
+import type { Repair } from '../types';
+
+let outDir: string;
+
+beforeEach(() => {
+  outDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zlv-repair-'));
+});
+
+afterEach(() => {
+  fs.rmSync(outDir, { recursive: true });
+});
+
+describe('plan()', () => {
+  it('writes RepairActions to plan.jsonl', async () => {
+    const housing = genHousingApi();
+    const repair: Repair = {
+      name: 'test',
+      query: async () => [housing],
+      decide: () => ({
+        update: { status: HousingStatus.NEVER_CONTACTED, subStatus: null }
+      })
+    };
+
+    const summary = await plan(repair, { outDir });
+
+    expect(summary.planned).toBe(1);
+    expect(summary.skipped).toBe(0);
+    expect(summary.errors).toBe(0);
+
+    const lines = fs
+      .readFileSync(path.join(outDir, 'plan.jsonl'), 'utf-8')
+      .trim()
+      .split('\n');
+    expect(lines).toHaveLength(1);
+    const row = JSON.parse(lines[0]);
+    expect(row).toMatchObject({
+      housingId: housing.id,
+      housingGeoCode: housing.geoCode,
+      update: { status: HousingStatus.NEVER_CONTACTED, subStatus: null }
+    });
+  });
+
+  it('writes RepairSkips to skipped.jsonl', async () => {
+    const housing = genHousingApi();
+    const repair: Repair = {
+      name: 'test',
+      query: async () => [housing],
+      decide: () => ({ action: 'skip' })
+    };
+
+    const summary = await plan(repair, { outDir });
+
+    expect(summary.skipped).toBe(1);
+    expect(summary.planned).toBe(0);
+
+    const lines = fs
+      .readFileSync(path.join(outDir, 'skipped.jsonl'), 'utf-8')
+      .trim()
+      .split('\n');
+    expect(JSON.parse(lines[0])).toMatchObject({
+      housingId: housing.id,
+      housingGeoCode: housing.geoCode
+    });
+  });
+
+  it('writes RepairErrors to errors.jsonl', async () => {
+    const housing = genHousingApi();
+    const repair: Repair = {
+      name: 'test',
+      query: async () => [housing],
+      decide: () => ({ action: 'error', reason: 'no restorable event' })
+    };
+
+    const summary = await plan(repair, { outDir });
+
+    expect(summary.errors).toBe(1);
+
+    const lines = fs
+      .readFileSync(path.join(outDir, 'errors.jsonl'), 'utf-8')
+      .trim()
+      .split('\n');
+    expect(JSON.parse(lines[0])).toMatchObject({
+      housingId: housing.id,
+      housingGeoCode: housing.geoCode,
+      reason: 'no restorable event'
+    });
+  });
+
+  it('counts events to delete and create in summary', async () => {
+    const housing = genHousingApi();
+    const repair: Repair = {
+      name: 'test',
+      query: async () => [housing],
+      decide: () => ({
+        update: { status: HousingStatus.NEVER_CONTACTED },
+        deleteEventIds: ['evt-1', 'evt-2'],
+        createEvents: []
+      })
+    };
+
+    const summary = await plan(repair, { outDir });
+
+    expect(summary.eventsToDelete).toBe(2);
+    expect(summary.eventsToCreate).toBe(0);
+  });
+
+  it('returns correct totals across all outcomes', async () => {
+    const [h1, h2, h3] = [genHousingApi(), genHousingApi(), genHousingApi()];
+    const repair: Repair = {
+      name: 'test',
+      query: async () => [h1, h2, h3],
+      decide: (h) => {
+        if (h.id === h1.id)
+          return { update: { status: HousingStatus.NEVER_CONTACTED } };
+        if (h.id === h2.id) return { action: 'skip' };
+        return { action: 'error', reason: 'test' };
+      }
+    };
+
+    const summary = await plan(repair, { outDir });
+
+    expect(summary).toEqual({
+      total: 3,
+      planned: 1,
+      skipped: 1,
+      errors: 1,
+      eventsToDelete: 0,
+      eventsToCreate: 0
+    });
+  });
+});

--- a/server/src/scripts/repairs/lib/test/plan.test.ts
+++ b/server/src/scripts/repairs/lib/test/plan.test.ts
@@ -6,9 +6,11 @@ import { Readable } from 'node:stream';
 import { HousingStatus } from '@zerologementvacant/models';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
+import type { HousingApi } from '~/models/HousingApi';
 import { factories } from '~/test/factories';
 
 import { plan } from '../plan';
+import { rows } from '../row-stream';
 import type { Repair } from '../types';
 
 let outDir: string;
@@ -26,7 +28,7 @@ describe('plan()', () => {
     const housing = factories.housing.build();
     const repair: Repair = {
       name: 'test',
-      query: () => Readable.from([housing]),
+      query: () => rows([housing]),
       decide: () => ({
         update: { status: HousingStatus.NEVER_CONTACTED, subStatus: null }
       })
@@ -55,7 +57,7 @@ describe('plan()', () => {
     const housing = factories.housing.build();
     const repair: Repair = {
       name: 'test',
-      query: () => Readable.from([housing]),
+      query: () => rows([housing]),
       decide: () => ({ action: 'skip' })
     };
 
@@ -78,7 +80,7 @@ describe('plan()', () => {
     const housing = factories.housing.build();
     const repair: Repair = {
       name: 'test',
-      query: () => Readable.from([housing]),
+      query: () => rows([housing]),
       decide: () => ({ action: 'error', reason: 'no restorable event' })
     };
 
@@ -101,7 +103,7 @@ describe('plan()', () => {
     const housing = factories.housing.build();
     const repair: Repair = {
       name: 'test',
-      query: () => Readable.from([housing]),
+      query: () => rows([housing]),
       decide: () => ({
         update: { status: HousingStatus.NEVER_CONTACTED },
         deleteEventIds: ['evt-1', 'evt-2'],
@@ -123,7 +125,7 @@ describe('plan()', () => {
     ];
     const repair: Repair = {
       name: 'test',
-      query: () => Readable.from([h1, h2, h3]),
+      query: () => rows([h1, h2, h3]),
       decide: (h) => {
         if (h.id === h1.id)
           return { update: { status: HousingStatus.NEVER_CONTACTED } };
@@ -156,7 +158,7 @@ describe('plan()', () => {
       query: () => {
         const stream = new Readable({ objectMode: true, read() {} });
         stream.destroy(new Error('db unavailable'));
-        return stream;
+        return rows<HousingApi>(stream);
       },
       decide: () => ({ action: 'skip' })
     };
@@ -166,5 +168,19 @@ describe('plan()', () => {
     expect(fs.readFileSync(planFile, 'utf-8')).toBe(
       '{"housingId":"keep","housingGeoCode":"01001"}\n'
     );
+  });
+});
+
+describe('Repair type safety', () => {
+  it('requires rows(): a plain Readable is not a RowStream<H>', () => {
+    const repair: Repair = {
+      name: 'test',
+      // @ts-expect-error query() must return RowStream<H>; wrap the stream with rows()
+      query: () => Readable.from([]),
+      decide: () => ({ action: 'skip' })
+    };
+    // The @ts-expect-error above is the assertion — it fails typecheck if a
+    // plain Readable ever becomes assignable (i.e. the brand stops enforcing).
+    expect(repair.name).toBe('test');
   });
 });

--- a/server/src/scripts/repairs/lib/types.ts
+++ b/server/src/scripts/repairs/lib/types.ts
@@ -1,7 +1,5 @@
 import type { HousingEventApi } from '~/models/EventApi';
-import type { HousingApi, HousingId } from '~/models/HousingApi';
-
-export type { HousingId };
+import type { HousingApi } from '~/models/HousingApi';
 
 export interface Repair<H extends HousingApi = HousingApi> {
   name: string;

--- a/server/src/scripts/repairs/lib/types.ts
+++ b/server/src/scripts/repairs/lib/types.ts
@@ -5,6 +5,14 @@ export type { HousingId };
 
 export interface Repair<H extends HousingApi = HousingApi> {
   name: string;
+  /**
+   * Disable the `fast_housing` / `housing_events` count triggers during
+   * `apply` and recompute the counts once at the end, instead of firing them
+   * per row. Set to `true` for large repairs that touch `status` or
+   * `occupancy` (the trigger-watched columns). Defaults to `false`; the
+   * `--bypass-triggers` / `--no-bypass-triggers` CLI flag overrides it.
+   */
+  bypassTriggers?: boolean;
   query(): Promise<H[]>;
   decide(housing: H): RepairAction | RepairSkip | RepairError;
 }

--- a/server/src/scripts/repairs/lib/types.ts
+++ b/server/src/scripts/repairs/lib/types.ts
@@ -1,7 +1,7 @@
-import type { Readable } from 'node:stream';
-
 import type { HousingEventApi } from '~/models/EventApi';
 import type { HousingApi } from '~/models/HousingApi';
+
+import type { RowStream } from './row-stream';
 
 export interface Repair<H extends HousingApi = HousingApi> {
   name: string;
@@ -14,12 +14,13 @@ export interface Repair<H extends HousingApi = HousingApi> {
    */
   bypassTriggers?: boolean;
   /**
-   * A Node object-mode stream of the candidate housings — e.g. a Knex
-   * `.stream()` — so `plan` never holds the whole set in memory. Each emitted
-   * value must be an `H`; enrich via a JOIN (or a Transform piped inside
-   * `query()`) so that {@link decide} can stay pure.
+   * A stream of the candidate housings — build it with {@link rows} (e.g.
+   * `rows<H>(db(...).stream())`) so its element type is tied to {@link decide}
+   * at compile time. `plan` streams it, so the whole set never sits in memory.
+   * Enrich via a JOIN (or a Transform piped inside `query()`) so `decide` stays
+   * pure.
    */
-  query(): Readable;
+  query(): RowStream<H>;
   decide(housing: H): RepairAction | RepairSkip | RepairError;
 }
 

--- a/server/src/scripts/repairs/lib/types.ts
+++ b/server/src/scripts/repairs/lib/types.ts
@@ -1,0 +1,61 @@
+import type { HousingEventApi } from '~/models/EventApi';
+import type { HousingApi, HousingId } from '~/models/HousingApi';
+
+export type { HousingId };
+
+export interface Repair<H extends HousingApi = HousingApi> {
+  name: string;
+  query(): Promise<H[]>;
+  decide(housing: H): RepairAction | RepairSkip | RepairError;
+}
+
+export interface RepairAction {
+  update?: Partial<
+    Pick<HousingApi, 'status' | 'subStatus' | 'occupancy' | 'occupancyIntended'>
+  >;
+  createEvents?: HousingEventApi[];
+  deleteEventIds?: string[];
+}
+
+export interface RepairSkip {
+  action: 'skip';
+}
+
+export interface RepairError {
+  action: 'error';
+  reason: string;
+}
+
+export interface PlanRow {
+  housingId: string;
+  housingGeoCode: string;
+  update?: RepairAction['update'];
+  createEvents?: HousingEventApi[];
+  deleteEventIds?: string[];
+}
+
+export interface SkippedRow {
+  housingId: string;
+  housingGeoCode: string;
+}
+
+export interface ErrorRow {
+  housingId: string;
+  housingGeoCode: string;
+  reason: string;
+}
+
+export interface PlanSummary {
+  total: number;
+  planned: number;
+  skipped: number;
+  errors: number;
+  eventsToDelete: number;
+  eventsToCreate: number;
+}
+
+export interface ApplySummary {
+  updated: number;
+  eventsDeleted: number;
+  eventsCreated: number;
+}

--- a/server/src/scripts/repairs/lib/types.ts
+++ b/server/src/scripts/repairs/lib/types.ts
@@ -1,3 +1,5 @@
+import type { Readable } from 'node:stream';
+
 import type { HousingEventApi } from '~/models/EventApi';
 import type { HousingApi } from '~/models/HousingApi';
 
@@ -11,7 +13,13 @@ export interface Repair<H extends HousingApi = HousingApi> {
    * `--bypass-triggers` / `--no-bypass-triggers` CLI flag overrides it.
    */
   bypassTriggers?: boolean;
-  query(): Promise<H[]>;
+  /**
+   * A Node object-mode stream of the candidate housings — e.g. a Knex
+   * `.stream()` — so `plan` never holds the whole set in memory. Each emitted
+   * value must be an `H`; enrich via a JOIN (or a Transform piped inside
+   * `query()`) so that {@link decide} can stay pure.
+   */
+  query(): Readable;
   decide(housing: H): RepairAction | RepairSkip | RepairError;
 }
 

--- a/server/src/scripts/repairs/test/cli.test.ts
+++ b/server/src/scripts/repairs/test/cli.test.ts
@@ -1,0 +1,179 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ApplySummary, PlanSummary } from '../lib/types';
+
+// Mock the underlying functions before importing the CLI
+vi.mock('../lib/plan', () => ({
+  plan: vi.fn()
+}));
+vi.mock('../lib/apply', () => ({
+  apply: vi.fn()
+}));
+vi.mock('../lib/stats', () => ({
+  stats: vi.fn()
+}));
+vi.mock('../index', () => ({
+  repairs: {}
+}));
+
+import { repairCommand } from '../cli';
+import { apply } from '../lib/apply';
+import { plan } from '../lib/plan';
+import { stats } from '../lib/stats';
+
+const mockPlan = vi.mocked(plan);
+const mockApply = vi.mocked(apply);
+const mockStats = vi.mocked(stats);
+
+let outDir: string;
+
+beforeEach(() => {
+  outDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zlv-cli-test-'));
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  fs.rmSync(outDir, { recursive: true, force: true });
+});
+
+describe('repairCommand()', () => {
+  describe('list', () => {
+    it('prints "No repairs registered." when registry is empty', async () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const cmd = repairCommand();
+      await cmd.parseAsync(['list'], { from: 'user' });
+      expect(consoleSpy).toHaveBeenCalledWith('No repairs registered.');
+      consoleSpy.mockRestore();
+    });
+
+    it('lists repair names when registry has entries', async () => {
+      const { repairs } = await import('../index');
+      (repairs as Record<string, unknown>)['test-repair'] = {
+        name: 'test-repair',
+        query: async () => [],
+        decide: () => ({ action: 'skip' as const })
+      };
+
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const cmd = repairCommand();
+      await cmd.parseAsync(['list'], { from: 'user' });
+      expect(consoleSpy).toHaveBeenCalledWith('test-repair');
+      consoleSpy.mockRestore();
+
+      delete (repairs as Record<string, unknown>)['test-repair'];
+    });
+  });
+
+  describe('plan', () => {
+    it('calls plan() with the named repair and prints summary', async () => {
+      const { repairs } = await import('../index');
+      (repairs as Record<string, unknown>)['my-repair'] = {
+        name: 'my-repair',
+        query: async () => [],
+        decide: () => ({ action: 'skip' as const })
+      };
+
+      const summary: PlanSummary = {
+        total: 10,
+        planned: 8,
+        skipped: 1,
+        errors: 1,
+        eventsToDelete: 3,
+        eventsToCreate: 2
+      };
+      mockPlan.mockResolvedValue(summary);
+
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const cmd = repairCommand();
+      await cmd.parseAsync(['plan', 'my-repair', '--out', outDir], {
+        from: 'user'
+      });
+
+      expect(mockPlan).toHaveBeenCalledOnce();
+      expect(mockPlan).toHaveBeenCalledWith(
+        (repairs as Record<string, unknown>)['my-repair'],
+        { outDir }
+      );
+      expect(consoleSpy).toHaveBeenCalledWith('Total:    10');
+      expect(consoleSpy).toHaveBeenCalledWith('Planned:  8');
+      consoleSpy.mockRestore();
+
+      delete (repairs as Record<string, unknown>)['my-repair'];
+    });
+
+    it('exits with error when repair name is unknown', async () => {
+      const consoleErrSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      const exitSpy = vi
+        .spyOn(process, 'exit')
+        .mockImplementation((() => {}) as never);
+
+      const cmd = repairCommand();
+      await cmd.parseAsync(['plan', 'nonexistent'], { from: 'user' });
+
+      expect(consoleErrSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Unknown repair: "nonexistent"')
+      );
+      expect(exitSpy).toHaveBeenCalledWith(1);
+
+      consoleErrSpy.mockRestore();
+      exitSpy.mockRestore();
+    });
+  });
+
+  describe('stats', () => {
+    it('calls stats() with the plan file and prints summary', async () => {
+      const planFile = path.join(outDir, 'plan.jsonl');
+      fs.writeFileSync(planFile, '');
+
+      const summary: Pick<
+        PlanSummary,
+        'planned' | 'eventsToDelete' | 'eventsToCreate'
+      > = {
+        planned: 5,
+        eventsToDelete: 2,
+        eventsToCreate: 3
+      };
+      mockStats.mockResolvedValue(summary);
+
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const cmd = repairCommand();
+      await cmd.parseAsync(['stats', planFile], { from: 'user' });
+
+      expect(mockStats).toHaveBeenCalledWith(planFile);
+      expect(consoleSpy).toHaveBeenCalledWith('Planned:  5');
+      expect(consoleSpy).toHaveBeenCalledWith('Events to delete: 2');
+      expect(consoleSpy).toHaveBeenCalledWith('Events to create: 3');
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('apply', () => {
+    it('calls apply() with the plan file and prints summary', async () => {
+      const planFile = path.join(outDir, 'plan.jsonl');
+      fs.writeFileSync(planFile, '');
+
+      const summary: ApplySummary = {
+        updated: 7,
+        eventsDeleted: 4,
+        eventsCreated: 2
+      };
+      mockApply.mockResolvedValue(summary);
+
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const cmd = repairCommand();
+      await cmd.parseAsync(['apply', planFile], { from: 'user' });
+
+      expect(mockApply).toHaveBeenCalledWith(planFile);
+      expect(consoleSpy).toHaveBeenCalledWith('Updated:         7');
+      expect(consoleSpy).toHaveBeenCalledWith('Events deleted:  4');
+      expect(consoleSpy).toHaveBeenCalledWith('Events created:  2');
+      consoleSpy.mockRestore();
+    });
+  });
+});

--- a/server/src/scripts/repairs/test/cli.test.ts
+++ b/server/src/scripts/repairs/test/cli.test.ts
@@ -154,26 +154,137 @@ describe('repairCommand()', () => {
   });
 
   describe('apply', () => {
+    const summary: ApplySummary = {
+      updated: 7,
+      eventsDeleted: 4,
+      eventsCreated: 2
+    };
+
+    async function registerRepair(bypassTriggers?: boolean): Promise<string> {
+      const { repairs } = await import('../index');
+      (repairs as Record<string, unknown>)['my-repair'] = {
+        name: 'my-repair',
+        bypassTriggers,
+        query: async () => [],
+        decide: () => ({ action: 'skip' as const })
+      };
+      return 'my-repair';
+    }
+
+    async function unregisterRepair(): Promise<void> {
+      const { repairs } = await import('../index');
+      delete (repairs as Record<string, unknown>)['my-repair'];
+    }
+
     it('calls apply() with the plan file and prints summary', async () => {
+      const name = await registerRepair();
       const planFile = path.join(outDir, 'plan.jsonl');
       fs.writeFileSync(planFile, '');
-
-      const summary: ApplySummary = {
-        updated: 7,
-        eventsDeleted: 4,
-        eventsCreated: 2
-      };
       mockApply.mockResolvedValue(summary);
 
       const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
       const cmd = repairCommand();
-      await cmd.parseAsync(['apply', planFile], { from: 'user' });
+      await cmd.parseAsync(['apply', name, planFile], { from: 'user' });
 
-      expect(mockApply).toHaveBeenCalledWith(planFile);
+      expect(mockApply).toHaveBeenCalledWith(planFile, {
+        bypassTriggers: false
+      });
       expect(consoleSpy).toHaveBeenCalledWith('Updated:         7');
       expect(consoleSpy).toHaveBeenCalledWith('Events deleted:  4');
       expect(consoleSpy).toHaveBeenCalledWith('Events created:  2');
       consoleSpy.mockRestore();
+      await unregisterRepair();
+    });
+
+    it('defaults bypassTriggers to false when neither flag nor repair set it', async () => {
+      const name = await registerRepair(undefined);
+      const planFile = path.join(outDir, 'plan.jsonl');
+      fs.writeFileSync(planFile, '');
+      mockApply.mockResolvedValue(summary);
+
+      const cmd = repairCommand();
+      await cmd.parseAsync(['apply', name, planFile], { from: 'user' });
+
+      expect(mockApply).toHaveBeenCalledWith(planFile, {
+        bypassTriggers: false
+      });
+      await unregisterRepair();
+    });
+
+    it('uses repair.bypassTriggers when no flag is passed', async () => {
+      const name = await registerRepair(true);
+      const planFile = path.join(outDir, 'plan.jsonl');
+      fs.writeFileSync(planFile, '');
+      mockApply.mockResolvedValue(summary);
+
+      const cmd = repairCommand();
+      await cmd.parseAsync(['apply', name, planFile], { from: 'user' });
+
+      expect(mockApply).toHaveBeenCalledWith(planFile, {
+        bypassTriggers: true
+      });
+      await unregisterRepair();
+    });
+
+    it('lets --bypass-triggers override a repair that defaults to false', async () => {
+      const name = await registerRepair(false);
+      const planFile = path.join(outDir, 'plan.jsonl');
+      fs.writeFileSync(planFile, '');
+      mockApply.mockResolvedValue(summary);
+
+      const cmd = repairCommand();
+      await cmd.parseAsync(['apply', name, planFile, '--bypass-triggers'], {
+        from: 'user'
+      });
+
+      expect(mockApply).toHaveBeenCalledWith(planFile, {
+        bypassTriggers: true
+      });
+      await unregisterRepair();
+    });
+
+    it('lets --no-bypass-triggers override a repair that defaults to true', async () => {
+      const name = await registerRepair(true);
+      const planFile = path.join(outDir, 'plan.jsonl');
+      fs.writeFileSync(planFile, '');
+      mockApply.mockResolvedValue(summary);
+
+      const cmd = repairCommand();
+      await cmd.parseAsync(['apply', name, planFile, '--no-bypass-triggers'], {
+        from: 'user'
+      });
+
+      expect(mockApply).toHaveBeenCalledWith(planFile, {
+        bypassTriggers: false
+      });
+      await unregisterRepair();
+    });
+
+    it('exits with error and never applies when repair name is unknown', async () => {
+      const planFile = path.join(outDir, 'plan.jsonl');
+      fs.writeFileSync(planFile, '');
+      const consoleErrSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      // Model process.exit as terminating control flow, as it does in production.
+      const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((
+        code?: number
+      ) => {
+        throw new Error(`process.exit:${code}`);
+      }) as never);
+
+      const cmd = repairCommand();
+      await expect(
+        cmd.parseAsync(['apply', 'nonexistent', planFile], { from: 'user' })
+      ).rejects.toThrow('process.exit:1');
+
+      expect(consoleErrSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Unknown repair: "nonexistent"')
+      );
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(mockApply).not.toHaveBeenCalled();
+      consoleErrSpy.mockRestore();
+      exitSpy.mockRestore();
     });
   });
 });

--- a/server/src/scripts/repairs/test/cli.test.ts
+++ b/server/src/scripts/repairs/test/cli.test.ts
@@ -6,7 +6,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { ApplySummary, PlanSummary } from '../lib/types';
 
-// Mock the underlying functions before importing the CLI
+const mockLogger = vi.hoisted(() => ({
+  trace: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn()
+}));
+
+// Mock the underlying functions and the logger before importing the CLI
 vi.mock('../lib/plan', () => ({
   plan: vi.fn()
 }));
@@ -18,6 +26,10 @@ vi.mock('../lib/stats', () => ({
 }));
 vi.mock('../index', () => ({
   repairs: {}
+}));
+vi.mock('~/infra/logger', () => ({
+  createLogger: () => mockLogger,
+  logger: mockLogger
 }));
 
 import { repairCommand } from '../cli';
@@ -42,15 +54,13 @@ afterEach(() => {
 
 describe('repairCommand()', () => {
   describe('list', () => {
-    it('prints "No repairs registered." when registry is empty', async () => {
-      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    it('logs "No repairs registered." when registry is empty', async () => {
       const cmd = repairCommand();
       await cmd.parseAsync(['list'], { from: 'user' });
-      expect(consoleSpy).toHaveBeenCalledWith('No repairs registered.');
-      consoleSpy.mockRestore();
+      expect(mockLogger.info).toHaveBeenCalledWith('No repairs registered.');
     });
 
-    it('lists repair names when registry has entries', async () => {
+    it('logs repair names when registry has entries', async () => {
       const { repairs } = await import('../index');
       (repairs as Record<string, unknown>)['test-repair'] = {
         name: 'test-repair',
@@ -58,18 +68,16 @@ describe('repairCommand()', () => {
         decide: () => ({ action: 'skip' as const })
       };
 
-      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
       const cmd = repairCommand();
       await cmd.parseAsync(['list'], { from: 'user' });
-      expect(consoleSpy).toHaveBeenCalledWith('test-repair');
-      consoleSpy.mockRestore();
+      expect(mockLogger.info).toHaveBeenCalledWith('test-repair');
 
       delete (repairs as Record<string, unknown>)['test-repair'];
     });
   });
 
   describe('plan', () => {
-    it('calls plan() with the named repair and prints summary', async () => {
+    it('calls plan() with the named repair and logs the summary', async () => {
       const { repairs } = await import('../index');
       (repairs as Record<string, unknown>)['my-repair'] = {
         name: 'my-repair',
@@ -87,7 +95,6 @@ describe('repairCommand()', () => {
       };
       mockPlan.mockResolvedValue(summary);
 
-      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
       const cmd = repairCommand();
       await cmd.parseAsync(['plan', 'my-repair', '--out', outDir], {
         from: 'user'
@@ -98,17 +105,15 @@ describe('repairCommand()', () => {
         (repairs as Record<string, unknown>)['my-repair'],
         { outDir }
       );
-      expect(consoleSpy).toHaveBeenCalledWith('Total:    10');
-      expect(consoleSpy).toHaveBeenCalledWith('Planned:  8');
-      consoleSpy.mockRestore();
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        expect.stringContaining('Plan generated'),
+        expect.objectContaining({ total: 10, planned: 8, outDir })
+      );
 
       delete (repairs as Record<string, unknown>)['my-repair'];
     });
 
-    it('exits with error when repair name is unknown', async () => {
-      const consoleErrSpy = vi
-        .spyOn(console, 'error')
-        .mockImplementation(() => {});
+    it('logs an error and exits when repair name is unknown', async () => {
       const exitSpy = vi
         .spyOn(process, 'exit')
         .mockImplementation((() => {}) as never);
@@ -116,18 +121,17 @@ describe('repairCommand()', () => {
       const cmd = repairCommand();
       await cmd.parseAsync(['plan', 'nonexistent'], { from: 'user' });
 
-      expect(consoleErrSpy).toHaveBeenCalledWith(
+      expect(mockLogger.error).toHaveBeenCalledWith(
         expect.stringContaining('Unknown repair: "nonexistent"')
       );
       expect(exitSpy).toHaveBeenCalledWith(1);
 
-      consoleErrSpy.mockRestore();
       exitSpy.mockRestore();
     });
   });
 
   describe('stats', () => {
-    it('calls stats() with the plan file and prints summary', async () => {
+    it('calls stats() with the plan file and logs the summary', async () => {
       const planFile = path.join(outDir, 'plan.jsonl');
       fs.writeFileSync(planFile, '');
 
@@ -141,15 +145,11 @@ describe('repairCommand()', () => {
       };
       mockStats.mockResolvedValue(summary);
 
-      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
       const cmd = repairCommand();
       await cmd.parseAsync(['stats', planFile], { from: 'user' });
 
       expect(mockStats).toHaveBeenCalledWith(planFile);
-      expect(consoleSpy).toHaveBeenCalledWith('Planned:  5');
-      expect(consoleSpy).toHaveBeenCalledWith('Events to delete: 2');
-      expect(consoleSpy).toHaveBeenCalledWith('Events to create: 3');
-      consoleSpy.mockRestore();
+      expect(mockLogger.info).toHaveBeenCalledWith('Plan stats', summary);
     });
   });
 
@@ -176,23 +176,22 @@ describe('repairCommand()', () => {
       delete (repairs as Record<string, unknown>)['my-repair'];
     }
 
-    it('calls apply() with the plan file and prints summary', async () => {
+    it('calls apply() with the plan file and logs the summary', async () => {
       const name = await registerRepair();
       const planFile = path.join(outDir, 'plan.jsonl');
       fs.writeFileSync(planFile, '');
       mockApply.mockResolvedValue(summary);
 
-      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
       const cmd = repairCommand();
       await cmd.parseAsync(['apply', name, planFile], { from: 'user' });
 
       expect(mockApply).toHaveBeenCalledWith(planFile, {
         bypassTriggers: false
       });
-      expect(consoleSpy).toHaveBeenCalledWith('Updated:         7');
-      expect(consoleSpy).toHaveBeenCalledWith('Events deleted:  4');
-      expect(consoleSpy).toHaveBeenCalledWith('Events created:  2');
-      consoleSpy.mockRestore();
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        'Plan applied',
+        expect.objectContaining({ updated: 7, bypassTriggers: false })
+      );
       await unregisterRepair();
     });
 
@@ -260,12 +259,9 @@ describe('repairCommand()', () => {
       await unregisterRepair();
     });
 
-    it('exits with error and never applies when repair name is unknown', async () => {
+    it('logs an error and never applies when repair name is unknown', async () => {
       const planFile = path.join(outDir, 'plan.jsonl');
       fs.writeFileSync(planFile, '');
-      const consoleErrSpy = vi
-        .spyOn(console, 'error')
-        .mockImplementation(() => {});
       // Model process.exit as terminating control flow, as it does in production.
       const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((
         code?: number
@@ -278,12 +274,11 @@ describe('repairCommand()', () => {
         cmd.parseAsync(['apply', 'nonexistent', planFile], { from: 'user' })
       ).rejects.toThrow('process.exit:1');
 
-      expect(consoleErrSpy).toHaveBeenCalledWith(
+      expect(mockLogger.error).toHaveBeenCalledWith(
         expect.stringContaining('Unknown repair: "nonexistent"')
       );
       expect(exitSpy).toHaveBeenCalledWith(1);
       expect(mockApply).not.toHaveBeenCalled();
-      consoleErrSpy.mockRestore();
       exitSpy.mockRestore();
     });
   });


### PR DESCRIPTION
## Summary

- Adds a `zlv repair` CLI with a Terraform-style `plan` / `apply` / `stats` / `list` workflow for bulk housing data corrections
- Each repair implements a typed `Repair<H>` interface (`query()` + `decide()`); the shared scaffold handles chunking, transactions, and file I/O
- `plan` generates `plan.jsonl`, `skipped.jsonl`, and `errors.jsonl` staging files that can be inspected with `jq`, edited, or filtered before committing
- `apply` reads `plan.jsonl`, groups rows by update payload, chunks to 1000 per Postgres UPDATE, and commits everything in a single atomic transaction (full rollback on failure)
- Bad events (from system bugs) are hard-deleted inside `apply` — not promoted to a repository method, not compensating events — so downstream systems (LOVAC) see a clean event history
- **New: opt-in count-trigger bypass** for large repairs (see below)
- **New: `apply` is isolated from the domain layer** — it writes via the table accessors and pure formatters and manages its own `db.transaction`, never repository methods, so a repository refactor can't silently change what a reviewed repair does
- **New: a README** documenting the workflow, how to write/register a repair (incl. the enrich-in-`query()` pattern for related data), and the bypass
- Also fixes the immediate bug: `housingBulkUpdatePayload` schema no longer allows a sub-status update without a status, preventing bulk updates from silently nulling `subStatus`

## Count-trigger bypass (`bypassTriggers`)

`fast_housing` / `housing_events` carry `FOR EACH ROW` triggers that recompute derived counts on every `status` / `occupancy` change. For a large repair those per-row fires dominate the runtime (partition pruning is **not** the bottleneck — Postgres prunes the `WHERE (geo_code, id) IN (…)` that `apply` emits). Setting `bypassTriggers` disables the triggers, applies the plan, recomputes the counts once, and re-enables them — **all inside the transaction**.

- **Precedence:** `--bypass-triggers` / `--no-bypass-triggers` flag > `repair.bypassTriggers` > `false` (flat default). Not row-count based: the cost tracks trigger fires on the watched columns, not row count.
- **Interrupt-safe by construction:** the disable is transactional, so an early exit (Ctrl-C, SIGTERM, SIGKILL, crash, dropped connection) rolls it back — the triggers are never left disabled. No signal handler needed (SIGKILL can't be caught; only rollback is airtight). A regression test forces a mid-bypass failure and asserts the triggers come back and the data reverts.
- Reuses `import-lovac`'s `housings-counts-maintenance`; those helpers now take an optional `Knex` executor so they can run inside a transaction (backward-compatible — existing no-arg callers are unchanged).

## Architecture

```
server/src/scripts/repairs/
  lib/
    types.ts        # Repair<H> (+ bypassTriggers), RepairAction/Skip/Error, PlanRow, …
    plan.ts         # query → decide → write plan.jsonl / skipped.jsonl / errors.jsonl
    apply.ts        # read plan.jsonl → chunk → db.transaction → commit (accessors + formatters)
    stats.ts        # pure file reader, no DB
  index.ts          # repair registry (empty, ready for first repair definition)
  cli.ts            # repairCommand() — commander subcommand tree
  README.md         # workflow, writing/registering a repair, the bypass

server/src/bin/
  zlv.ts            # top-level binary entry point
```

Run with: `yarn workspace @zerologementvacant/server zlv repair list`

## Test plan

- [ ] `yarn nx test server -- repairs` — 23 tests (unit + integration against the real test DB, incl. bypass apply + rollback self-heal)
- [ ] `yarn nx typecheck server` — clean
- [ ] `yarn lint` — clean
- [ ] Smoke: `yarn workspace @zerologementvacant/server zlv repair list` prints "No repairs registered."
- [ ] Smoke: `yarn workspace @zerologementvacant/server zlv repair --help` shows all four subcommands

🤖 Generated with [Claude Code](https://claude.com/claude-code)
