### PR TITLE
feat(server): migrate the campaign write-cluster to Kysely

### DIFF
--- a/server/src/repositories/campaignDraftRepository.ts
+++ b/server/src/repositories/campaignDraftRepository.ts
@@ -1,7 +1,7 @@
 import { Knex } from 'knex';
 
 import db from '~/infra/database';
-import { withinTransaction } from '~/infra/database/transaction';
+import { withinKyselyTransaction } from '~/infra/database/kysely-transaction';
 import { CampaignApi } from '~/models/CampaignApi';
 import { DraftApi } from '~/models/DraftApi';
 
@@ -10,14 +10,15 @@ export const CampaignsDrafts = (transaction: Knex<CampaignDraftDBO> = db) =>
   transaction(campaignsDraftsTable);
 
 async function save(campaign: CampaignApi, draft: DraftApi): Promise<void> {
-  await withinTransaction(async (transaction) => {
-    await CampaignsDrafts(transaction)
-      .insert({
-        campaign_id: campaign.id,
-        draft_id: draft.id
+  await withinKyselyTransaction(async (trx) => {
+    await trx
+      .insertInto('campaignsDrafts')
+      .values({
+        campaignId: campaign.id,
+        draftId: draft.id
       })
-      .onConflict(['campaign_id', 'draft_id'])
-      .ignore();
+      .onConflict((oc) => oc.columns(['campaignId', 'draftId']).doNothing())
+      .execute();
   });
 }
 

--- a/server/src/repositories/campaignHousingRepository.ts
+++ b/server/src/repositories/campaignHousingRepository.ts
@@ -1,5 +1,5 @@
 import db from '~/infra/database';
-import { withinTransaction } from '~/infra/database/transaction';
+import { withinKyselyTransaction } from '~/infra/database/kysely-transaction';
 import { CampaignApi } from '~/models/CampaignApi';
 import { HousingApi } from '~/models/HousingApi';
 
@@ -11,18 +11,24 @@ const insertHousingList = async (
   campaignId: string,
   housingList: HousingApi[]
 ): Promise<void> => {
-  await withinTransaction(async (transaction) => {
-    await CampaignsHousing(transaction)
-      .insert(
+  if (housingList.length === 0) {
+    return;
+  }
+
+  await withinKyselyTransaction(async (trx) => {
+    await trx
+      .insertInto('campaignsHousing')
+      .values(
         housingList.map((housing) => ({
-          campaign_id: campaignId,
-          housing_id: housing.id,
-          housing_geo_code: housing.geoCode
+          campaignId,
+          housingId: housing.id,
+          housingGeoCode: housing.geoCode
         }))
       )
-      .onConflict(['campaign_id', 'housing_id', 'housing_geo_code'])
-      .ignore()
-      .returning('housing_id');
+      .onConflict((oc) =>
+        oc.columns(['campaignId', 'housingId', 'housingGeoCode']).doNothing()
+      )
+      .execute();
   });
 };
 
@@ -34,14 +40,21 @@ async function removeMany(
     return;
   }
 
-  await withinTransaction(async (transaction) => {
-    await CampaignsHousing(transaction)
-      .where({ campaign_id: campaign.id })
-      .whereIn(
-        ['housing_geo_code', 'housing_id'],
-        housings.map((housing) => [housing.geoCode, housing.id])
+  await withinKyselyTransaction(async (trx) => {
+    await trx
+      .deleteFrom('campaignsHousing')
+      .where('campaignId', '=', campaign.id)
+      .where((eb) =>
+        eb.or(
+          housings.map((housing) =>
+            eb.and([
+              eb('housingGeoCode', '=', housing.geoCode),
+              eb('housingId', '=', housing.id)
+            ])
+          )
+        )
       )
-      .delete();
+      .execute();
   });
 }
 

--- a/server/src/repositories/campaignHousingRepository.ts
+++ b/server/src/repositories/campaignHousingRepository.ts
@@ -1,3 +1,6 @@
+import { Array } from 'effect';
+import pMap from 'p-map';
+
 import db from '~/infra/database';
 import { withinKyselyTransaction } from '~/infra/database/kysely-transaction';
 import { CampaignApi } from '~/models/CampaignApi';
@@ -6,6 +9,10 @@ import { HousingApi } from '~/models/HousingApi';
 export const campaignsHousingTable = 'campaigns_housing';
 export const CampaignsHousing = (transaction = db) =>
   transaction<CampaignHousingDBO>(campaignsHousingTable);
+
+// Matches Knex's batchInsert default chunk size, replicated manually to keep the
+// bulk delete under Postgres's 65535 bind-parameter limit (2 params per housing).
+const INSERT_BATCH_SIZE = 1000;
 
 const insertHousingList = async (
   campaignId: string,
@@ -41,20 +48,26 @@ async function removeMany(
   }
 
   await withinKyselyTransaction(async (trx) => {
-    await trx
-      .deleteFrom('campaignsHousing')
-      .where('campaignId', '=', campaign.id)
-      .where((eb) =>
-        eb.or(
-          housings.map((housing) =>
-            eb.and([
-              eb('housingGeoCode', '=', housing.geoCode),
-              eb('housingId', '=', housing.id)
-            ])
+    await pMap(
+      Array.chunksOf(housings, INSERT_BATCH_SIZE),
+      async (batch) => {
+        await trx
+          .deleteFrom('campaignsHousing')
+          .where('campaignId', '=', campaign.id)
+          .where((eb) =>
+            eb.or(
+              batch.map((housing) =>
+                eb.and([
+                  eb('housingGeoCode', '=', housing.geoCode),
+                  eb('housingId', '=', housing.id)
+                ])
+              )
+            )
           )
-        )
-      )
-      .execute();
+          .execute();
+      },
+      { concurrency: 1 }
+    );
   });
 }
 

--- a/server/src/repositories/campaignRepository.ts
+++ b/server/src/repositories/campaignRepository.ts
@@ -1,8 +1,10 @@
 import { CampaignStatus, HousingFiltersDTO } from '@zerologementvacant/models';
 import { Knex } from 'knex';
+import type { Insertable } from 'kysely';
 
 import db from '~/infra/database';
-import { withinTransaction } from '~/infra/database/transaction';
+import type { DB } from '~/infra/database/db';
+import { withinKyselyTransaction } from '~/infra/database/kysely-transaction';
 import { logger } from '~/infra/logger';
 import { CampaignApi, CampaignSortApi } from '~/models/CampaignApi';
 import { CampaignFiltersApi } from '~/models/CampaignFiltersApi';
@@ -134,13 +136,53 @@ const insert = async (campaignApi: CampaignApi): Promise<CampaignApi> => {
 
 async function save(campaign: CampaignApi): Promise<void> {
   logger.debug('Saving campaign', campaign);
-  await withinTransaction(async (transaction) => {
-    await Campaigns(transaction)
-      .insert(formatCampaignApi(campaign))
-      .onConflict(['id'])
-      .merge(['status', 'title', 'description', 'file', 'sent_at']);
+  await withinKyselyTransaction(async (trx) => {
+    await trx
+      .insertInto('campaigns')
+      .values(toCampaignInsert(campaign))
+      .onConflict((oc) =>
+        oc.column('id').doUpdateSet((eb) => ({
+          status: eb.ref('excluded.status'),
+          title: eb.ref('excluded.title'),
+          description: eb.ref('excluded.description'),
+          file: eb.ref('excluded.file'),
+          sentAt: eb.ref('excluded.sentAt')
+        }))
+      )
+      .execute();
   });
   logger.debug('Campaign saved', campaign);
+}
+
+function toCampaignInsert(campaign: CampaignApi): Insertable<DB['campaigns']> {
+  return {
+    id: campaign.id,
+    establishmentId: campaign.establishmentId,
+    status: campaign.status,
+    filters: campaign.filters as Insertable<DB['campaigns']>['filters'],
+    file: campaign.file,
+    title: campaign.title,
+    description: campaign.description,
+    userId: campaign.userId,
+    createdAt: new Date(campaign.createdAt),
+    validatedAt: campaign.validatedAt
+      ? new Date(campaign.validatedAt)
+      : undefined,
+    exportedAt: campaign.exportedAt
+      ? new Date(campaign.exportedAt)
+      : undefined,
+    sentAt: campaign.sentAt
+      ? new Date(campaign.sentAt.slice(0, 'yyyy-mm-dd'.length))
+      : undefined,
+    archivedAt: campaign.archivedAt
+      ? new Date(campaign.archivedAt)
+      : undefined,
+    confirmedAt: campaign.confirmedAt
+      ? new Date(campaign.confirmedAt)
+      : undefined,
+    groupId: campaign.groupId,
+    returnCount: campaign.returnCount ?? 0
+  };
 }
 
 const update = async (campaignApi: CampaignApi): Promise<string> => {
@@ -153,9 +195,9 @@ const update = async (campaignApi: CampaignApi): Promise<string> => {
 
 async function remove(id: string): Promise<void> {
   logger.debug('Removing campaign...', { id });
-  await withinTransaction(async (transaction) => {
+  await withinKyselyTransaction(async (trx) => {
     await eventRepository.removeCampaignEvents(id);
-    await Campaigns(transaction).where({ id }).delete();
+    await trx.deleteFrom('campaigns').where('id', '=', id).execute();
   });
   logger.debug('Campaign removed', { id });
 }

--- a/server/src/repositories/campaignRepository.ts
+++ b/server/src/repositories/campaignRepository.ts
@@ -4,7 +4,10 @@ import type { Insertable } from 'kysely';
 
 import db from '~/infra/database';
 import type { DB } from '~/infra/database/db';
-import { withinKyselyTransaction } from '~/infra/database/kysely-transaction';
+import {
+  runWithinKyselyTransaction,
+  withinKyselyTransaction
+} from '~/infra/database/kysely-transaction';
 import { logger } from '~/infra/logger';
 import { CampaignApi, CampaignSortApi } from '~/models/CampaignApi';
 import { CampaignFiltersApi } from '~/models/CampaignFiltersApi';
@@ -168,15 +171,11 @@ function toCampaignInsert(campaign: CampaignApi): Insertable<DB['campaigns']> {
     validatedAt: campaign.validatedAt
       ? new Date(campaign.validatedAt)
       : undefined,
-    exportedAt: campaign.exportedAt
-      ? new Date(campaign.exportedAt)
-      : undefined,
+    exportedAt: campaign.exportedAt ? new Date(campaign.exportedAt) : undefined,
     sentAt: campaign.sentAt
       ? new Date(campaign.sentAt.slice(0, 'yyyy-mm-dd'.length))
       : undefined,
-    archivedAt: campaign.archivedAt
-      ? new Date(campaign.archivedAt)
-      : undefined,
+    archivedAt: campaign.archivedAt ? new Date(campaign.archivedAt) : undefined,
     confirmedAt: campaign.confirmedAt
       ? new Date(campaign.confirmedAt)
       : undefined,
@@ -196,7 +195,12 @@ const update = async (campaignApi: CampaignApi): Promise<string> => {
 async function remove(id: string): Promise<void> {
   logger.debug('Removing campaign...', { id });
   await withinKyselyTransaction(async (trx) => {
-    await eventRepository.removeCampaignEvents(id);
+    // Seed the ambient transaction so removeCampaignEvents joins this trx
+    // instead of opening its own — otherwise the two deletes are not atomic
+    // (same wiring startTransaction uses to make repos share one unit).
+    await runWithinKyselyTransaction(trx, () =>
+      eventRepository.removeCampaignEvents(id)
+    );
     await trx.deleteFrom('campaigns').where('id', '=', id).execute();
   });
   logger.debug('Campaign removed', { id });

--- a/server/src/repositories/draftRepository.ts
+++ b/server/src/repositories/draftRepository.ts
@@ -1,10 +1,12 @@
 import { FileUploadDTO } from '@zerologementvacant/models';
 import async from 'async';
 import { Knex } from 'knex';
+import type { Insertable } from 'kysely';
 
 import { download } from '~/controllers/fileRepository';
 import db from '~/infra/database';
-import { withinTransaction } from '~/infra/database/transaction';
+import type { DB } from '~/infra/database/db';
+import { withinKyselyTransaction } from '~/infra/database/kysely-transaction';
 import { createLogger } from '~/infra/logger';
 import { DraftApi } from '~/models/DraftApi';
 import { campaignsDraftsTable } from '~/repositories/campaignDraftRepository';
@@ -67,23 +69,43 @@ async function findOne(opts: FindOneOptions): Promise<DraftApi | null> {
 
 async function save(draft: DraftApi): Promise<void> {
   logger.debug('Saving draft...', draft);
-  await withinTransaction(async (transaction) => {
-    await Drafts(transaction)
-      .insert(formatDraftApi(draft))
-      .onConflict('id')
-      .merge([
-        'subject',
-        'body',
-        'logo',
-        'logo_next_one',
-        'logo_next_two',
-        'written_at',
-        'written_from',
-        'updated_at',
-        'sender_id'
-      ]);
+  await withinKyselyTransaction(async (trx) => {
+    await trx
+      .insertInto('drafts')
+      .values(toDraftInsert(draft))
+      .onConflict((oc) =>
+        oc.column('id').doUpdateSet((eb) => ({
+          subject: eb.ref('excluded.subject'),
+          body: eb.ref('excluded.body'),
+          logo: eb.ref('excluded.logo'),
+          logoNextOne: eb.ref('excluded.logoNextOne'),
+          logoNextTwo: eb.ref('excluded.logoNextTwo'),
+          writtenAt: eb.ref('excluded.writtenAt'),
+          writtenFrom: eb.ref('excluded.writtenFrom'),
+          updatedAt: eb.ref('excluded.updatedAt'),
+          senderId: eb.ref('excluded.senderId')
+        }))
+      )
+      .execute();
   });
   logger.debug('Saved draft', draft);
+}
+
+function toDraftInsert(draft: DraftApi): Insertable<DB['drafts']> {
+  return {
+    id: draft.id,
+    subject: draft.subject,
+    body: draft.body,
+    logo: draft.logo?.map((logo) => logo.id) ?? null,
+    logoNextOne: draft.logoNext?.[0]?.id ?? null,
+    logoNextTwo: draft.logoNext?.[1]?.id ?? null,
+    writtenAt: draft.writtenAt,
+    writtenFrom: draft.writtenFrom,
+    establishmentId: draft.establishmentId,
+    senderId: draft.senderId,
+    createdAt: new Date(draft.createdAt),
+    updatedAt: new Date(draft.updatedAt)
+  };
 }
 
 function listQuery(query: Knex.QueryBuilder): void {

--- a/server/src/repositories/eventRepository.ts
+++ b/server/src/repositories/eventRepository.ts
@@ -159,13 +159,37 @@ async function insertManyCampaignHousingEvents(
   logger.debug('Inserting campaign housing events...', {
     events: events.length
   });
-  await withinTransaction(async (transaction) => {
-    await transaction.batchInsert(EVENTS_TABLE, events.map(formatEventApi));
-    await transaction.batchInsert(
-      CAMPAIGN_HOUSING_EVENTS_TABLE,
-      events.map(formatCampaignHousingEventApi)
-    );
+  await withinKyselyTransaction(async (trx) => {
+    await trx.insertInto('events').values(events.map(toEventInsert)).execute();
+    await trx
+      .insertInto('campaignHousingEvents')
+      .values(events.map(toCampaignHousingEventInsert))
+      .execute();
   });
+}
+
+function toEventInsert<Type extends EventType>(
+  event: EventApi<Type>
+): Insertable<DB['events']> {
+  return {
+    id: event.id,
+    type: event.type,
+    nextOld: event.nextOld as Insertable<DB['events']>['nextOld'],
+    nextNew: event.nextNew as Insertable<DB['events']>['nextNew'],
+    createdAt: new Date(event.createdAt),
+    createdBy: event.createdBy
+  };
+}
+
+function toCampaignHousingEventInsert(
+  event: CampaignHousingEventApi
+): Insertable<DB['campaignHousingEvents']> {
+  return {
+    eventId: event.id,
+    campaignId: event.campaignId,
+    housingGeoCode: event.housingGeoCode,
+    housingId: event.housingId
+  };
 }
 
 async function insertManyCampaignEvents(
@@ -397,15 +421,16 @@ async function removeCampaignEvents(campaignId: string): Promise<void> {
   logger.debug('Removing campaign events...', {
     campaign: campaignId
   });
-  await withinTransaction(async (transaction) => {
-    await Events(transaction)
-      .join(
-        CAMPAIGN_EVENTS_TABLE,
-        `${CAMPAIGN_EVENTS_TABLE}.event_id`,
-        `${EVENTS_TABLE}.id`
+  await withinKyselyTransaction(async (trx) => {
+    await trx
+      .deleteFrom('events')
+      .where('id', 'in', (qb) =>
+        qb
+          .selectFrom('campaignEvents')
+          .select('eventId')
+          .where('campaignId', '=', campaignId)
       )
-      .where(`${CAMPAIGN_EVENTS_TABLE}.campaign_id`, campaignId)
-      .delete();
+      .execute();
   });
   logger.debug('Campaign events removed', {
     campaign: campaignId

--- a/server/src/repositories/eventRepository.ts
+++ b/server/src/repositories/eventRepository.ts
@@ -160,25 +160,18 @@ async function insertManyCampaignHousingEvents(
     events: events.length
   });
   await withinKyselyTransaction(async (trx) => {
-    await trx.insertInto('events').values(events.map(toEventInsert)).execute();
-    await trx
-      .insertInto('campaignHousingEvents')
-      .values(events.map(toCampaignHousingEventInsert))
-      .execute();
+    await pMap(
+      Array.chunksOf(events, INSERT_BATCH_SIZE),
+      async (batch) => {
+        await trx.insertInto('events').values(batch.map(toEventDBO)).execute();
+        await trx
+          .insertInto('campaignHousingEvents')
+          .values(batch.map(toCampaignHousingEventInsert))
+          .execute();
+      },
+      { concurrency: 1 }
+    );
   });
-}
-
-function toEventInsert<Type extends EventType>(
-  event: EventApi<Type>
-): Insertable<DB['events']> {
-  return {
-    id: event.id,
-    type: event.type,
-    nextOld: event.nextOld as Insertable<DB['events']>['nextOld'],
-    nextNew: event.nextNew as Insertable<DB['events']>['nextNew'],
-    createdAt: new Date(event.createdAt),
-    createdBy: event.createdBy
-  };
 }
 
 function toCampaignHousingEventInsert(

--- a/server/src/repositories/senderRepository.ts
+++ b/server/src/repositories/senderRepository.ts
@@ -1,6 +1,9 @@
+import type { Insertable } from 'kysely';
+
 import { download } from '~/controllers/fileRepository';
 import db, { where } from '~/infra/database';
-import { withinTransaction } from '~/infra/database/transaction';
+import type { DB } from '~/infra/database/db';
+import { withinKyselyTransaction } from '~/infra/database/kysely-transaction';
 import { createLogger } from '~/infra/logger';
 import { SenderApi } from '~/models/SenderApi';
 import {
@@ -51,32 +54,61 @@ async function findOne(opts: FindOneOptions): Promise<SenderApi | null> {
 
 async function save(sender: SenderApi): Promise<void> {
   logger.debug('Saving sender...', sender);
-  await withinTransaction(async (transaction) => {
-    await Senders(transaction)
-      .insert(formatSenderApi(sender))
-      .onConflict('id')
-      .merge([
-        'name',
-        'service',
-        'first_name',
-        'last_name',
-        'address',
-        'email',
-        'phone',
-        'signatory_one_last_name',
-        'signatory_one_first_name',
-        'signatory_one_role',
-        'signatory_one_file',
-        'signatory_one_document_id',
-        'signatory_two_first_name',
-        'signatory_two_last_name',
-        'signatory_two_role',
-        'signatory_two_file',
-        'signatory_two_document_id',
-        'updated_at'
-      ]);
+  await withinKyselyTransaction(async (trx) => {
+    await trx
+      .insertInto('senders')
+      .values(toSenderInsert(sender))
+      .onConflict((oc) =>
+        oc.column('id').doUpdateSet((eb) => ({
+          name: eb.ref('excluded.name'),
+          service: eb.ref('excluded.service'),
+          firstName: eb.ref('excluded.firstName'),
+          lastName: eb.ref('excluded.lastName'),
+          address: eb.ref('excluded.address'),
+          email: eb.ref('excluded.email'),
+          phone: eb.ref('excluded.phone'),
+          signatoryOneLastName: eb.ref('excluded.signatoryOneLastName'),
+          signatoryOneFirstName: eb.ref('excluded.signatoryOneFirstName'),
+          signatoryOneRole: eb.ref('excluded.signatoryOneRole'),
+          signatoryOneFile: eb.ref('excluded.signatoryOneFile'),
+          signatoryOneDocumentId: eb.ref('excluded.signatoryOneDocumentId'),
+          signatoryTwoFirstName: eb.ref('excluded.signatoryTwoFirstName'),
+          signatoryTwoLastName: eb.ref('excluded.signatoryTwoLastName'),
+          signatoryTwoRole: eb.ref('excluded.signatoryTwoRole'),
+          signatoryTwoFile: eb.ref('excluded.signatoryTwoFile'),
+          signatoryTwoDocumentId: eb.ref('excluded.signatoryTwoDocumentId'),
+          updatedAt: eb.ref('excluded.updatedAt')
+        }))
+      )
+      .execute();
   });
   logger.debug('Saved sender', sender);
+}
+
+function toSenderInsert(sender: SenderApi): Insertable<DB['senders']> {
+  return {
+    id: sender.id,
+    name: sender.name,
+    service: sender.service,
+    firstName: sender.firstName,
+    lastName: sender.lastName,
+    address: sender.address,
+    email: sender.email,
+    phone: sender.phone,
+    signatoryOneFirstName: sender.signatories?.[0]?.firstName ?? null,
+    signatoryOneLastName: sender.signatories?.[0]?.lastName ?? null,
+    signatoryOneRole: sender.signatories?.[0]?.role ?? null,
+    signatoryOneFile: sender.signatories?.[0]?.file?.id ?? null,
+    signatoryOneDocumentId: sender.signatories?.[0]?.document?.id ?? null,
+    signatoryTwoFirstName: sender.signatories?.[1]?.firstName ?? null,
+    signatoryTwoLastName: sender.signatories?.[1]?.lastName ?? null,
+    signatoryTwoRole: sender.signatories?.[1]?.role ?? null,
+    signatoryTwoFile: sender.signatories?.[1]?.file?.id ?? null,
+    signatoryTwoDocumentId: sender.signatories?.[1]?.document?.id ?? null,
+    createdAt: new Date(sender.createdAt),
+    updatedAt: new Date(sender.updatedAt),
+    establishmentId: sender.establishmentId
+  };
 }
 
 export interface SenderDBO {


### PR DESCRIPTION
## Summary

Second — and largest — **transaction-cluster** migration (independent PR, base `feat/kysely-setup`), after the group cluster (#1900). `campaignController` saves `sender → draft → campaign → campaignDraft → campaignHousing` in one `startTransaction` and `eventRepository` writes `campaign_housing_events`. These are FK-linked:

- `campaigns_housing → campaigns`
- `campaigns_drafts → campaigns` / `drafts`
- `campaign_housing_events → campaigns` / `events`
- `campaign_events → campaigns` / `events`

so they can't be split across engines behind the visibility-less bridge (same class of failure that reverted the standalone `campaignHousing` attempt). They move to Kysely **together**:

- **`campaignRepository`**: `save` (upsert), `remove` (deletes the campaign after `removeCampaignEvents`) via `withinKyselyTransaction`. `insert`/`update` have **no app callers** → left on Knex; all **reads** stay on Knex.
- **`draftRepository.save`, `senderRepository.save`, `campaignDraftRepository.save`**: upserts migrated (`doUpdateSet` with `excluded` refs mirroring the Knex `.merge` lists). Draft/sender **reads** keep the Knex `joinDocumentWithCreator` helper.
- **`campaignHousingRepository.insertHousingList` / `removeMany`** → Kysely — now safe, because `campaigns` is written by Kysely in the same transaction, so the FK resolves.
- **`eventRepository.insertManyCampaignHousingEvents` and `removeCampaignEvents`** → Kysely (`events` + `campaign_housing_events`; the delete-via-join becomes a subquery, cascading `campaign_events` as before). `insertManyCampaignEvents` has no app callers and is untouched; **all other event methods stay on Knex**.

`housing.updateMany`/`saveMany` + `insertManyHousingEvents` stay on Knex (housing pre-committed, disjoint tables). The full exported Knex surface (accessors, DBO types, `format*Api`/`parse*Api`) is preserved for seeds, tests, and the reads.

## Test plan

- [x] `yarn nx test server -- run src/repositories/test/campaignRepository.test.ts src/repositories/test/campaignHousingRepository.test.ts src/repositories/test/eventRepository.test.ts src/controllers/test/campaign-api.test.ts src/controllers/test/draft-api.test.ts` — 147/147 (covers create/remove/removeHousing FK paths)
- [x] `yarn nx test server -- run src/repositories/test/draftRepository.test.ts src/controllers/test/group-api.test.ts src/controllers/test/housing-api.test.ts` — 109/109 (untouched event methods + other clusters intact)
- [x] `yarn nx typecheck server` — clean (only pre-existing `@deprecated`-field hints, mirrored from the `format*Api` functions)
- [x] `yarn lint` — clean on the six files

🤖 Generated with [Claude Code](https://claude.com/claude-code)