### PR TITLE
refactor(server): migrate ownerRepository reads to Kysely

### DIFF
--- a/server/src/repositories/ownerRepository.ts
+++ b/server/src/repositories/ownerRepository.ts
@@ -1,15 +1,19 @@
 import { Readable } from 'node:stream';
 import { ReadableStream } from 'node:stream/web';
 
-import { AddressKinds, OwnerEntity } from '@zerologementvacant/models';
+import {
+  AddressKinds,
+  OwnerEntity,
+  OwnerRank,
+  PropertyRight
+} from '@zerologementvacant/models';
 import { snakeToCamel } from 'effect/String';
-import { Knex } from 'knex';
-import type { Insertable } from 'kysely';
+import type { Insertable, Selectable } from 'kysely';
 import { sql } from 'kysely';
 import _ from 'lodash';
 import { match, Pattern } from 'ts-pattern';
 
-import db, { ConflictOptions, groupBy, where } from '~/infra/database';
+import db, { ConflictOptions } from '~/infra/database';
 import type { DB } from '~/infra/database/db';
 import { kysely } from '~/infra/database/kysely';
 import { withinKyselyTransaction } from '~/infra/database/kysely-transaction';
@@ -19,22 +23,14 @@ import { HousingApi } from '~/models/HousingApi';
 import { HousingOwnerApi } from '~/models/HousingOwnerApi';
 import { OwnerApi } from '~/models/OwnerApi';
 import { PaginatedResultApi } from '~/models/PaginatedResultApi';
-import { paginate, type PaginationApi } from '~/models/PaginationApi';
-import { compact } from '~/utils/object';
-
-import {
-  AddressDBO,
-  banAddressesTable,
-  parseAddressApi
-} from './banAddressesRepository';
-import { campaignsHousingTable } from './campaignHousingRepository';
-import { GROUPS_HOUSING_TABLE } from './groupRepository';
+import { isPaginationEnabled, type PaginationApi } from '~/models/PaginationApi';
+import { AddressDBO, parseAddressApi } from './banAddressesRepository';
 import {
   fromRelativeLocationDBO,
   HousingOwnerDBO,
   housingOwnersTable
 } from './housingOwnerRepository';
-import { housingTable, ownerHousingJoinClause } from './housingRepository';
+import { housingTable } from './housingRepository';
 
 const logger = createLogger('ownerRepository');
 
