### PR TITLE
refactor(server): migrate draft and sender reads to Kysely

### DIFF
--- a/server/src/infra/database/kysely.ts
+++ b/server/src/infra/database/kysely.ts
@@ -27,9 +27,10 @@ export const kysely = new Kysely<DB>({
   dialect: new PostgresDialect({ pool, cursor: Cursor }),
   plugins: [
     // maintainNestedObjectKeys keeps keys inside JSON aggregates
-    // (`to_json(users.*)`, `json_build_object(...)`) untouched, so the snake_case
-    // DBO parsers (fromUserDBO, fromDocumentDBO) still read them. Without it the
-    // plugin recursively camelCases nested JSON and those parsers get undefined.
+    // (`to_json(users.*)`, `to_json(senders.*)`, `jsonb_build_object(...)`)
+    // untouched, so the snake_case DBO parsers (fromUserDBO, parseSenderApi,
+    // fromDocumentDBO) still read them. Without it the plugin recursively
+    // camelCases nested JSON and those parsers get undefined.
     new CamelCasePlugin({ maintainNestedObjectKeys: true }),
     new DeduplicateJoinsPlugin(),
     new SafeNullComparisonPlugin(),

--- a/server/src/repositories/documentRepository.ts
+++ b/server/src/repositories/documentRepository.ts
@@ -195,6 +195,47 @@ export function joinDocumentWithCreator(
     );
 }
 
+/**
+ * Kysely mirror of {@link joinDocumentWithCreator}. Returns a correlated scalar
+ * subquery that builds the document + nested creator JSON blob for the document
+ * referenced by `fkColumn` (a raw, table-qualified snake_case column such as
+ * `senders.signatory_one_document_id`). The blob keys stay snake_case — the
+ * CamelCasePlugin's `maintainNestedObjectKeys` leaves them untouched, so
+ * {@link fromDocumentDBO} reads them. Resolves to NULL when the FK is null or
+ * no matching document exists, matching the Knex `CASE WHEN ... ELSE NULL END`.
+ */
+export function selectDocumentWithCreator(fkColumn: string, alias: string) {
+  return sql`(
+    SELECT jsonb_build_object(
+      'id', d.id,
+      'filename', d.filename,
+      's3_key', d.s3_key,
+      'content_type', d.content_type,
+      'size_bytes', d.size_bytes,
+      'establishment_id', d.establishment_id,
+      'created_by', d.created_by,
+      'created_at', d.created_at,
+      'updated_at', d.updated_at,
+      'deleted_at', d.deleted_at,
+      'creator', json_build_object(
+        'id', u.id,
+        'email', u.email,
+        'first_name', u.first_name,
+        'last_name', u.last_name,
+        'role', u.role,
+        'establishment_id', u.establishment_id,
+        'time_per_week', u.time_per_week,
+        'phone', u.phone,
+        'position', u.position,
+        'updated_at', u.updated_at
+      )
+    )
+    FROM ${sql.raw(DOCUMENTS_TABLE)} d
+    LEFT JOIN ${sql.raw(USERS_TABLE)} u ON u.id = d.created_by
+    WHERE d.id = ${sql.raw(fkColumn)}
+  )`.as(alias);
+}
+
 // Kysely query builder with the creator embedded as a JSON column.
 // The creator fields mirror the Knex `queryWithCreator` projection (no
 // sensitive columns) so the parsed `UserDBO` shape is unchanged.

--- a/server/src/repositories/draftRepository.ts
+++ b/server/src/repositories/draftRepository.ts
@@ -102,31 +102,33 @@ function toDraftInsert(draft: DraftApi): Insertable<DB['drafts']> {
 }
 
 function draftListQuery(): any {
-  return kysely
-    .selectFrom('drafts')
-    .selectAll('drafts')
-    .leftJoin('senders', 'drafts.senderId', 'senders.id')
-    .select(sql`to_json(senders.*)`.as('sender'))
-    // signatory documents (from the joined sender)
-    .select(
-      selectDocumentWithCreator(
-        'senders.signatory_one_document_id',
-        'signatory_one_doc'
+  return (
+    kysely
+      .selectFrom('drafts')
+      .selectAll('drafts')
+      .leftJoin('senders', 'drafts.senderId', 'senders.id')
+      .select(sql`to_json(senders.*)`.as('sender'))
+      // signatory documents (from the joined sender)
+      .select(
+        selectDocumentWithCreator(
+          'senders.signatory_one_document_id',
+          'signatory_one_doc'
+        )
       )
-    )
-    .select(
-      selectDocumentWithCreator(
-        'senders.signatory_two_document_id',
-        'signatory_two_doc'
+      .select(
+        selectDocumentWithCreator(
+          'senders.signatory_two_document_id',
+          'signatory_two_doc'
+        )
       )
-    )
-    // logo next documents (from the draft)
-    .select(
-      selectDocumentWithCreator('drafts.logo_next_one', 'logo_next_one_doc')
-    )
-    .select(
-      selectDocumentWithCreator('drafts.logo_next_two', 'logo_next_two_doc')
-    );
+      // logo next documents (from the draft)
+      .select(
+        selectDocumentWithCreator('drafts.logo_next_one', 'logo_next_one_doc')
+      )
+      .select(
+        selectDocumentWithCreator('drafts.logo_next_two', 'logo_next_two_doc')
+      )
+  );
 }
 
 function applyDraftFilters(query: any, filters?: DraftFilters): any {

--- a/server/src/repositories/draftRepository.ts
+++ b/server/src/repositories/draftRepository.ts
@@ -1,25 +1,21 @@
 import { FileUploadDTO } from '@zerologementvacant/models';
 import async from 'async';
 import { Knex } from 'knex';
-import type { Insertable } from 'kysely';
+import { sql, type Insertable } from 'kysely';
 
 import { download } from '~/controllers/fileRepository';
 import db from '~/infra/database';
 import type { DB } from '~/infra/database/db';
+import { kysely } from '~/infra/database/kysely';
 import { withinKyselyTransaction } from '~/infra/database/kysely-transaction';
 import { createLogger } from '~/infra/logger';
 import { DraftApi } from '~/models/DraftApi';
-import { campaignsDraftsTable } from '~/repositories/campaignDraftRepository';
 import {
   fromDocumentDBO,
-  joinDocumentWithCreator,
+  selectDocumentWithCreator,
   type DocumentWithCreatorDBO
 } from '~/repositories/documentRepository';
-import {
-  parseSenderApi,
-  SenderDBO,
-  sendersTable
-} from '~/repositories/senderRepository';
+import { parseSenderApi, SenderDBO } from '~/repositories/senderRepository';
 
 const logger = createLogger('draftRepository');
 
@@ -39,32 +35,29 @@ interface FindOptions {
 
 async function find(opts?: FindOptions): Promise<DraftApi[]> {
   logger.debug('Finding drafts...', opts);
-  const drafts: DraftDBO[] = await Drafts()
-    .modify(listQuery)
-    .modify(filterQuery(opts?.filters))
-    .orderBy('created_at', 'desc');
-  logger.debug('Found drafts', drafts);
-  return async.map(drafts, parseDraftApi);
+  let query = draftListQuery();
+  query = applyDraftFilters(query, opts?.filters);
+  query = query.orderBy('drafts.createdAt', 'desc');
+  const rows = await query.execute();
+  logger.debug('Found drafts', rows);
+  return async.map(rows, parseDraftRow);
 }
 
 type FindOneOptions = Pick<DraftApi, 'id' | 'establishmentId'>;
 
 async function findOne(opts: FindOneOptions): Promise<DraftApi | null> {
-  const draft = await Drafts()
-    .modify(listQuery)
-    .where(
-      filterQuery({
-        id: opts.id,
-        establishment: opts.establishmentId
-      })
-    )
-    .first();
-  if (!draft) {
+  let query = draftListQuery();
+  query = applyDraftFilters(query, {
+    id: opts.id,
+    establishment: opts.establishmentId
+  });
+  const row = await query.executeTakeFirst();
+  if (!row) {
     return null;
   }
 
-  logger.debug('Found draft', draft);
-  return parseDraftApi(draft);
+  logger.debug('Found draft', row);
+  return parseDraftRow(row);
 }
 
 async function save(draft: DraftApi): Promise<void> {
@@ -108,59 +101,50 @@ function toDraftInsert(draft: DraftApi): Insertable<DB['drafts']> {
   };
 }
 
-function listQuery(query: Knex.QueryBuilder): void {
-  query
-    .select(`${draftsTable}.*`)
-    .leftJoin<SenderDBO>(
-      sendersTable,
-      `${draftsTable}.sender_id`,
-      `${sendersTable}.id`
+function draftListQuery(): any {
+  return kysely
+    .selectFrom('drafts')
+    .selectAll('drafts')
+    .leftJoin('senders', 'drafts.senderId', 'senders.id')
+    .select(sql`to_json(senders.*)`.as('sender'))
+    // signatory documents (from the joined sender)
+    .select(
+      selectDocumentWithCreator(
+        'senders.signatory_one_document_id',
+        'signatory_one_doc'
+      )
     )
-    .select(db.raw(`to_json(${sendersTable}.*) AS sender`));
-  // signatory documents
-  joinDocumentWithCreator(
-    query,
-    `${sendersTable}.signatory_one_document_id`,
-    'signatory_one_doc'
-  );
-  joinDocumentWithCreator(
-    query,
-    `${sendersTable}.signatory_two_document_id`,
-    'signatory_two_doc'
-  );
-  // logo next documents
-  joinDocumentWithCreator(
-    query,
-    `${draftsTable}.logo_next_one`,
-    'logo_next_one_doc'
-  );
-  joinDocumentWithCreator(
-    query,
-    `${draftsTable}.logo_next_two`,
-    'logo_next_two_doc'
-  );
+    .select(
+      selectDocumentWithCreator(
+        'senders.signatory_two_document_id',
+        'signatory_two_doc'
+      )
+    )
+    // logo next documents (from the draft)
+    .select(
+      selectDocumentWithCreator('drafts.logo_next_one', 'logo_next_one_doc')
+    )
+    .select(
+      selectDocumentWithCreator('drafts.logo_next_two', 'logo_next_two_doc')
+    );
 }
 
-function filterQuery(filters?: DraftFilters) {
-  return (query: Knex.QueryBuilder): void => {
-    if (filters?.id) {
-      query.where(`${draftsTable}.id`, filters.id);
-    }
+function applyDraftFilters(query: any, filters?: DraftFilters): any {
+  if (filters?.id) {
+    query = query.where('drafts.id', '=', filters.id);
+  }
 
-    if (filters?.establishment) {
-      query.where(`${draftsTable}.establishment_id`, filters.establishment);
-    }
+  if (filters?.establishment) {
+    query = query.where('drafts.establishmentId', '=', filters.establishment);
+  }
 
-    if (filters?.campaign) {
-      query
-        .join(
-          campaignsDraftsTable,
-          `${campaignsDraftsTable}.draft_id`,
-          `${draftsTable}.id`
-        )
-        .where(`${campaignsDraftsTable}.campaign_id`, filters.campaign);
-    }
-  };
+  if (filters?.campaign) {
+    query = query
+      .innerJoin('campaignsDrafts', 'campaignsDrafts.draftId', 'drafts.id')
+      .where('campaignsDrafts.campaignId', '=', filters.campaign);
+  }
+
+  return query;
 }
 
 export interface DraftRecordDBO {
@@ -232,6 +216,46 @@ export const parseDraftApi = async (draft: DraftDBO): Promise<DraftApi> => {
     }),
     createdAt: draft.created_at.toJSON(),
     updatedAt: draft.updated_at.toJSON()
+  };
+};
+
+/**
+ * Camel-case Kysely mirror of {@link parseDraftApi}. The draft columns come back
+ * camelCase (CamelCasePlugin) while the joined `sender` (to_json) and document
+ * blobs stay snake_case (maintainNestedObjectKeys), so the existing snake-case
+ * {@link parseSenderApi} and {@link fromDocumentDBO} still read them.
+ */
+export const parseDraftRow = async (row: any): Promise<DraftApi> => {
+  let logo: FileUploadDTO[] | null = null;
+
+  if (Array.isArray(row.logo)) {
+    try {
+      logo = await Promise.all(row.logo.map(download));
+    } catch {
+      logo = null;
+    }
+  }
+
+  return {
+    id: row.id,
+    subject: row.subject,
+    body: row.body,
+    logo: logo,
+    logoNext: [
+      row.logoNextOneDoc ? fromDocumentDBO(row.logoNextOneDoc) : null,
+      row.logoNextTwoDoc ? fromDocumentDBO(row.logoNextTwoDoc) : null
+    ],
+    writtenAt: row.writtenAt,
+    writtenFrom: row.writtenFrom,
+    establishmentId: row.establishmentId,
+    senderId: row.senderId,
+    sender: await parseSenderApi({
+      ...row.sender,
+      signatory_one_document: row.signatoryOneDoc ?? null,
+      signatory_two_document: row.signatoryTwoDoc ?? null
+    }),
+    createdAt: new Date(row.createdAt).toJSON(),
+    updatedAt: new Date(row.updatedAt).toJSON()
   };
 };
 

--- a/server/src/repositories/senderRepository.ts
+++ b/server/src/repositories/senderRepository.ts
@@ -1,14 +1,15 @@
 import type { Insertable } from 'kysely';
 
 import { download } from '~/controllers/fileRepository';
-import db, { where } from '~/infra/database';
+import db from '~/infra/database';
 import type { DB } from '~/infra/database/db';
+import { kysely } from '~/infra/database/kysely';
 import { withinKyselyTransaction } from '~/infra/database/kysely-transaction';
 import { createLogger } from '~/infra/logger';
 import { SenderApi } from '~/models/SenderApi';
 import {
   fromDocumentDBO,
-  joinDocumentWithCreator,
+  selectDocumentWithCreator,
   type DocumentWithCreatorDBO
 } from '~/repositories/documentRepository';
 
@@ -24,32 +25,38 @@ type FindOneOptions = Partial<
 
 async function findOne(opts: FindOneOptions): Promise<SenderApi | null> {
   logger.debug('Finding sender...', opts);
-  const whereOptions = where<FindOneOptions>(
-    ['id', 'name', 'establishmentId'],
-    { table: sendersTable }
-  );
 
-  const query = Senders().where(whereOptions(opts));
-  joinDocumentWithCreator(
-    query,
-    `${sendersTable}.signatory_one_document_id`,
-    'signatory_one_document'
-  );
-  joinDocumentWithCreator(
-    query,
-    `${sendersTable}.signatory_two_document_id`,
-    'signatory_two_document'
-  );
+  let query: any = kysely.selectFrom('senders').selectAll('senders');
+  if (opts.id !== undefined) {
+    query = query.where('senders.id', '=', opts.id);
+  }
+  if (opts.name !== undefined) {
+    query = query.where('senders.name', '=', opts.name);
+  }
+  if (opts.establishmentId !== undefined) {
+    query = query.where('senders.establishmentId', '=', opts.establishmentId);
+  }
+  query = query
+    .select(
+      selectDocumentWithCreator(
+        'senders.signatory_one_document_id',
+        'signatory_one_document'
+      )
+    )
+    .select(
+      selectDocumentWithCreator(
+        'senders.signatory_two_document_id',
+        'signatory_two_document'
+      )
+    );
 
-  const sender = (await query.select(`${sendersTable}.*`).first()) as
-    | SenderDBOWithDocuments
-    | undefined;
-  if (!sender) {
+  const row = await query.executeTakeFirst();
+  if (!row) {
     return null;
   }
 
-  logger.debug('Found sender', sender);
-  return parseSenderApi(sender);
+  logger.debug('Found sender', row);
+  return parseSenderRow(row);
 }
 
 async function save(sender: SenderApi): Promise<void> {
@@ -217,6 +224,66 @@ export const parseSenderApi = async (
     createdAt: new Date(sender.created_at).toJSON(),
     updatedAt: new Date(sender.updated_at).toJSON(),
     establishmentId: sender.establishment_id
+  };
+};
+
+/**
+ * Camel-case Kysely mirror of {@link parseSenderApi}. Reads the top-level
+ * senders columns as camelCase (CamelCasePlugin) while the signatory document
+ * blobs stay snake_case (jsonb_build_object + maintainNestedObjectKeys), so
+ * {@link fromDocumentDBO} still reads them.
+ */
+export const parseSenderRow = async (row: any): Promise<SenderApi> => {
+  let signatory_one_file;
+  try {
+    signatory_one_file = row.signatoryOneFile
+      ? await download(row.signatoryOneFile)
+      : null;
+  } catch {
+    signatory_one_file = null;
+  }
+
+  let signatory_two_file;
+  try {
+    signatory_two_file = row.signatoryTwoFile
+      ? await download(row.signatoryTwoFile)
+      : null;
+  } catch {
+    signatory_two_file = null;
+  }
+
+  return {
+    id: row.id,
+    name: row.name,
+    service: row.service,
+    firstName: row.firstName,
+    lastName: row.lastName,
+    address: row.address,
+    email: row.email,
+    phone: row.phone,
+    signatories: [
+      {
+        firstName: row.signatoryOneFirstName,
+        lastName: row.signatoryOneLastName,
+        role: row.signatoryOneRole,
+        file: signatory_one_file,
+        document: row.signatoryOneDocument
+          ? fromDocumentDBO(row.signatoryOneDocument)
+          : null
+      },
+      {
+        firstName: row.signatoryTwoFirstName,
+        lastName: row.signatoryTwoLastName,
+        role: row.signatoryTwoRole,
+        file: signatory_two_file,
+        document: row.signatoryTwoDocument
+          ? fromDocumentDBO(row.signatoryTwoDocument)
+          : null
+      }
+    ],
+    createdAt: new Date(row.createdAt).toJSON(),
+    updatedAt: new Date(row.updatedAt).toJSON(),
+    establishmentId: row.establishmentId
   };
 };
 

--- a/server/src/repositories/test/draftRepository.test.ts
+++ b/server/src/repositories/test/draftRepository.test.ts
@@ -4,6 +4,7 @@ import { DraftApi } from '~/models/DraftApi';
 import { SenderApi } from '~/models/SenderApi';
 import { factories } from '~/test/factories';
 import {
+  genDocumentApi,
   genDraftApi,
   genEstablishmentApi,
   genSenderApi,
@@ -11,6 +12,7 @@ import {
 } from '~/test/testFixtures';
 
 import { CampaignsDrafts } from '../campaignDraftRepository';
+import { Documents, toDocumentDBO } from '../documentRepository';
 import draftRepository, { Drafts, formatDraftApi } from '../draftRepository';
 import {
   Establishments,
@@ -103,6 +105,46 @@ describe('Draft repository', () => {
       });
 
       expect(actual).toStrictEqual<DraftApi>(draft);
+    });
+
+    it('should hydrate a signatory document with its nested creator', async () => {
+      const document = genDocumentApi({
+        establishmentId: establishment.id,
+        creator: user
+      });
+      await Documents().insert(toDocumentDBO(document));
+
+      const documentSender = genSenderApi(establishment);
+      documentSender.signatories[0] = {
+        firstName: documentSender.signatories[0]?.firstName ?? null,
+        lastName: documentSender.signatories[0]?.lastName ?? null,
+        role: documentSender.signatories[0]?.role ?? null,
+        file: null,
+        document
+      };
+      await Senders().insert(formatSenderApi(documentSender));
+
+      const documentDraft = genDraftApi(establishment, documentSender);
+      await Drafts().insert(formatDraftApi(documentDraft));
+
+      const actual = await draftRepository.findOne({
+        id: documentDraft.id,
+        establishmentId: documentDraft.establishmentId
+      });
+
+      expect(actual).not.toBeNull();
+      expect(actual?.sender.signatories[0]?.document).toMatchObject({
+        id: document.id,
+        filename: document.filename,
+        s3Key: document.s3Key,
+        createdBy: user.id,
+        creator: expect.objectContaining({
+          id: user.id,
+          email: user.email
+        })
+      });
+      // the second (empty) signatory must stay null
+      expect(actual?.sender.signatories[1]?.document).toBeNull();
     });
   });
 


### PR DESCRIPTION
## Summary

Migrates the last Knex **reads** in the draft/sender area to Kysely: `draftRepository.find` / `findOne` and `senderRepository.findOne`. The corresponding writes were already migrated in the campaign write-cluster (#1901), on which this branch is based.

- Adds `selectDocumentWithCreator` to `documentRepository` — a Kysely correlated scalar subquery mirroring `joinDocumentWithCreator`. It builds the document + nested creator JSON blob (snake_case keys) and resolves to `NULL` when the FK is unset or no document matches, preserving the old `CASE WHEN ... ELSE NULL END`. The Knex `joinDocumentWithCreator` is kept (still used by the Knex document reads and its own test).
- Adds camelCase `parseDraftRow` / `parseSenderRow` alongside the kept snake_case `parseDraftApi` / `parseSenderApi`. The joined `to_json(senders.*)` blob and the document blobs stay snake_case, so the existing parsers still read them.
- Enables `CamelCasePlugin({ maintainNestedObjectKeys: true })` so nested JSON keys aren't recursively camelCased (this is the same fix already carried on the other read branches; required here because the nested creator JSON is read by `fromDocumentDBO` / `parseSenderApi`).
- Adds coverage for the previously-untested non-null document read path: a draft `findOne` now asserts the signatory document is hydrated with its nested creator (the alias keys + nested-JSON handling were only exercised with null documents before).

## Test plan
- [x] `yarn nx typecheck server`
- [x] `yarn lint` (0 errors)
- [x] `yarn nx test server -- run src/repositories/test/draftRepository.test.ts src/controllers/test/draft-api.test.ts src/controllers/test/campaign-api.test.ts` → **62 passed**
- [x] `yarn nx test server -- run src/repositories/test/documentRepository.test.ts` → **23 passed**
- [x] Full `src/repositories/test` sweep → 477 passed (1 unrelated pre-existing flake in the still-Knex `housingRepository` occupancy filter, passes in isolation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)