### PR TITLE
feat(server): migrate the housing+owner+housingOwner mega-cluster to Kysely

### DIFF
--- a/server/src/repositories/eventRepository.ts
+++ b/server/src/repositories/eventRepository.ts
@@ -79,30 +79,23 @@ async function insertManyHousingEvents(
 
   logger.debug('Inserting housing events...', { events: events.length });
   await withinKyselyTransaction(async (trx) => {
-    await trx
-      .insertInto('events')
-      .values(events.map(toEventInsert))
-      .onConflict((oc) => oc.column('id').doNothing())
-      .execute();
-    await trx
-      .insertInto('housingEvents')
-      .values(events.map(toHousingEventInsert))
-      .onConflict((oc) => oc.column('eventId').doNothing())
-      .execute();
+    await pMap(
+      Array.chunksOf(events, INSERT_BATCH_SIZE),
+      async (batch) => {
+        await trx
+          .insertInto('events')
+          .values(batch.map(toEventDBO))
+          .onConflict((oc) => oc.column('id').doNothing())
+          .execute();
+        await trx
+          .insertInto('housingEvents')
+          .values(batch.map(toHousingEventInsert))
+          .onConflict((oc) => oc.column('eventId').doNothing())
+          .execute();
+      },
+      { concurrency: 1 }
+    );
   });
-}
-
-function toEventInsert<Type extends EventType>(
-  event: EventApi<Type>
-): Insertable<DB['events']> {
-  return {
-    id: event.id,
-    type: event.type,
-    nextOld: event.nextOld as Insertable<DB['events']>['nextOld'],
-    nextNew: event.nextNew as Insertable<DB['events']>['nextNew'],
-    createdAt: new Date(event.createdAt),
-    createdBy: event.createdBy
-  };
 }
 
 function toHousingEventInsert(
@@ -146,16 +139,22 @@ async function insertManyHousingOwnerEvents(
     events: events.length
   });
   await withinKyselyTransaction(async (trx) => {
-    await trx
-      .insertInto('events')
-      .values(events.map(toEventInsert))
-      .onConflict((oc) => oc.column('id').doNothing())
-      .execute();
-    await trx
-      .insertInto('housingOwnerEvents')
-      .values(events.map(toHousingOwnerEventInsert))
-      .onConflict((oc) => oc.column('eventId').doNothing())
-      .execute();
+    await pMap(
+      Array.chunksOf(events, INSERT_BATCH_SIZE),
+      async (batch) => {
+        await trx
+          .insertInto('events')
+          .values(batch.map(toEventDBO))
+          .onConflict((oc) => oc.column('id').doNothing())
+          .execute();
+        await trx
+          .insertInto('housingOwnerEvents')
+          .values(batch.map(toHousingOwnerEventInsert))
+          .onConflict((oc) => oc.column('eventId').doNothing())
+          .execute();
+      },
+      { concurrency: 1 }
+    );
   });
 }
 
@@ -188,11 +187,17 @@ async function insertManyOwnerEvents(
 
   logger.debug('Inserting owner events...', { events: events.length });
   await withinKyselyTransaction(async (trx) => {
-    await trx.insertInto('events').values(events.map(toEventInsert)).execute();
-    await trx
-      .insertInto('ownerEvents')
-      .values(events.map(toOwnerEventInsert))
-      .execute();
+    await pMap(
+      Array.chunksOf(events, INSERT_BATCH_SIZE),
+      async (batch) => {
+        await trx.insertInto('events').values(batch.map(toEventDBO)).execute();
+        await trx
+          .insertInto('ownerEvents')
+          .values(batch.map(toOwnerEventInsert))
+          .execute();
+      },
+      { concurrency: 1 }
+    );
   });
 }
 

--- a/server/src/repositories/eventRepository.ts
+++ b/server/src/repositories/eventRepository.ts
@@ -78,16 +78,61 @@ async function insertManyHousingEvents(
   }
 
   logger.debug('Inserting housing events...', { events: events.length });