@@ -106,44 +102,63 @@ interface FindOptions {
 
 async function find(opts?: FindOptions): Promise<OwnerApi[]> {
   logger.debug('Finding owners...', opts);
-  const whereOptions = where<OwnerFilters>(['fullName']);
 
-  const owners = await Owners()
-    .select(`${ownerTable}.*`)
-    .where(whereOptions(opts?.filters ?? {}))
-    .modify(filter(opts?.filters))
-    .modify(search(opts?.search ?? null))
-    .modify(include(opts?.includes ?? []))
-    .modify(paginate(opts?.pagination))
-    .orderBy('full_name');
+  let query: any = kysely
+    .selectFrom('owners')
+    .selectAll('owners');
+  query = applyOwnerIncludes(query, opts?.includes ?? []);
+  query = applyOwnerFilters(query, opts?.filters);
+  query = applyOwnerSearch(query, opts?.search ?? null);
+  // Reproduce where<OwnerFilters>(['fullName']): add equality filter when present
+  if (opts?.filters?.fullName !== undefined) {
+    query = query.where('owners.fullName', '=', opts.filters.fullName);
+  }
+  // paginate() defaulted to { page: 1, perPage: 50 } when no pagination was
+  // provided, so unpaginated find() calls were still capped at 50 rows.
+  const pagination: PaginationApi = opts?.pagination ?? {
+    paginate: true,
+    page: 1,
+    perPage: 50
+  };
+  if (isPaginationEnabled(pagination)) {
+    query = query
+      .limit(pagination.perPage)
+      .offset((pagination.page - 1) * pagination.perPage);
+  }
+  query = query.orderBy('full_name');
 
-  logger.debug(`Found ${owners.length} owners`, opts);
-  return owners.map(parseOwnerApi);
+  const rows: OwnerRow[] = await query.execute();
+  logger.debug(`Found ${rows.length} owners`, opts);
+  return rows.map(parseOwnerRow);
 }
 
 async function count(opts?: FindOptions): Promise<number> {
   logger.debug('Counting owners...', opts);
-  const whereOptions = where<OwnerFilters>(['fullName']);
 
-  const result = await Owners()
-    .count('id')
-    .where(whereOptions(opts?.filters ?? {}))
-    .modify(filter(opts?.filters))
-    .modify(search(opts?.search ?? null))
-    .first();
+  let query: any = kysely
+    .selectFrom('owners')
+    .select(sql`count(id)`.as('count'));
+  query = applyOwnerFilters(query, opts?.filters);
+  query = applyOwnerSearch(query, opts?.search ?? null);
+  if (opts?.filters?.fullName !== undefined) {
+    query = query.where('owners.fullName', '=', opts.filters.fullName);
+  }
 
+  const result = await query.executeTakeFirst();
   const total = Number(result?.count ?? 0);
   logger.debug(`Counted ${total} owners`, opts);
   return total;
 }
 
 const get = async (ownerId: string): Promise<OwnerApi | null> => {
-  const owner = await Owners()
-    .select(`${ownerTable}.*`)
-    .modify(include(['banAddress']))
-    .where('id', ownerId)
-    .first();
-  return owner ? parseOwnerApi(owner) : null;
+  let query: any = kysely
+    .selectFrom('owners')
+    .selectAll('owners');
+  query = applyOwnerIncludes(query, ['banAddress']);
+  query = query.where('owners.id', '=', ownerId);
+
+  const row: OwnerRow | undefined = await query.executeTakeFirst();
+  return row ? parseOwnerRow(row) : null;
 };
 
 type StreamOptions = FindOptions;
@@ -151,16 +166,26 @@ type StreamOptions = FindOptions;
 function stream(
   options?: StreamOptions
 ): ReadableStream<OwnerApi & { housings?: ReadonlyArray<HousingApi> }> {
-  const stream = Owners()
-    .select(`${ownerTable}.*`)
-    .modify(include(options?.includes ?? []))
-    .modify(filter(options?.filters))
-    .modify(groupBy<OwnerDBO>(options?.groupBy))
-    .orderBy('full_name')
-    .stream()
-    .map(parseHousingOwnerApi);
+  let query: any = kysely
+    .selectFrom('owners')
+    .selectAll('owners');
+  query = applyOwnerIncludes(query, options?.includes ?? []);
+  query = applyOwnerFilters(query, options?.filters);
+  // Reproduce groupBy<OwnerDBO>(options?.groupBy): DISTINCT ON when columns given
+  if (options?.groupBy?.length) {
+    query = query.distinctOn(options.groupBy);
+  }
+  query = query.orderBy('full_name');
 
-  return Readable.toWeb(stream);
+  const rows = query.stream();
+  const mapped = (async function* () {
+    for await (const row of rows) {
+      yield parseHousingOwnerRow(row as HousingOwnerRow);
+    }
+  })();
+  return Readable.toWeb(
+    Readable.from(mapped)
+  ) as ReadableStream<OwnerApi & { housings?: ReadonlyArray<HousingApi> }>;
 }
 
 interface FindOneOptions extends Partial<
@@ -170,31 +195,40 @@ interface FindOneOptions extends Partial<
 }
 
 async function findOne(opts: FindOneOptions): Promise<OwnerApi | null> {
-  const owner = await Owners()
-    .where(
-      compact({
-        idpersonne: opts.idpersonne,
-        full_name: opts.fullName,
-        address_dgfip: opts.rawAddress,
-        birth_date: opts.birthDate
-      })
-    )
-    .first();
-  return owner ? parseOwnerApi(owner) : null;
+  let query: any = kysely.selectFrom('owners').selectAll('owners');
+  // Reproduce compact({...}).where(...) — only add conditions for defined values
+  if (opts.idpersonne !== undefined) {
+    query = query.where('owners.idpersonne', '=', opts.idpersonne);
+  }
+  if (opts.fullName !== undefined) {
+    query = query.where('owners.fullName', '=', opts.fullName);
+  }
+  if (opts.rawAddress !== undefined) {
+    // address_dgfip is text[]; a plain `where(col, '=', array)` makes Kysely emit
+    // a row constructor (text[] = record). Bind the array as a single parameter so
+    // node-postgres serialises it to a Postgres array literal instead.
+    query = query.where(sql`address_dgfip = ${opts.rawAddress}`);
+  }
+  if (opts.birthDate !== undefined) {
+    query = query.where('owners.birthDate', '=', opts.birthDate);
+  }
+
+  const row: OwnerRow | undefined = await query.executeTakeFirst();
+  return row ? parseOwnerRow(row) : null;
 }
 
