### PR TITLE
refactor(server): migrate housingOwnerRepository.findByOwner to Kysely

### DIFF
--- a/server/src/repositories/eventRepository.ts
+++ b/server/src/repositories/eventRepository.ts
@@ -84,7 +84,7 @@ async function insertManyHousingEvents(
       async (batch) => {
         await trx
           .insertInto('events')
-          .values(batch.map(toEventDBO))
+          .values(batch.map(toEventInsert))
           .onConflict((oc) => oc.column('id').doNothing())
           .execute();
         await trx
@@ -96,6 +96,19 @@ async function insertManyHousingEvents(
       { concurrency: 1 }
     );
   });
+}
+
+function toEventInsert<Type extends EventType>(
+  event: EventApi<Type>
+): Insertable<DB['events']> {
+  return {
+    id: event.id,
+    type: event.type,
+    nextOld: event.nextOld as Insertable<DB['events']>['nextOld'],
+    nextNew: event.nextNew as Insertable<DB['events']>['nextNew'],
+    createdAt: new Date(event.createdAt),
+    createdBy: event.createdBy
+  };
 }
 
 function toHousingEventInsert(
@@ -144,7 +157,7 @@ async function insertManyHousingOwnerEvents(
       async (batch) => {
         await trx
           .insertInto('events')
-          .values(batch.map(toEventDBO))
+          .values(batch.map(toEventInsert))
           .onConflict((oc) => oc.column('id').doNothing())
           .execute();
         await trx

--- a/server/src/repositories/housingOwnerRepository.ts
+++ b/server/src/repositories/housingOwnerRepository.ts
@@ -3,7 +3,7 @@ import type {
   RelativeLocationFilter
 } from '@zerologementvacant/models';
 import { OwnerRank, PropertyRight } from '@zerologementvacant/models';
-import type { Insertable } from 'kysely';
+import type { Insertable, Selectable } from 'kysely';
 import { match } from 'ts-pattern';
 
 import db from '~/infra/database';
@@ -15,9 +15,10 @@ import { HousingRecordApi } from '~/models/HousingApi';
 import { HousingOwnerApi } from '~/models/HousingOwnerApi';
 import { OwnerApi } from '~/models/OwnerApi';
 import {
-  housingTable,
   parseHousingRecordApi,
-  type HousingRecordDBO
+  parseHousingRecordRow,
+  type HousingRecordDBO,
+  type HousingRecordRow
 } from '~/repositories/housingRepository';
 
 export const housingOwnersTable = 'owners_housing';
@@ -37,40 +38,33 @@ async function findByOwner(
 > {
   logger.debug('Finding housing owners by owner...');
 
-  const ownerHousings: ReadonlyArray<HousingOwnerDBO & HousingRecordDBO> =
-    await HousingOwners()
-      .select(`${housingOwnersTable}.*`)
-      .where({
-        owner_id: owner.id
-      })
-      .modify((query) => {
-        // Filter by geoCodes (user perimeter filtering)
-        // Note: geoCodes is an array when a restriction applies
-        //   - non-empty array: filter to housings in these geoCodes
-        //   - empty array: user should see NO housings (intersection with perimeter is empty)
-        if (options?.geoCodes !== undefined) {
-          if (options.geoCodes.length === 0) {
-            // Empty geoCodes means no access - return no results
-            query.whereRaw('1 = 0');
-          } else {
-            query.whereIn(
-              `${housingOwnersTable}.housing_geo_code`,
-              options.geoCodes as string[]
-            );
-          }
-        }
-      })
-      .join(housingTable, (join) => {
-        join
-          .on(`${housingOwnersTable}.housing_id`, `${housingTable}.id`)
-          .andOn(
-            `${housingOwnersTable}.housing_geo_code`,
-            `${housingTable}.geo_code`
-          );
-      })
-      .select(`${housingTable}.*`);
+  let query: any = kysely
+    .selectFrom('ownersHousing')
+    .innerJoin('fastHousing', (join) =>
+      join
+        .onRef('ownersHousing.housingId', '=', 'fastHousing.id')
+        .onRef('ownersHousing.housingGeoCode', '=', 'fastHousing.geoCode')
+    )
+    .selectAll('ownersHousing')
+    .selectAll('fastHousing')
+    .where('ownersHousing.ownerId', '=', owner.id);
 
-  return ownerHousings.map(parseOwnerHousingApi);
+  // Filter by geoCodes (user perimeter filtering)
+  //   - non-empty array: filter to housings in these geoCodes
+  //   - empty array: user should see NO housings (HandleEmptyInListsPlugin turns
+  //     the empty `in ()` into a non-contingent false, matching the old `1 = 0`)
+  if (options?.geoCodes !== undefined) {
+    query = query.where(
+      'ownersHousing.housingGeoCode',
+      'in',
+      options.geoCodes as string[]
+    );
+  }
+
+  const rows: ReadonlyArray<Selectable<DB['ownersHousing']> & HousingRecordRow> =
+    await query.execute();
+
+  return rows.map(parseOwnerHousingRow);
 }
 
 async function insert(housingOwner: HousingOwnerApi): Promise<void> {
@@ -198,6 +192,44 @@ export function parseOwnerHousingApi(
     ...owner
   };
 }
+
+/**
+ * Camel-case Kysely mirror of {@link parseOwnerHousingApi}. Reads a joined
+ * owners_housing + fast_housing row (camelCase columns; fast_housing supplies
+ * the housing id/geoCode) and returns the owner-housing link merged with the
+ * housing record.
+ */
+export function parseOwnerHousingRow(
+  row: Selectable<DB['ownersHousing']> & HousingRecordRow
+): Omit<HousingOwnerApi, keyof OwnerApi> & HousingRecordApi {
+  const owner: Omit<HousingOwnerApi, keyof OwnerApi> = {
+    housingGeoCode: row.geoCode,
+    housingId: row.id,
+    ownerId: row.ownerId,
+    rank: row.rank as OwnerRank,
+    // DATE columns come back as "YYYY-MM-DD" strings; the API type declares Date,
+    // matching the pre-migration passthrough.
+    startDate: row.startDate as unknown as Date | null,
+    endDate: row.endDate as unknown as Date | null,
+    origin: row.origin,
+    idprocpte: row.idprocpte,
+    idprodroit: row.idprodroit,
+    locprop:
+      row.locpropSource !== null ? Number(row.locpropSource) : null,
+    propertyRight: row.propertyRight as PropertyRight | null,
+    relativeLocation: row.locpropRelativeBan
+      ? fromRelativeLocationDBO(row.locpropRelativeBan)
+      : null,
+    absoluteDistance: row.locpropDistanceBan
+  };
+  const housing: HousingRecordApi = parseHousingRecordRow(row);
+
+  return {
+    ...housing,
+    ...owner
+  };
+}
+
 export const formatHousingOwnerApi = (
   housingOwner: Omit<HousingOwnerApi, keyof OwnerApi>
 ): HousingOwnerDBO => ({

--- a/server/src/repositories/housingOwnerRepository.ts
+++ b/server/src/repositories/housingOwnerRepository.ts
@@ -61,8 +61,9 @@ async function findByOwner(
     );
   }
 
-  const rows: ReadonlyArray<Selectable<DB['ownersHousing']> & HousingRecordRow> =
-    await query.execute();
+  const rows: ReadonlyArray<
+    Selectable<DB['ownersHousing']> & HousingRecordRow
+  > = await query.execute();
 
   return rows.map(parseOwnerHousingRow);
 }
@@ -214,8 +215,7 @@ export function parseOwnerHousingRow(
     origin: row.origin,
     idprocpte: row.idprocpte,
     idprodroit: row.idprodroit,
-    locprop:
-      row.locpropSource !== null ? Number(row.locpropSource) : null,
+    locprop: row.locpropSource !== null ? Number(row.locpropSource) : null,
     propertyRight: row.propertyRight as PropertyRight | null,
     relativeLocation: row.locpropRelativeBan
       ? fromRelativeLocationDBO(row.locpropRelativeBan)

--- a/server/src/repositories/housingRepository.ts
+++ b/server/src/repositories/housingRepository.ts
@@ -638,6 +638,65 @@ export const parseHousingRecordApi = (
   lastTransactionValue: housing.last_transaction_value
 });
 
+/**
+ * Camel-case Kysely mirror of {@link parseHousingRecordApi}. Reads the plain
+ * fast_housing record columns (no joined includes) from a Kysely row and is
+ * used by the housingOwner read path (findByOwner).
+ */
+export type HousingRecordRow = Selectable<DB['fastHousing']>;
+
+export const parseHousingRecordRow = (
+  row: HousingRecordRow
+): HousingRecordApi => ({
+  id: row.id,
+  invariant: row.invariant,
+  localId: row.localId,
+  plotId: row.plotId,
+  plotArea: row.plotArea,
+  buildingGroupId: row.buildingGroupId,
+  buildingId: row.buildingId,
+  buildingYear: row.buildingYear,
+  buildingLocation: row.buildingLocation,
+  rawAddress: row.addressDgfip,
+  longitude: row.longitudeDgfip,
+  latitude: row.latitudeDgfip,
+  geoCode: row.geoCode,
+  geolocation: row.geolocation as unknown as Point | null,
+  cadastralClassification:
+    row.cadastralClassification as CadastralClassification | null,
+  uncomfortable: row.uncomfortable,
+  vacancyStartYear: row.vacancyStartYear,
+  housingKind: row.housingKind as HousingKind,
+  roomsCount: row.roomsCount,
+  livingArea: row.livingArea,
+  cadastralReference: row.cadastralReference,
+  beneficiaryCount: row.beneficiaryCount,
+  rentalValue: row.rentalValue,
+  taxed: row.taxed,
+  ownershipKind: row.condominium,
+  dataYears: row.dataYears,
+  dataFileYears: (row.dataFileYears ?? []) as DataFileYear[],
+  source: row.dataSource as HousingSource | null,
+  status: row.status as HousingStatus,
+  subStatus: row.subStatus,
+  actualEnergyConsumption: row.actualDpe as EnergyConsumption | null,
+  energyConsumption: row.energyConsumptionBdnb as EnergyConsumption | null,
+  energyConsumptionAt: row.energyConsumptionAtBdnb
+    ? new Date(row.energyConsumptionAtBdnb)
+    : null,
+  occupancy: row.occupancy as Occupancy,
+  occupancyRegistered: row.occupancySource as Occupancy,
+  occupancyIntended: row.occupancyIntended as Occupancy | null,
+  lastMutationType: row.lastMutationType as Mutation['type'] | null,
+  lastMutationDate: row.lastMutationDate
+    ? new Date(row.lastMutationDate).toJSON()
+    : null,
+  lastTransactionDate: row.lastTransactionDate
+    ? new Date(row.lastTransactionDate).toJSON()
+    : null,
+  lastTransactionValue: row.lastTransactionValue
+});
+
 // ---------------------------------------------------------------------------
 // Kysely read layer (find/findOne/stream/count). Mirrors the Knex builders
 // below; the Knex query surface is kept for seeds/LOVAC/still-Knex callers.


### PR DESCRIPTION
## Summary

Migrates `housingOwnerRepository.findByOwner` (the last Knex **read** in this repo) to Kysely. Writes (`insert`, `saveMany`) were already migrated in an earlier PR.

- Adds an exported `parseHousingRecordRow` / `HousingRecordRow` to `housingRepository` — a camelCase Kysely mirror of `parseHousingRecordApi` covering the plain `fast_housing` record columns (no joined includes).
- Adds `parseOwnerHousingRow` mirroring `parseOwnerHousingApi`: reads camelCase `owners_housing` columns and the `fast_housing` record via `parseHousingRecordRow`.
- `findByOwner` now joins `owners_housing → fast_housing` directly in Kysely. The empty-`geoCodes` "no access" case is handled by `HandleEmptyInListsPlugin` (an empty `in ()` becomes a non-contingent false), preserving the old `whereRaw('1 = 0')` behaviour.

## Test plan
- [x] `yarn nx typecheck server`
- [x] `yarn lint` (0 errors)
- [x] `yarn nx test server -- run src/repositories/test/housingOwnerRepository.test.ts src/repositories/test/ownerRepository.test.ts src/controllers/test/owner-api.test.ts` → **110 passed**
- [x] `yarn nx test server -- run src/controllers/test/housing-owner-api.test.ts` → **3 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)