-  await withinTransaction(async (transaction) => {
-    await transaction(EVENTS_TABLE)
-      .insert(events.map(formatEventApi))
-      .onConflict('id')
-      .ignore();
-    await transaction(HOUSING_EVENTS_TABLE)
-      .insert(events.map(formatHousingEventApi))
-      .onConflict('event_id')
-      .ignore();
+  await withinKyselyTransaction(async (trx) => {
+    await trx
+      .insertInto('events')
+      .values(events.map(toEventInsert))
+      .onConflict((oc) => oc.column('id').doNothing())
+      .execute();
+    await trx
+      .insertInto('housingEvents')
+      .values(events.map(toHousingEventInsert))
+      .onConflict((oc) => oc.column('eventId').doNothing())
+      .execute();
   });
+}
+
+function toEventInsert<Type extends EventType>(
+  event: EventApi<Type>
+): Insertable<DB['events']> {
+  return {
+    id: event.id,
+    type: event.type,
+    nextOld: event.nextOld as Insertable<DB['events']>['nextOld'],
+    nextNew: event.nextNew as Insertable<DB['events']>['nextNew'],
+    createdAt: new Date(event.createdAt),
+    createdBy: event.createdBy
+  };
+}
+
+function toHousingEventInsert(
+  event: HousingEventApi
+): Insertable<DB['housingEvents']> {
+  return {
+    eventId: event.id,
+    housingGeoCode: event.housingGeoCode,
+    housingId: event.housingId
+  };
+}
+
+function toOwnerEventInsert(
+  event: OwnerEventApi
+): Insertable<DB['ownerEvents']> {
+  return {
+    eventId: event.id,
+    ownerId: event.ownerId
+  };
+}
+
+function toHousingOwnerEventInsert(
+  event: HousingOwnerEventApi
+): Insertable<DB['housingOwnerEvents']> {
+  return {
+    eventId: event.id,
+    housingGeoCode: event.housingGeoCode,
+    housingId: event.housingId,
+    ownerId: event.ownerId ?? null
+  };
 }
 
 async function insertManyHousingOwnerEvents(
@@ -100,15 +145,17 @@ async function insertManyHousingOwnerEvents(
   logger.debug('Inserting housing owner events...', {
     events: events.length
   });
-  await withinTransaction(async (transaction) => {
-    await transaction(EVENTS_TABLE)
-      .insert(events.map(formatEventApi))
-      .onConflict('id')
-      .ignore();
-    await transaction(HOUSING_OWNER_EVENTS_TABLE)
-      .insert(events.map(formatHousingOwnerEventApi))
-      .onConflict('event_id')
-      .ignore();
+  await withinKyselyTransaction(async (trx) => {
+    await trx
+      .insertInto('events')
+      .values(events.map(toEventInsert))
+      .onConflict((oc) => oc.column('id').doNothing())
+      .execute();
+    await trx
+      .insertInto('housingOwnerEvents')
+      .values(events.map(toHousingOwnerEventInsert))
+      .onConflict((oc) => oc.column('eventId').doNothing())
+      .execute();
   });
 }
 
@@ -140,12 +187,12 @@ async function insertManyOwnerEvents(
   }
 
   logger.debug('Inserting owner events...', { events: events.length });
-  await withinTransaction(async (transaction) => {
-    await transaction.batchInsert(EVENTS_TABLE, events.map(formatEventApi));
-    await transaction.batchInsert(
-      OWNER_EVENTS_TABLE,
-      events.map(formatOwnerEventApi)
-    );
+  await withinKyselyTransaction(async (trx) => {
+    await trx.insertInto('events').values(events.map(toEventInsert)).execute();
+    await trx
+      .insertInto('ownerEvents')
+      .values(events.map(toOwnerEventInsert))
+      .execute();
   });
 }
 

--- a/server/src/repositories/housingOwnerRepository.ts
+++ b/server/src/repositories/housingOwnerRepository.ts
@@ -3,10 +3,13 @@ import type {
   RelativeLocationFilter
 } from '@zerologementvacant/models';
 import { OwnerRank, PropertyRight } from '@zerologementvacant/models';
+import type { Insertable } from 'kysely';
 import { match } from 'ts-pattern';
 
 import db from '~/infra/database';
-import { withinTransaction } from '~/infra/database/transaction';
+import type { DB } from '~/infra/database/db';
+import { kysely } from '~/infra/database/kysely';
+import { withinKyselyTransaction } from '~/infra/database/kysely-transaction';
 import { logger } from '~/infra/logger';
 import { HousingRecordApi } from '~/models/HousingApi';
 import { HousingOwnerApi } from '~/models/HousingOwnerApi';
@@ -75,11 +78,38 @@ async function insert(housingOwner: HousingOwnerApi): Promise<void> {
     housingOwner
   });
 
-  await HousingOwners()
-    .insert(formatHousingOwnerApi(housingOwner))
-    .onConflict()
-    .ignore();
+  await kysely
+    .insertInto('ownersHousing')
+    .values(toHousingOwnerInsert(housingOwner))
+    .onConflict((oc) => oc.doNothing())
+    .execute();
   logger.debug('Saved housing owner.');
+}
+
+// Camel-case Insertable mirror of formatHousingOwnerApi. start_date/end_date are
+// `date` columns typed as string by kysely-codegen; the API carries Date values,
+// so they are passed through unchanged (pg serializes them exactly as Knex did).
+function toHousingOwnerInsert(
+  housingOwner: Omit<HousingOwnerApi, keyof OwnerApi>
+): Insertable<DB['ownersHousing']> {
+  return {
+    ownerId: housingOwner.ownerId,
+    housingId: housingOwner.housingId,
+    housingGeoCode: housingOwner.housingGeoCode,
+    rank: housingOwner.rank,
+    startDate: housingOwner.startDate as unknown as string | null,
+    endDate: housingOwner.endDate as unknown as string | null,
+    origin: housingOwner.origin,
+    idprocpte: housingOwner.idprocpte,
+    idprodroit: housingOwner.idprodroit,
+    locpropSource:
+      typeof housingOwner.locprop === 'number'
+        ? String(housingOwner.locprop)
+        : null,
+    locpropRelativeBan: toRelativeLocationDBO(housingOwner.relativeLocation),
+    locpropDistanceBan: housingOwner.absoluteDistance,
+    propertyRight: housingOwner.propertyRight
+  };
 }
 
 async function saveMany(
@@ -97,19 +127,25 @@ async function saveMany(
   let affectedOwnerIds: string[] = newOwnerIds;
 
   // Remove owners before inserting them back
-  await withinTransaction(async (transaction) => {
-    const existing = await HousingOwners(transaction)
-      .where({ housing_geo_code: housingGeoCode, housing_id: housingId })
-      .select('owner_id');
+  await withinKyselyTransaction(async (trx) => {
+    const existing = await trx
+      .selectFrom('ownersHousing')
+      .where('housingGeoCode', '=', housingGeoCode)
+      .where('housingId', '=', housingId)
+      .select('ownerId')
+      .execute();
     affectedOwnerIds = [
-      ...new Set([...existing.map((r) => r.owner_id), ...newOwnerIds])
+      ...new Set([...existing.map((row) => row.ownerId), ...newOwnerIds])
     ];
-    await HousingOwners(transaction)
-      .where({ housing_geo_code: housingGeoCode, housing_id: housingId })
-      .delete();
-    await HousingOwners(transaction).insert(
-      housingOwners.map(formatHousingOwnerApi)
-    );
+    await trx
+      .deleteFrom('ownersHousing')
+      .where('housingGeoCode', '=', housingGeoCode)
+      .where('housingId', '=', housingId)
+      .execute();
+    await trx
+      .insertInto('ownersHousing')
+      .values(housingOwners.map(toHousingOwnerInsert))
+      .execute();
   });
 
   logger.debug(`Saved ${housingOwners.length} housing owners.`);

--- a/server/src/repositories/housingRepository.ts
+++ b/server/src/repositories/housingRepository.ts
@@ -23,6 +23,7 @@ import {
 } from '@zerologementvacant/models';
 import { compactUndefined, isNotNull } from '@zerologementvacant/utils';
 import { Array, identity, Predicate, Struct } from 'effect';
+import { snakeToCamel } from 'effect/String';
 import type { Point } from 'geojson';
 import { Set } from 'immutable';
 import { Knex } from 'knex';
@@ -310,12 +311,19 @@ async function saveMany(
       .values(housingList.map(toHousingInsert))
       .onConflict((oc) => {
         const conflict = oc.columns(['geoCode', 'localId']);
-        if (opts?.onConflict === 'merge') {
-          return conflict.doUpdateSet((eb: any) =>
-            buildHousingMergeSet(eb, opts?.merge)
-          );
+        if (opts?.onConflict !== 'merge') {
+          return conflict.doNothing();
         }
-        return conflict.doNothing();
+        const columns = housingMergeColumns(opts?.merge);
+        // An explicit empty merge list means "update nothing on conflict".
+        if (columns.length === 0) {
+          return conflict.doNothing();
+        }
+        return conflict.doUpdateSet((eb: any) =>
+          Object.fromEntries(
+            columns.map((column) => [column, eb.ref(`excluded.${column}`)])
+          )
+        );
       })
       .execute();
   });
@@ -327,9 +335,6 @@ type HousingInclude =
   | 'perimeters'
   | 'precisions'
   | 'buildings';
-
-const snakeToCamel = (value: string): string =>
-  value.replace(/_([a-z])/g, (_match, char: string) => char.toUpperCase());
 
 // Camel-case Insertable mirror of formatHousingRecordApi for the Kysely write
 // path. plot_area/occupancy_history are READ_ONLY (nullable, no default): set
@@ -390,20 +395,26 @@ function toHousingInsert(
   };
 }
 
-// Reproduces Knex `.merge(columns)` for Kysely. Callers pass snake_case columns
-// (keyof HousingRecordDBO); undefined means "merge all inserted fields". The
-// conflict-key columns are excluded (updating them to excluded.* is a no-op).
-function buildHousingMergeSet(
-  eb: any,
-  merge?: Array<keyof HousingRecordDBO>
-): Record<string, unknown> {
-  const columns = (
-    merge && merge.length
+// Reproduces Knex `.merge(columns)` for Kysely: returns the camelCase columns to
+// update on conflict. Callers pass snake_case columns (keyof HousingRecordDBO);
+// `undefined` means "merge all inserted fields" and an empty array means none.
+// The conflict-key columns are always excluded (updating them to excluded.* is a
+// no-op), and so are the READ_ONLY plotArea/occupancyHistory: toHousingInsert
+// forces those to null, so merging them would wipe LOVAC-imported values — the
+// Knex path omitted them via `Omit<HousingRecordDBO, READ_ONLY_FIELDS>`.
+const HOUSING_NON_MERGEABLE_COLUMNS = [
+  'geoCode',
+  'localId',
+  'plotArea',
+  'occupancyHistory'
+];
+function housingMergeColumns(merge?: Array<keyof HousingRecordDBO>): string[] {
+  const columns =
+    merge !== undefined
       ? merge.map((column) => snakeToCamel(column as string))
-      : Object.keys(toHousingInsert({} as HousingRecordApi))
-  ).filter((column) => column !== 'geoCode' && column !== 'localId');
-  return Object.fromEntries(
-    columns.map((column) => [column, eb.ref(`excluded.${column}`)])
+      : Object.keys(toHousingInsert({} as HousingRecordApi));
+  return columns.filter(
+    (column) => !HOUSING_NON_MERGEABLE_COLUMNS.includes(column)
   );
 }
 

--- a/server/src/repositories/housingRepository.ts
+++ b/server/src/repositories/housingRepository.ts
@@ -26,14 +26,14 @@ import { Array, identity, Predicate, Struct } from 'effect';
 import type { Point } from 'geojson';
 import { Set } from 'immutable';
 import { Knex } from 'knex';
+import type { Insertable } from 'kysely';
 import { uniq } from 'lodash-es';
 import { match, Pattern } from 'ts-pattern';
 
 import db, { toRawArray, where } from '~/infra/database';
-import {
-  getTransaction,
-  withinTransaction
-} from '~/infra/database/transaction';
+import type { DB } from '~/infra/database/db';
+import { kysely } from '~/infra/database/kysely';
+import { withinKyselyTransaction } from '~/infra/database/kysely-transaction';
 import { createLogger } from '~/infra/logger';
 import type { EstablishmentApi } from '~/models/EstablishmentApi';
 import {
@@ -304,17 +304,20 @@ async function saveMany(
     return;
   }
 
-  await withinTransaction(async (transaction) => {
-    await Housing(transaction)
-      .insert(housingList.map(formatHousingRecordApi))
-      .modify((builder) => {
+  await withinKyselyTransaction(async (trx) => {
+    await trx
+      .insertInto('fastHousing')
+      .values(housingList.map(toHousingInsert))
+      .onConflict((oc) => {
+        const conflict = oc.columns(['geoCode', 'localId']);
         if (opts?.onConflict === 'merge') {
-          return builder
-            .onConflict(['geo_code', 'local_id'])
-            .merge(opts?.merge);
+          return conflict.doUpdateSet((eb: any) =>
+            buildHousingMergeSet(eb, opts?.merge)
+          );
         }
-        return builder.onConflict(['geo_code', 'local_id']).ignore();
-      });
+        return conflict.doNothing();
+      })
+      .execute();
   });
 }
 
@@ -324,6 +327,85 @@ type HousingInclude =
   | 'perimeters'
   | 'precisions'
   | 'buildings';
+
+const snakeToCamel = (value: string): string =>
+  value.replace(/_([a-z])/g, (_match, char: string) => char.toUpperCase());
+
+// Camel-case Insertable mirror of formatHousingRecordApi for the Kysely write
+// path. plot_area/occupancy_history are READ_ONLY (nullable, no default): set
+// null to satisfy Insertable, matching the NULL the Knex path produced by
+// omitting them. last_mutation_type is Generated and stays omitted.
+function toHousingInsert(
+  housing: HousingRecordApi
+): Insertable<DB['fastHousing']> {
+  return {
+    id: housing.id,
+    invariant: housing.invariant,
+    localId: housing.localId,
+    plotId: housing.plotId,
+    buildingId: housing.buildingId,
+    buildingGroupId: housing.buildingGroupId,
+    buildingLocation: housing.buildingLocation,
+    buildingYear: housing.buildingYear,
+    addressDgfip: housing.rawAddress,
+    longitudeDgfip: housing.longitude,
+    latitudeDgfip: housing.latitude,
+    rentalValue: housing.rentalValue,
+    beneficiaryCount: housing.beneficiaryCount,
+    // geolocation is a PostGIS geometry column (typed `string` by codegen); the
+    // API carries a GeoJSON Point, passed through exactly as the Knex path did.
+    geolocation: housing.geolocation as unknown as string | null,
+    geoCode: housing.geoCode,
+    cadastralClassification: housing.cadastralClassification,
+    uncomfortable: housing.uncomfortable,
+    vacancyStartYear: housing.vacancyStartYear,
+    housingKind: housing.housingKind,
+    roomsCount: housing.roomsCount,
+    livingArea: housing.livingArea,
+    cadastralReference: housing.cadastralReference,
+    taxed: housing.taxed,
+    condominium: housing.ownershipKind,
+    dataYears: housing.dataYears,
+    dataFileYears: housing.dataFileYears,
+    status: housing.status,
+    subStatus: housing.subStatus ?? null,
+    actualDpe: housing.actualEnergyConsumption,
+    energyConsumptionBdnb: housing.energyConsumption,
+    energyConsumptionAtBdnb: housing.energyConsumptionAt,
+    occupancy: housing.occupancy,
+    occupancySource: housing.occupancyRegistered,
+    occupancyIntended: housing.occupancyIntended ?? null,
+    dataSource: housing.source,
+    mutationDate: null,
+    lastMutationDate: housing.lastMutationDate
+      ? new Date(housing.lastMutationDate)
+      : null,
+    lastTransactionDate: housing.lastTransactionDate
+      ? new Date(housing.lastTransactionDate)
+      : null,
+    lastTransactionValue: housing.lastTransactionValue,
+    geolocationSource: null,
+    plotArea: null,
+    occupancyHistory: null
+  };
+}
+
+// Reproduces Knex `.merge(columns)` for Kysely. Callers pass snake_case columns
+// (keyof HousingRecordDBO); undefined means "merge all inserted fields". The
+// conflict-key columns are excluded (updating them to excluded.* is a no-op).
+function buildHousingMergeSet(
+  eb: any,
+  merge?: Array<keyof HousingRecordDBO>
+): Record<string, unknown> {
+  const columns = (
+    merge && merge.length
+      ? merge.map((column) => snakeToCamel(column as string))
+      : Object.keys(toHousingInsert({} as HousingRecordApi))
+  ).filter((column) => column !== 'geoCode' && column !== 'localId');
+  return Object.fromEntries(
+    columns.map((column) => [column, eb.ref(`excluded.${column}`)])
+  );
+}
 
 interface ListQueryOptions {
   filters: HousingFiltersApi;
@@ -426,20 +508,21 @@ function include(includes: HousingInclude[], filters?: HousingFiltersApi) {
 async function update(housing: HousingApi): Promise<void> {
   logger.debug('Update housing', housing.id);
 
-  const transaction = getTransaction();
-  await Housing(transaction)
-    .where({
+  await withinKyselyTransaction(async (trx) => {
+    await trx
+      .updateTable('fastHousing')
       // Use the index on the partitioned table
-      geo_code: housing.geoCode,
-      id: housing.id
-    })
-    .update({
-      occupancy: housing.occupancy,
-      occupancy_intended: housing.occupancyIntended ?? null,
-      status: housing.status,
-      sub_status: housing.subStatus ?? null,
-      actual_dpe: housing.actualEnergyConsumption
-    });
+      .where('geoCode', '=', housing.geoCode)
+      .where('id', '=', housing.id)
+      .set({
+        occupancy: housing.occupancy,
+        occupancyIntended: housing.occupancyIntended ?? null,
+        status: housing.status,
+        subStatus: housing.subStatus ?? null,
+        actualDpe: housing.actualEnergyConsumption
+      })
+      .execute();
+  });
 }
 
 async function updateMany(
@@ -455,9 +538,9 @@ async function updateMany(
 
   const fields = compactUndefined({
     status: payload.status,
-    sub_status: payload.subStatus,
+    subStatus: payload.subStatus,
     occupancy: payload.occupancy,
-    occupancy_intended: payload.occupancyIntended
+    occupancyIntended: payload.occupancyIntended
   });
   if (Object.keys(fields).length === 0) {
     logger.debug('No fields to update. Skipping...');
@@ -468,25 +551,32 @@ async function updateMany(
     housings: housings.length,
     payload
   });
-  await withinTransaction(async (transaction) => {
-    await Housing(transaction)
-      .whereIn(
-        ['geo_code', 'id'],
-        housings.map((housing) => [housing.geoCode, housing.id])
+  await withinKyselyTransaction(async (trx) => {
+    await trx
+      .updateTable('fastHousing')
+      .where((eb) =>
+        eb.or(
+          housings.map((housing) =>
+            eb.and([
+              eb('geoCode', '=', housing.geoCode),
+              eb('id', '=', housing.id)
+            ])
+          )
+        )
       )
-      .update(fields);
+      .set(fields)
+      .execute();
   });
 }
 
 async function remove(housing: HousingApi): Promise<void> {
   const info = Struct.pick(housing, 'geoCode', 'id', 'localId');
   logger.debug('Removing housing...', info);
-  await Housing()
-    .where({
-      geo_code: housing.geoCode,
-      id: housing.id
-    })
-    .delete();
+  await kysely
+    .deleteFrom('fastHousing')
+    .where('geoCode', '=', housing.geoCode)
+    .where('id', '=', housing.id)
+    .execute();
   logger.info('Removed housing.', info);
 }
 

--- a/server/src/repositories/ownerRepository.ts
+++ b/server/src/repositories/ownerRepository.ts
@@ -349,7 +349,9 @@ function kyselyOwnerConflict(opts: BetterSaveOptions) {
   if (opts.onConflict.length === 0) {
     throw new Error('onConflict must have at least one column');
   }
-  const columns = (opts.onConflict as ReadonlyArray<string>).map(snakeToCamel);
+  const columns = (opts.onConflict as ReadonlyArray<string>).map((column) =>
+    snakeToCamel(column)
+  );
   return (oc: any) => {
     const builder = oc.columns(columns);
     if (opts.merge === false) {
@@ -360,7 +362,9 @@ function kyselyOwnerConflict(opts: BetterSaveOptions) {
         ? (Object.keys(toOwnerInsert({} as OwnerApi)) as string[]).filter(
             (column) => !columns.includes(column)
           )
-        : (opts.merge as ReadonlyArray<string>).map(snakeToCamel);
+        : (opts.merge as ReadonlyArray<string>).map((column) =>
+            snakeToCamel(column)
+          );
     return builder.doUpdateSet((eb: any) =>
       Object.fromEntries(
         mergeColumns.map((column) => [column, eb.ref(`excluded.${column}`)])

--- a/server/src/repositories/ownerRepository.ts
+++ b/server/src/repositories/ownerRepository.ts
@@ -2,12 +2,12 @@ import { Readable } from 'node:stream';
 import { ReadableStream } from 'node:stream/web';
 
 import { AddressKinds, OwnerEntity } from '@zerologementvacant/models';
+import { snakeToCamel } from 'effect/String';
 import { Knex } from 'knex';
-import _ from 'lodash';
-import { match, Pattern } from 'ts-pattern';
-
 import type { Insertable } from 'kysely';
 import { sql } from 'kysely';
+import _ from 'lodash';
+import { match, Pattern } from 'ts-pattern';
 
 import db, { ConflictOptions, groupBy, where } from '~/infra/database';
 import type { DB } from '~/infra/database/db';
@@ -343,25 +343,24 @@ function toOwnerInsert(owner: OwnerApi): Insertable<DB['owners']> {
   };
 }
 
-const snakeToCamel = (value: string): string =>
-  value.replace(/_([a-z])/g, (_match, char: string) => char.toUpperCase());
-
 // Reproduces the Knex `onConflict(opts)` helper for Kysely. Callers pass
 // snake_case column names (keyof OwnerDBO); map them to the camelCase DB keys.
 function kyselyOwnerConflict(opts: BetterSaveOptions) {
+  if (opts.onConflict.length === 0) {
+    throw new Error('onConflict must have at least one column');
+  }
   const columns = (opts.onConflict as ReadonlyArray<string>).map(snakeToCamel);
   return (oc: any) => {
     const builder = oc.columns(columns);
     if (opts.merge === false) {
       return builder.doNothing();
     }
-    const mergeColumns = (
+    const mergeColumns =
       opts.merge === true
         ? (Object.keys(toOwnerInsert({} as OwnerApi)) as string[]).filter(
             (column) => !columns.includes(column)
           )
-        : (opts.merge as ReadonlyArray<string>).map(snakeToCamel)
-    );
+        : (opts.merge as ReadonlyArray<string>).map(snakeToCamel);
     return builder.doUpdateSet((eb: any) =>
       Object.fromEntries(
         mergeColumns.map((column) => [column, eb.ref(`excluded.${column}`)])

--- a/server/src/repositories/ownerRepository.ts
+++ b/server/src/repositories/ownerRepository.ts
@@ -6,13 +6,13 @@ import { Knex } from 'knex';
 import _ from 'lodash';
 import { match, Pattern } from 'ts-pattern';
 
-import db, {
-  ConflictOptions,
-  groupBy,
-  onConflict,
-  where
-} from '~/infra/database';
-import { withinTransaction } from '~/infra/database/transaction';
+import type { Insertable } from 'kysely';
+import { sql } from 'kysely';
+
+import db, { ConflictOptions, groupBy, where } from '~/infra/database';
+import type { DB } from '~/infra/database/db';
+import { kysely } from '~/infra/database/kysely';
+import { withinKyselyTransaction } from '~/infra/database/kysely-transaction';
 import { createLogger } from '~/infra/logger';
 import { AddressApi } from '~/models/AddressApi';
 import { HousingApi } from '~/models/HousingApi';
@@ -295,7 +295,11 @@ async function betterSave(
   opts: BetterSaveOptions
 ): Promise<void> {
   logger.debug(`Saving owner...`, { owner });
-  await Owners().insert(formatOwnerApi(owner)).modify(onConflict(opts));
+  await kysely
+    .insertInto('owners')
+    .values(toOwnerInsert(owner))
+    .onConflict(kyselyOwnerConflict(opts))
+    .execute();
 }
 
 async function betterSaveMany(
@@ -307,11 +311,63 @@ async function betterSaveMany(
     return;
   }
 
-  await withinTransaction(async (transaction) => {
-    await Owners(transaction)
-      .insert(owners.map(formatOwnerApi))
-      .modify(onConflict(opts));
+  await withinKyselyTransaction(async (trx) => {
+    await trx
+      .insertInto('owners')
+      .values(owners.map(toOwnerInsert))
+      .onConflict(kyselyOwnerConflict(opts))
+      .execute();
   });
+}
+
+// Camel-case Insertable mirror of formatOwnerApi for the Kysely write path.
+function toOwnerInsert(owner: OwnerApi): Insertable<DB['owners']> {
+  return {
+    id: owner.id,
+    idpersonne: owner.idpersonne ?? null,
+    fullName: owner.fullName,
+    birthDate: owner.birthDate,
+    administrator: owner.administrator ?? null,
+    siren: owner.siren ?? null,
+    addressDgfip: owner.rawAddress,
+    additionalAddress: owner.additionalAddress ?? null,
+    email: owner.email ?? null,
+    phone: owner.phone ?? null,
+    dataSource: owner.dataSource ?? null,
+    kindClass: owner.kind ?? null,
+    entity: owner.entity,
+    username: owner.username ?? null,
+    createdAt: owner.createdAt ? new Date(owner.createdAt) : null,
+    updatedAt: owner.updatedAt ? new Date(owner.updatedAt) : null,
+    isMultiOwner: null
+  };
+}
+
+const snakeToCamel = (value: string): string =>
+  value.replace(/_([a-z])/g, (_match, char: string) => char.toUpperCase());
+
+// Reproduces the Knex `onConflict(opts)` helper for Kysely. Callers pass
+// snake_case column names (keyof OwnerDBO); map them to the camelCase DB keys.
+function kyselyOwnerConflict(opts: BetterSaveOptions) {
+  const columns = (opts.onConflict as ReadonlyArray<string>).map(snakeToCamel);
+  return (oc: any) => {
+    const builder = oc.columns(columns);
+    if (opts.merge === false) {
+      return builder.doNothing();
+    }
+    const mergeColumns = (
+      opts.merge === true
+        ? (Object.keys(toOwnerInsert({} as OwnerApi)) as string[]).filter(
+            (column) => !columns.includes(column)
+          )
+        : (opts.merge as ReadonlyArray<string>).map(snakeToCamel)
+    );
+    return builder.doUpdateSet((eb: any) =>
+      Object.fromEntries(
+        mergeColumns.map((column) => [column, eb.ref(`excluded.${column}`)])
+      )
+    );
+  };
 }
 
 interface SaveOptions {
@@ -668,14 +724,14 @@ async function refreshMultiOwnerFlags(
   if (!ownerIds.length) return;
   for (let i = 0; i < ownerIds.length; i += MULTI_OWNER_BATCH_SIZE) {
     const chunk = ownerIds.slice(i, i + MULTI_OWNER_BATCH_SIZE);
-    await withinTransaction(async (transaction) => {
-      await Owners(transaction)
-        .whereIn('id', chunk)
-        .update({
-          is_multi_owner: db.raw(
-            `(SELECT COUNT(*) > 1 FROM ${housingOwnersTable} WHERE owner_id = owners.id AND rank = 1)`
-          )
-        });
+    await withinKyselyTransaction(async (trx) => {
+      await trx
+        .updateTable('owners')
+        .set({
+          isMultiOwner: sql<boolean>`(SELECT COUNT(*) > 1 FROM ${sql.raw(housingOwnersTable)} WHERE owner_id = owners.id AND rank = 1)`
+        })
+        .where('id', 'in', chunk)
+        .execute();
     });
   }
 }

--- a/server/src/repositories/test/housingRepository.test.ts
+++ b/server/src/repositories/test/housingRepository.test.ts
@@ -2819,6 +2819,27 @@ describe('Housing repository', () => {
         occupancy_intended: original.occupancyIntended
       });
     });
+
+    it('should preserve read-only columns (plot_area, occupancy_history) on a merge-all upsert', async () => {
+      const original = genHousingApi(oneOf(establishment.geoCodes));
+      // plot_area/occupancy_history are LOVAC-imported and never written by the
+      // API path (toHousingInsert forces them to null), so seed them directly.
+      await Housing().insert({
+        ...formatHousingRecordApi(original),
+        plot_area: 500,
+        occupancy_history: 'V;2020'
+      });
+      const update: HousingApi = { ...original, occupancy: Occupancy.RENT };
+
+      await housingRepository.save(update, { onConflict: 'merge' });
+
+      const actual = await Housing().where('id', original.id).first();
+      expect(actual).toMatchObject({
+        occupancy: update.occupancy,
+        plot_area: 500,
+        occupancy_history: 'V;2020'
+      });
+    });
   });
 
   describe('updateMany', () => {


### PR DESCRIPTION
## Summary

The **final and largest** transaction-cluster migration (plan: #1902), after the group (#1900) and campaign (#1901) clusters. `housingController.createHousing` binds `housing` + `owners` + `owners_housing` + `refreshMultiOwnerFlags` + housing/owner/housingOwner events into one `startTransaction`, with FK edges (`owners_housing → owners`/`fast_housing`, `owner_events → owners`, `housing_owner_events → owners`/`fast_housing`). Behind the visibility-less bridge these can't be split, so the whole write-cluster moves to Kysely together:

- **`housingRepository` writes**: `save`, `saveMany` (onConflict `[geo_code, local_id]` merge/ignore via a snake→camel merge-set helper), `update`, `updateMany` (composite where as OR-of-AND), `remove`. **Reads stay Knex.**
- **`ownerRepository`**: `betterSave`, `betterSaveMany` (dynamic `ConflictOptions` → Kysely `onConflict`), `refreshMultiOwnerFlags` (raw recompute via `sql`, joins the bridge so it sees the same-tx `owners_housing`). `insert`/`update`/`save`/`saveMany` have **no app callers** and stay Knex; reads + `updateAddressList` stay Knex.
- **`housingOwnerRepository`**: `insert`, `saveMany`. `findByOwner` stays Knex (feeds `parseHousingRecordApi`). The `owners_housing.start_date`/`end_date` `date` columns (typed `string` by codegen) receive the API's `Date` values unchanged — pg serializes them exactly as Knex did.
- **`eventRepository`**: `insertManyHousingEvents`, `insertManyOwnerEvents`, `insertManyHousingOwnerEvents` → Kysely (onConflict do-nothing preserved). Other event methods stay Knex.

Behaviour is preserved: the full exported Knex surface (accessors, DBO types, `format*Api`/`parse*Api`) is kept for seeds, LOVAC import, the factory, and the reads. `plot_area`/`occupancy_history` (READ_ONLY, nullable, no default) are set `null` to satisfy `Insertable`, matching the NULL the Knex path produced by omission; `geolocation` (PostGIS geometry) is passed through unchanged.

## Test plan

- [x] `yarn nx test server -- run src/repositories/test/housingRepository.test.ts` — 168/168
- [x] `yarn nx test server -- run src/controllers/test/housing-api.test.ts src/controllers/test/owner-api.test.ts src/controllers/test/campaign-api.test.ts src/repositories/test/eventRepository.test.ts` — 189/189 (incl. the `createHousing` FK block: new housing + owners + `owners_housing` + `refreshMultiOwnerFlags` + 3 event kinds)
- [x] `yarn nx test server -- run src/repositories/test/ownerRepository.test.ts src/repositories/test/housingOwnerRepository.test.ts` — 80/80
- [x] `yarn nx test server -- run src/controllers/test/group-api.test.ts src/controllers/test/draft-api.test.ts` — regression on untouched event methods/reads, green
- [x] `yarn nx typecheck server` — clean (only pre-existing `@deprecated`-field hints, mirrored from the `format*Api` functions)
- [x] `yarn lint` — clean on the four files

## Follow-up

After this lands, the only Knex writers left are the reads' query builders and `ownerRepository.updateAddressList`. Remaining work: migrate the reads (now unblocked — housing/owner/group/housingOwner/draft/sender `find*`), then drop Knex per the design's "Step final".

🤖 Generated with [Claude Code](https://claude.com/claude-code)