-function search(query: string | null) {
-  return (builder: Knex.QueryBuilder) => {
-    if (query) {
-      const tsQuery = query
-        .trim()
-        .split(/\s+/)
-        .map((term) => `${term}:*`) // permet le préfixe (ex: dupont:* = dupont, dupontet...)
-        .join(' & '); // opérateur logique AND entre les mots
-
-      builder.whereRaw(`full_name_fts @@ to_tsquery('simple', ?)`, [tsQuery]);
-    }
-  };
+function applyOwnerSearch(query: any, searchQuery: string | null): any {
+  if (!searchQuery) {
+    return query;
+  }
+  const tsQuery = searchQuery
+    .trim()
+    .split(/\s+/)
+    .map((term) => `${term}:*`) // permet le préfixe (ex: dupont:* = dupont, dupontet...)
+    .join(' & '); // opérateur logique AND entre les mots
+  return query.where(
+    sql`full_name_fts @@ to_tsquery('simple', ${tsQuery})`
+  );
 }
 
 /**
@@ -215,33 +249,35 @@ const searchOwners = async (
     .map((term) => `${term}:*`) // permet le préfixe (ex: dupont:* = dupont, dupontet...)
     .join(' & '); // opérateur logique AND entre les mots
 
-  const filterQuery = db(ownerTable)
-    .select('*')
-    .whereRaw(`full_name_fts @@ to_tsquery('simple', ?)`, [tsQuery])
-    .orderBy('id', 'desc');
+  const filteredCount = await (kysely
+    .selectFrom('owners')
+    .select(sql`count(id)`.as('count')) as any)
+    .where(sql`full_name_fts @@ to_tsquery('simple', ${tsQuery})`)
+    .executeTakeFirst()
+    .then((row: any) => Number(row?.count));
 
-  const filteredCount = await db(ownerTable)
-    .whereRaw(`full_name_fts @@ to_tsquery('simple', ?)`, [tsQuery])
-    .count('id')
-    .first()
+  const totalCount = await kysely
+    .selectFrom('owners')
+    .select(sql`count(id)`.as('count'))
+    .executeTakeFirst()
     .then((row) => Number(row?.count));
 
-  const totalCount = await db(ownerTable)
-    .count('id')
-    .first()
-    .then((row) => Number(row?.count));
-
-  const results = await filterQuery.modify((queryBuilder: any) => {
-    queryBuilder.orderBy('full_name');
-    if (page && perPage) {
-      queryBuilder.offset((page - 1) * perPage).limit(perPage);
-    }
-  });
+  let filterQuery: any = (kysely
+    .selectFrom('owners')
+    .selectAll('owners') as any)
+    .where(sql`full_name_fts @@ to_tsquery('simple', ${tsQuery})`)
+    .orderBy('full_name');
+  if (page && perPage) {
+    filterQuery = filterQuery
+      .offset((page - 1) * perPage)
+      .limit(perPage);
+  }
+  const results: OwnerRow[] = await filterQuery.execute();
 
   logger.debug('filteredCount', filteredCount);
 
   return <PaginatedResultApi<OwnerApi>>{
-    entities: results.map((result: any) => parseOwnerApi(result)),
+    entities: results.map(parseOwnerRow),
     totalCount,
     filteredCount,
     page,
@@ -252,21 +288,24 @@ const searchOwners = async (
 const findByHousing = async (
   housing: HousingApi
 ): Promise<HousingOwnerApi[]> => {
-  const owners: Array<OwnerDBO & HousingOwnerDBO> = await db(ownerTable)
-    .select(`${ownerTable}.*`)
-    .join(
-      housingOwnersTable,
-      `${ownerTable}.id`,
-      `${housingOwnersTable}.owner_id`
+  let query: any = kysely
+    .selectFrom('owners')
+    .selectAll('owners')
+    .innerJoin(
+      'ownersHousing',
+      'owners.id',
+      'ownersHousing.ownerId'
     )
-    .select(`${housingOwnersTable}.*`)
-    .modify(include(['banAddress']))
-    .where(`${housingOwnersTable}.housing_id`, housing.id)
-    .where(`${housingOwnersTable}.housing_geo_code`, housing.geoCode)
+    .selectAll('ownersHousing')
+    .where('ownersHousing.housingId', '=', housing.id)
+    .where('ownersHousing.housingGeoCode', '=', housing.geoCode);
+  query = applyOwnerIncludes(query, ['banAddress']);
+  query = query
     .orderBy('end_date', 'desc')
     .orderBy('rank');
 
-  return owners.map(parseHousingOwnerApi);
+  const rows: HousingOwnerRow[] = await query.execute();
+  return rows.map(parseHousingOwnerRow);
 };
 
 const insert = async (draftOwnerApi: OwnerApi): Promise<OwnerApi> => {
@@ -552,99 +591,170 @@ const escapeValue = (value?: string) => {
 
 type OwnerInclude = 'banAddress' | 'housings';
 
-function include(includes: OwnerInclude[]) {
-  const joins: Record<OwnerInclude, (query: Knex.QueryBuilder) => void> = {
-    banAddress: (query) =>
-      query
-        .leftJoin(banAddressesTable, (query: any) => {
-          query
-            .on(`${ownerTable}.id`, `${banAddressesTable}.ref_id`)
-            .andOnVal('address_kind', AddressKinds.Owner);
-        })
-        .select(db.raw(`to_json(${banAddressesTable}.*) AS ban`)),
-    housings: (query) =>
-      query
-        .joinRaw(
-          `
-          LEFT JOIN LATERAL (
-            SELECT json_agg(${housingTable}.*) AS housings
-            FROM ${housingOwnersTable}
-            JOIN ${housingTable}
-              ON ${housingOwnersTable}.housing_geo_code = ${housingTable}.geo_code
-              AND ${housingOwnersTable}.housing_id = ${housingTable}.id
-            WHERE ${ownerTable}.id = ${housingOwnersTable}.owner_id
-          ) h ON true
-        `
-        )
-        .select('h.housings')
-  };
+// Row type returned by Kysely for owner queries.
+// Top-level columns come back camelCase (CamelCasePlugin); the `ban` JSON blob
+// stays snake_case (maintainNestedObjectKeys: true), matching AddressDBO.
+type OwnerRow = Selectable<DB['owners']> & {
+  ban?: AddressDBO | null;
+};
 
-  return (query: Knex.QueryBuilder) => {
-    _.uniq(includes).forEach((include) => {
-      joins[include](query);
-    });
+// ---------------------------------------------------------------------------
+// Row parsers for the Kysely read path
+// ---------------------------------------------------------------------------
+
+/**
+ * Maps a camelCase Kysely owner row to OwnerApi.
+ * Field-for-field mirror of parseOwnerApi (which reads from snake_case OwnerDBO).
+ * The `ban` JSON blob stays snake_case (maintainNestedObjectKeys: true).
+ */
+export const parseOwnerRow = (row: OwnerRow): OwnerApi => {
+  const birthDate = match(row.birthDate as Date | string | null | undefined)
+    .returnType<string | null>()
+    .with(Pattern.string, (value) => value.substring(0, 'yyyy-mm-dd'.length))
+    .with(Pattern.instanceOf(Date), (value) =>
+      value.toJSON().substring(0, 'yyyy-mm-dd'.length)
+    )
+    .otherwise((value) => value ?? null);
+  return {
+    id: row.id,
+    idpersonne: row.idpersonne ?? null,
+    rawAddress: row.addressDgfip ?? null,
+    fullName: row.fullName,
+    administrator: row.administrator ?? null,
+    birthDate: birthDate,
+    email: row.email ?? null,
+    phone: row.phone ?? null,
+    kind: row.kindClass ?? null,
+    siren: row.siren ?? null,
+    banAddress: row.ban ? parseAddressApi(row.ban) : null,
+    additionalAddress: row.additionalAddress ?? null,
+    entity: (row.entity as OwnerEntity | null) ?? null,
+    username: row.username ?? null,
+    createdAt: row.createdAt ? new Date(row.createdAt as Date | string).toJSON() : null,
+    updatedAt: row.updatedAt ? new Date(row.updatedAt as Date | string).toJSON() : null
   };
+};
+
+/**
+ * Maps a camelCase Kysely owner+housingOwner row to HousingOwnerApi.
+ * Field-for-field mirror of parseHousingOwnerApi (which reads snake_case).
+ * Used by stream (which joins ownersHousing) and findByHousing.
+ */
+type HousingOwnerRow = OwnerRow & Selectable<DB['ownersHousing']>;
+
+const parseHousingOwnerRow = (row: HousingOwnerRow): HousingOwnerApi => ({
+  ...parseOwnerRow(row),
+  ownerId: row.id,
+  housingId: row.housingId,
+  housingGeoCode: row.housingGeoCode,
+  rank: row.rank as OwnerRank,
+  // DATE columns come back as "YYYY-MM-DD" strings (global pg DATE parser); the
+  // API type still declares Date, matching the pre-migration passthrough.
+  startDate: row.startDate as unknown as Date | null,
+  endDate: row.endDate as unknown as Date | null,
+  origin: row.origin,
+  idprocpte: row.idprocpte,
+  idprodroit: row.idprodroit,
+  locprop:
+    typeof row.locpropSource === 'string' ? Number(row.locpropSource) : null,
+  relativeLocation: fromRelativeLocationDBO(row.locpropRelativeBan),
+  absoluteDistance: row.locpropDistanceBan,
+  propertyRight: row.propertyRight as PropertyRight | null
+});
+
+// ---------------------------------------------------------------------------
+// Kysely include / filter / search helpers
+// ---------------------------------------------------------------------------
+
+function applyOwnerIncludes(query: any, includes: OwnerInclude[]): any {
+  const unique = [...new Set(includes)];
+  for (const inc of unique) {
+    if (inc === 'banAddress') {
+      query = query
+        .leftJoin('banAddresses as ban', (join: any) =>
+          join
+            .onRef('owners.id', '=', 'ban.refId')
+            .on('ban.addressKind', '=', AddressKinds.Owner)
+        )
+        .select(sql`to_json(ban.*)`.as('ban'));
+    } else if (inc === 'housings') {
+      query = query
+        .select(
+          sql`(
+            SELECT json_agg(${sql.raw(housingTable)}.*)
+            FROM ${sql.raw(housingOwnersTable)}
+            JOIN ${sql.raw(housingTable)}
+              ON ${sql.raw(housingOwnersTable)}.housing_geo_code = ${sql.raw(housingTable)}.geo_code
+              AND ${sql.raw(housingOwnersTable)}.housing_id = ${sql.raw(housingTable)}.id
+            WHERE owners.id = ${sql.raw(housingOwnersTable)}.owner_id
+          )`.as('housings')
+        );
+    }
+  }
+  return query;
 }
 
-function filter(filters?: OwnerFilters) {
-  return (query: Knex.QueryBuilder) => {
-    if (filters?.idpersonne !== undefined) {
-      match(filters.idpersonne)
-        .with(true, () => {
-          query.whereNotNull('idpersonne');
-        })
-        .with(false, () => {
-          query.whereNull('idpersonne');
-        })
-        .with(Pattern.string, (value) => {
-          query.where('idpersonne', value);
-        })
-        .with(Pattern.array(Pattern.string), (value) => {
-          if (value.length > 0) {
-            query.whereIn('idpersonne', value);
-          }
-        })
-        .exhaustive();
-    }
+function applyOwnerFilters(query: any, filters?: OwnerFilters): any {
+  if (!filters) return query;
 
-    if (filters?.campaignId) {
-      query
-        .join(
-          housingOwnersTable,
-          `${ownerTable}.id`,
-          `${housingOwnersTable}.owner_id`
-        )
-        .join(housingTable, ownerHousingJoinClause)
-        .join(campaignsHousingTable, (query) =>
-          query
-            .on(`${housingTable}.id`, `${campaignsHousingTable}.housing_id`)
-            .andOn(
-              `${housingTable}.geo_code`,
-              `${campaignsHousingTable}.housing_geo_code`
-            )
-        )
-        .where(`${campaignsHousingTable}.campaign_id`, filters.campaignId);
-    }
+  if (filters.idpersonne !== undefined) {
+    query = match(filters.idpersonne)
+      .with(true, () => query.where('owners.idpersonne', 'is not', null))
+      .with(false, () => query.where('owners.idpersonne', 'is', null))
+      .with(Pattern.string, (value) =>
+        query.where('owners.idpersonne', '=', value)
+      )
+      .with(Pattern.array(Pattern.string), (value) =>
+        value.length > 0
+          ? query.where('owners.idpersonne', 'in', value)
+          : query
+      )
+      .exhaustive();
+  }
 
-    if (filters?.groupId) {
-      query
-        .join(
-          housingOwnersTable,
-          `${ownerTable}.id`,
-          `${housingOwnersTable}.owner_id`
-        )
-        .join(housingTable, ownerHousingJoinClause)
-        .join(GROUPS_HOUSING_TABLE, (query) =>
-          query
-            .on(`${housingTable}.id`, `${GROUPS_HOUSING_TABLE}.housing_id`)
-            .andOn(
-              `${housingTable}.geo_code`,
-              `${GROUPS_HOUSING_TABLE}.housing_geo_code`
-            )
-        )
-        .where(`${GROUPS_HOUSING_TABLE}.group_id`, filters.groupId);
-    }
-  };
+  if (filters.campaignId) {
+    query = query
+      .innerJoin('ownersHousing', 'owners.id', 'ownersHousing.ownerId')
+      .innerJoin(
+        'fastHousing',
+        (join: any) =>
+          join
+            .onRef('fastHousing.id', '=', 'ownersHousing.housingId')
+            .onRef('fastHousing.geoCode', '=', 'ownersHousing.housingGeoCode')
+            .on('ownersHousing.rank', '=', 1)
+      )
+      .innerJoin(
+        'campaignsHousing',
+        (join: any) =>
+          join
+            .onRef('fastHousing.id', '=', 'campaignsHousing.housingId')
+            .onRef('fastHousing.geoCode', '=', 'campaignsHousing.housingGeoCode')
+      )
+      .where('campaignsHousing.campaignId', '=', filters.campaignId);
+  }
+
+  if (filters.groupId) {
+    query = query
+      .innerJoin('ownersHousing', 'owners.id', 'ownersHousing.ownerId')
+      .innerJoin(
+        'fastHousing',
+        (join: any) =>
+          join
+            .onRef('fastHousing.id', '=', 'ownersHousing.housingId')
+            .onRef('fastHousing.geoCode', '=', 'ownersHousing.housingGeoCode')
+            .on('ownersHousing.rank', '=', 1)
+      )
+      .innerJoin(
+        'groupsHousing',
+        (join: any) =>
+          join
+            .onRef('fastHousing.id', '=', 'groupsHousing.housingId')
+            .onRef('fastHousing.geoCode', '=', 'groupsHousing.housingGeoCode')
+      )
+      .where('groupsHousing.groupId', '=', filters.groupId);
+  }
+
+  return query;
 }
 
 export const parseOwnerApi = (owner: OwnerDBO): OwnerApi => {

--- a/server/src/repositories/ownerRepository.ts
+++ b/server/src/repositories/ownerRepository.ts
@@ -23,7 +23,11 @@ import { HousingApi } from '~/models/HousingApi';
 import { HousingOwnerApi } from '~/models/HousingOwnerApi';
 import { OwnerApi } from '~/models/OwnerApi';
 import { PaginatedResultApi } from '~/models/PaginatedResultApi';
-import { isPaginationEnabled, type PaginationApi } from '~/models/PaginationApi';
+import {
+  isPaginationEnabled,
+  type PaginationApi
+} from '~/models/PaginationApi';
+
 import { AddressDBO, parseAddressApi } from './banAddressesRepository';
 import {
   fromRelativeLocationDBO,
@@ -103,9 +107,7 @@ interface FindOptions {
 async function find(opts?: FindOptions): Promise<OwnerApi[]> {
   logger.debug('Finding owners...', opts);
 
-  let query: any = kysely
-    .selectFrom('owners')
-    .selectAll('owners');
+  let query: any = kysely.selectFrom('owners').selectAll('owners');
   query = applyOwnerIncludes(query, opts?.includes ?? []);
   query = applyOwnerFilters(query, opts?.filters);
   query = applyOwnerSearch(query, opts?.search ?? null);
@@ -151,9 +153,7 @@ async function count(opts?: FindOptions): Promise<number> {
 }
 
 const get = async (ownerId: string): Promise<OwnerApi | null> => {
-  let query: any = kysely
-    .selectFrom('owners')
-    .selectAll('owners');
+  let query: any = kysely.selectFrom('owners').selectAll('owners');
   query = applyOwnerIncludes(query, ['banAddress']);
   query = query.where('owners.id', '=', ownerId);
 
@@ -166,9 +166,7 @@ type StreamOptions = FindOptions;
 function stream(
   options?: StreamOptions
 ): ReadableStream<OwnerApi & { housings?: ReadonlyArray<HousingApi> }> {
-  let query: any = kysely
-    .selectFrom('owners')
-    .selectAll('owners');
+  let query: any = kysely.selectFrom('owners').selectAll('owners');
   query = applyOwnerIncludes(query, options?.includes ?? []);
   query = applyOwnerFilters(query, options?.filters);
   // Reproduce groupBy<OwnerDBO>(options?.groupBy): DISTINCT ON when columns given
@@ -183,9 +181,9 @@ function stream(
       yield parseHousingOwnerRow(row as HousingOwnerRow);
     }
   })();
-  return Readable.toWeb(
-    Readable.from(mapped)
-  ) as ReadableStream<OwnerApi & { housings?: ReadonlyArray<HousingApi> }>;
+  return Readable.toWeb(Readable.from(mapped)) as ReadableStream<
+    OwnerApi & { housings?: ReadonlyArray<HousingApi> }
+  >;
 }
 
 interface FindOneOptions extends Partial<
@@ -226,9 +224,7 @@ function applyOwnerSearch(query: any, searchQuery: string | null): any {
     .split(/\s+/)
     .map((term) => `${term}:*`) // permet le préfixe (ex: dupont:* = dupont, dupontet...)
     .join(' & '); // opérateur logique AND entre les mots
-  return query.where(
-    sql`full_name_fts @@ to_tsquery('simple', ${tsQuery})`
-  );
+  return query.where(sql`full_name_fts @@ to_tsquery('simple', ${tsQuery})`);
 }
 
 /**
@@ -249,9 +245,9 @@ const searchOwners = async (
     .map((term) => `${term}:*`) // permet le préfixe (ex: dupont:* = dupont, dupontet...)
     .join(' & '); // opérateur logique AND entre les mots
 
-  const filteredCount = await (kysely
-    .selectFrom('owners')
-    .select(sql`count(id)`.as('count')) as any)
+  const filteredCount = await (
+    kysely.selectFrom('owners').select(sql`count(id)`.as('count')) as any
+  )
     .where(sql`full_name_fts @@ to_tsquery('simple', ${tsQuery})`)
     .executeTakeFirst()
     .then((row: any) => Number(row?.count));
@@ -262,15 +258,13 @@ const searchOwners = async (
     .executeTakeFirst()
     .then((row) => Number(row?.count));
 
-  let filterQuery: any = (kysely
-    .selectFrom('owners')
-    .selectAll('owners') as any)
+  let filterQuery: any = (
+    kysely.selectFrom('owners').selectAll('owners') as any
+  )
     .where(sql`full_name_fts @@ to_tsquery('simple', ${tsQuery})`)
     .orderBy('full_name');
   if (page && perPage) {
-    filterQuery = filterQuery
-      .offset((page - 1) * perPage)
-      .limit(perPage);
+    filterQuery = filterQuery.offset((page - 1) * perPage).limit(perPage);
   }
   const results: OwnerRow[] = await filterQuery.execute();
 
@@ -291,18 +285,12 @@ const findByHousing = async (
   let query: any = kysely
     .selectFrom('owners')
     .selectAll('owners')
-    .innerJoin(
-      'ownersHousing',
-      'owners.id',
-      'ownersHousing.ownerId'
-    )
+    .innerJoin('ownersHousing', 'owners.id', 'ownersHousing.ownerId')
     .selectAll('ownersHousing')
     .where('ownersHousing.housingId', '=', housing.id)
     .where('ownersHousing.housingGeoCode', '=', housing.geoCode);
   query = applyOwnerIncludes(query, ['banAddress']);
-  query = query
-    .orderBy('end_date', 'desc')
-    .orderBy('rank');
+  query = query.orderBy('end_date', 'desc').orderBy('rank');
 
   const rows: HousingOwnerRow[] = await query.execute();
   return rows.map(parseHousingOwnerRow);
@@ -630,8 +618,12 @@ export const parseOwnerRow = (row: OwnerRow): OwnerApi => {
     additionalAddress: row.additionalAddress ?? null,
     entity: (row.entity as OwnerEntity | null) ?? null,
     username: row.username ?? null,
-    createdAt: row.createdAt ? new Date(row.createdAt as Date | string).toJSON() : null,
-    updatedAt: row.updatedAt ? new Date(row.updatedAt as Date | string).toJSON() : null
+    createdAt: row.createdAt
+      ? new Date(row.createdAt as Date | string).toJSON()
+      : null,
+    updatedAt: row.updatedAt
+      ? new Date(row.updatedAt as Date | string).toJSON()
+      : null
   };
 };
 
@@ -678,9 +670,8 @@ function applyOwnerIncludes(query: any, includes: OwnerInclude[]): any {
         )
         .select(sql`to_json(ban.*)`.as('ban'));
     } else if (inc === 'housings') {
-      query = query
-        .select(
-          sql`(
+      query = query.select(
+        sql`(
             SELECT json_agg(${sql.raw(housingTable)}.*)
             FROM ${sql.raw(housingOwnersTable)}
             JOIN ${sql.raw(housingTable)}
@@ -688,7 +679,7 @@ function applyOwnerIncludes(query: any, includes: OwnerInclude[]): any {
               AND ${sql.raw(housingOwnersTable)}.housing_id = ${sql.raw(housingTable)}.id
             WHERE owners.id = ${sql.raw(housingOwnersTable)}.owner_id
           )`.as('housings')
-        );
+      );
     }
   }
   return query;
@@ -705,9 +696,7 @@ function applyOwnerFilters(query: any, filters?: OwnerFilters): any {
         query.where('owners.idpersonne', '=', value)
       )
       .with(Pattern.array(Pattern.string), (value) =>
-        value.length > 0
-          ? query.where('owners.idpersonne', 'in', value)
-          : query
+        value.length > 0 ? query.where('owners.idpersonne', 'in', value) : query
       )
       .exhaustive();
   }
@@ -715,20 +704,16 @@ function applyOwnerFilters(query: any, filters?: OwnerFilters): any {
   if (filters.campaignId) {
     query = query
       .innerJoin('ownersHousing', 'owners.id', 'ownersHousing.ownerId')
-      .innerJoin(
-        'fastHousing',
-        (join: any) =>
-          join
-            .onRef('fastHousing.id', '=', 'ownersHousing.housingId')
-            .onRef('fastHousing.geoCode', '=', 'ownersHousing.housingGeoCode')
-            .on('ownersHousing.rank', '=', 1)
+      .innerJoin('fastHousing', (join: any) =>
+        join
+          .onRef('fastHousing.id', '=', 'ownersHousing.housingId')
+          .onRef('fastHousing.geoCode', '=', 'ownersHousing.housingGeoCode')
+          .on('ownersHousing.rank', '=', 1)
       )
-      .innerJoin(
-        'campaignsHousing',
-        (join: any) =>
-          join
-            .onRef('fastHousing.id', '=', 'campaignsHousing.housingId')
-            .onRef('fastHousing.geoCode', '=', 'campaignsHousing.housingGeoCode')
+      .innerJoin('campaignsHousing', (join: any) =>
+        join
+          .onRef('fastHousing.id', '=', 'campaignsHousing.housingId')
+          .onRef('fastHousing.geoCode', '=', 'campaignsHousing.housingGeoCode')
       )
       .where('campaignsHousing.campaignId', '=', filters.campaignId);
   }
@@ -736,20 +721,16 @@ function applyOwnerFilters(query: any, filters?: OwnerFilters): any {
   if (filters.groupId) {
     query = query
       .innerJoin('ownersHousing', 'owners.id', 'ownersHousing.ownerId')
-      .innerJoin(
-        'fastHousing',
-        (join: any) =>
-          join
-            .onRef('fastHousing.id', '=', 'ownersHousing.housingId')
-            .onRef('fastHousing.geoCode', '=', 'ownersHousing.housingGeoCode')
-            .on('ownersHousing.rank', '=', 1)
+      .innerJoin('fastHousing', (join: any) =>
+        join
+          .onRef('fastHousing.id', '=', 'ownersHousing.housingId')
+          .onRef('fastHousing.geoCode', '=', 'ownersHousing.housingGeoCode')
+          .on('ownersHousing.rank', '=', 1)
       )
-      .innerJoin(
-        'groupsHousing',
-        (join: any) =>
-          join
-            .onRef('fastHousing.id', '=', 'groupsHousing.housingId')
-            .onRef('fastHousing.geoCode', '=', 'groupsHousing.housingGeoCode')
+      .innerJoin('groupsHousing', (join: any) =>
+        join
+          .onRef('fastHousing.id', '=', 'groupsHousing.housingId')
+          .onRef('fastHousing.geoCode', '=', 'groupsHousing.housingGeoCode')
       )
       .where('groupsHousing.groupId', '=', filters.groupId);
   }


### PR DESCRIPTION
## Summary

Migrates the **read** path of `ownerRepository` from Knex to Kysely, mirroring the `housingRepository` read migration (#1910). Write methods (`betterSave`, `betterSaveMany`, `insert`, `update`, `save`, `saveMany`, `refreshMultiOwnerFlags`) and `updateAddressList` stay on Knex, and the full exported Knex surface (`Owners`, `OwnerDBO`, `parseOwnerApi`, `parseHousingOwnerApi`, `formatOwnerApi`, …) is preserved.

Rewired to Kysely: `find`, `count`, `get`, `stream`, `findOne`, `searchOwners`, `findByHousing`, plus the `include` / `filter` / `search` helpers.

### Behaviour-preserving details
- Adds camelCase `parseOwnerRow` / `parseHousingOwnerRow` alongside the kept snake_case parsers. The `ban` JSON blob stays snake_case via `maintainNestedObjectKeys`.
- Keeps the `paginate()` default of `{ page: 1, perPage: 50 }` so unpaginated `find()` calls stay capped at 50 rows.
- Binds the `rawAddress` `text[]` filter as a single array parameter — a plain `where(col, '=', array)` makes Kysely emit `text[] = record`.
- Reads `owners_housing` columns as camelCase in `parseHousingOwnerRow`, so `housing_geo_code`/`start_date`/… are no longer `null` (this was surfacing as null-constraint violations when writing housing-owner events).

## Test plan
- [x] `yarn nx typecheck server`
- [x] `yarn lint` (0 errors)
- [x] `yarn nx test server -- run src/repositories/test/ownerRepository.test.ts src/controllers/test/owner-api.test.ts src/repositories/test/housingOwnerRepository.test.ts` → **110 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)