### PR TITLE
Add a parameter for DB flavor and default to xxs_sml

### DIFF
--- a/tools/terraform/main.tf
+++ b/tools/terraform/main.tf
@@ -28,6 +28,7 @@ resource "random_password" "e2e_password" {
 module "database" {
   source = "./modules/database"
 
+  flavor       = var.db.flavor
   project_name = var.project_name
   region       = var.region
 }

--- a/tools/terraform/variables.tf
+++ b/tools/terraform/variables.tf
@@ -57,3 +57,13 @@ variable "region" {
   type        = string
   default     = "par" # Paris (Europe)
 }
+
+variable "db" {
+  description = "Database configuration"
+  type = object({
+    flavor = string
+  })
+  default = {
+    flavor = "xxs_sml"
+  }
+}


### PR DESCRIPTION
## Summary
- Add a `db.flavor` variable to the root Terraform config so the Clever Cloud PostgreSQL plan is configurable per environment instead of hardcoded
- Wire it through to the `database` module's existing `flavor` input, defaulting to `xxs_sml` (matches the module's prior default, so no behavior change for existing deployments)

## Test plan
- [ ] `terraform validate` / `terraform plan` in `tools/terraform` shows no unexpected diff with the default value
- [ ] Confirm overriding `db.flavor` in a `.tfvars` file changes the planned Clever Cloud PostgreSQL plan