### PR TITLE
feat: save a campaign from the campaigns list

### DIFF
--- a/apps/front-e2e-pw/README.md
+++ b/apps/front-e2e-pw/README.md
@@ -56,3 +56,11 @@ yarn workspace @zerologementvacant/front-e2e-pw exec playwright show-trace path/
   session cookie, and protected routes redirect again.
 - `tests/suspended-user.spec.ts` — a suspended user sees the
   SuspendedUserModal.
+- `tests/save-campaign.spec.ts` — "Enregistrer une campagne" two-step modal
+  on the campaigns list, against a pre-existing eligible group; redirect to
+  the new campaign's page; step 2 reopens after cancelling and re-selecting
+  the same group.
+- `tests/group-to-campaign.spec.ts` — full journey from the housing list:
+  select all housings, create a group, then create a campaign from it via
+  either the group's own page or the campaigns list, with and without a
+  sending date — each path redirects to the new campaign's page.

--- a/apps/front-e2e-pw/tests/group-to-campaign.spec.ts
+++ b/apps/front-e2e-pw/tests/group-to-campaign.spec.ts
@@ -1,0 +1,217 @@
+import { type Locator, type Page } from '@playwright/test';
+
+import { expect, test } from '../fixtures/auth';
+
+/**
+ * Full journey from the housing list to a created campaign, going through a
+ * freshly created group: select every housing, create a group from that
+ * selection, then create a campaign from it either via the group's own page
+ * ("Créer une campagne") or via the campaigns list ("Enregistrer une
+ * campagne"). Both paths must redirect to the new campaign's own page
+ * (`/campagnes/:id`) on success — see `save-campaign.spec.ts` for the
+ * dedicated regression guard on the two-step modal itself.
+ *
+ * Each test creates its own group and campaign (unique, timestamped names)
+ * and deletes both afterwards, so runs are repeatable and parallel-safe.
+ */
+
+function nearFutureDate(): string {
+  const date = new Date();
+  date.setDate(date.getDate() + 7);
+  return date.toISOString().slice(0, 10);
+}
+
+async function createGroupFromAllHousings(
+  page: Page,
+  title: string
+): Promise<{ groupId: string }> {
+  await page.goto('/parc-de-logements');
+  await page
+    .getByRole('checkbox', { name: 'Sélectionner tous les éléments' })
+    .click();
+  await page.getByRole('button', { name: 'Intégrer dans un groupe' }).click();
+  await page.getByRole('button', { name: 'Créer un nouveau groupe' }).click();
+
+  const groupDialog = page
+    .getByRole('dialog')
+    .filter({ hasText: 'Créer un nouveau groupe de logements' });
+  await groupDialog
+    .getByRole('textbox', { name: /^Nom du groupe/ })
+    .fill(title);
+  await groupDialog
+    .getByRole('textbox', { name: /^Description du groupe/ })
+    .fill('Groupe créé par le test e2e');
+
+  const created = page.waitForResponse(
+    (response) =>
+      response.request().method() === 'POST' && /\/groups$/.test(response.url())
+  );
+  await groupDialog.getByRole('button', { name: 'Créer un groupe' }).click();
+  const createdResponse = await created;
+  expect(createdResponse.ok()).toBe(true);
+  const { id: groupId } = await createdResponse.json();
+
+  await page.waitForURL(`**/groupes/${groupId}`);
+  return { groupId };
+}
+
+/**
+ * Fills the (shared) campaign creation form inside the given dialog and
+ * submits it, returning the id of the campaign the API created.
+ */
+async function submitCampaignForm(
+  dialog: Locator,
+  options: { name: string; sentAt?: string }
+): Promise<{ campaignId: string }> {
+  await dialog.getByLabel(/^Nom/).fill(options.name);
+  if (options.sentAt) {
+    await dialog.getByLabel(/Date d’envoi/).fill(options.sentAt);
+  }
+
+  const created = dialog
+    .page()
+    .waitForResponse(
+      (response) =>
+        response.request().method() === 'POST' &&
+        /\/groups\/[^/]+\/campaigns$/.test(response.url())
+    );
+  await dialog.getByRole('button', { name: 'Confirmer' }).click();
+  const createdResponse = await created;
+  expect(createdResponse.ok()).toBe(true);
+  const { id: campaignId } = await createdResponse.json();
+
+  return { campaignId };
+}
+
+async function cleanUp(page: Page, groupId: string): Promise<void> {
+  await page.getByRole('button', { name: 'Supprimer la campagne' }).click();
+  await page
+    .getByRole('dialog')
+    .filter({ hasText: 'Supprimer la campagne' })
+    .getByRole('button', { name: 'Confirmer' })
+    .click();
+
+  await page.goto(`/groupes/${groupId}`);
+  await page.getByRole('button', { name: 'Supprimer le groupe' }).click();
+  await page
+    .getByRole('dialog')
+    .filter({ hasText: 'Supprimer le groupe' })
+    .getByRole('button', { name: 'Confirmer' })
+    .click();
+}
+
+test.describe('Create a campaign from a freshly created group', () => {
+  test.describe('From the group page', () => {
+    test('redirects to the new campaign without a sending date', async ({
+      signedInPage: page
+    }) => {
+      const { groupId } = await createGroupFromAllHousings(
+        page,
+        `E2E group ${Date.now()}`
+      );
+
+      await page.getByRole('button', { name: /^Créer une campagne/ }).click();
+      const modal = page
+        .getByRole('dialog')
+        .filter({ hasText: /Créer une campagne/ });
+      const name = `E2E campaign ${Date.now()}`;
+      const { campaignId } = await submitCampaignForm(modal, { name });
+
+      await page.waitForURL(`**/campagnes/${campaignId}`);
+      await expect(page.getByRole('heading', { name, level: 1 })).toBeVisible();
+
+      await cleanUp(page, groupId);
+    });
+
+    test('redirects to the new campaign with a sending date in the near future', async ({
+      signedInPage: page
+    }) => {
+      const { groupId } = await createGroupFromAllHousings(
+        page,
+        `E2E group ${Date.now()}`
+      );
+
+      await page.getByRole('button', { name: /^Créer une campagne/ }).click();
+      const modal = page
+        .getByRole('dialog')
+        .filter({ hasText: /Créer une campagne/ });
+      const name = `E2E campaign ${Date.now()}`;
+      const { campaignId } = await submitCampaignForm(modal, {
+        name,
+        sentAt: nearFutureDate()
+      });
+
+      await page.waitForURL(`**/campagnes/${campaignId}`);
+      await expect(page.getByRole('heading', { name, level: 1 })).toBeVisible();
+
+      await cleanUp(page, groupId);
+    });
+  });
+
+  test.describe('From the campaign list ("Enregistrer une campagne")', () => {
+    test('redirects to the new campaign without a sending date', async ({
+      signedInPage: page
+    }) => {
+      const title = `E2E group ${Date.now()}`;
+      const { groupId } = await createGroupFromAllHousings(page, title);
+
+      await page.goto('/campagnes');
+      await page
+        .getByRole('button', { name: 'Enregistrer une campagne' })
+        .click();
+      const step1 = page
+        .getByRole('dialog')
+        .filter({ hasText: 'Étape 1 sur 2' });
+      await expect(step1).toBeVisible();
+      await step1
+        .getByRole('button', { name: `Sélectionner le groupe ${title}` })
+        .click();
+
+      const step2 = page
+        .getByRole('dialog')
+        .filter({ hasText: 'Étape 2 sur 2' });
+      await expect(step2).toBeVisible();
+      const name = `E2E campaign ${Date.now()}`;
+      const { campaignId } = await submitCampaignForm(step2, { name });
+
+      await page.waitForURL(`**/campagnes/${campaignId}`);
+      await expect(page.getByRole('heading', { name, level: 1 })).toBeVisible();
+
+      await cleanUp(page, groupId);
+    });
+
+    test('redirects to the new campaign with a sending date in the near future', async ({
+      signedInPage: page
+    }) => {
+      const title = `E2E group ${Date.now()}`;
+      const { groupId } = await createGroupFromAllHousings(page, title);
+
+      await page.goto('/campagnes');
+      await page
+        .getByRole('button', { name: 'Enregistrer une campagne' })
+        .click();
+      const step1 = page
+        .getByRole('dialog')
+        .filter({ hasText: 'Étape 1 sur 2' });
+      await expect(step1).toBeVisible();
+      await step1
+        .getByRole('button', { name: `Sélectionner le groupe ${title}` })
+        .click();
+
+      const step2 = page
+        .getByRole('dialog')
+        .filter({ hasText: 'Étape 2 sur 2' });
+      await expect(step2).toBeVisible();
+      const name = `E2E campaign ${Date.now()}`;
+      const { campaignId } = await submitCampaignForm(step2, {
+        name,
+        sentAt: nearFutureDate()
+      });
+
+      await page.waitForURL(`**/campagnes/${campaignId}`);
+      await expect(page.getByRole('heading', { name, level: 1 })).toBeVisible();
+
+      await cleanUp(page, groupId);
+    });
+  });
+});

--- a/apps/front-e2e-pw/tests/save-campaign.spec.ts
+++ b/apps/front-e2e-pw/tests/save-campaign.spec.ts
@@ -1,0 +1,137 @@
+import { type Page } from '@playwright/test';
+
+import { expect, test } from '../fixtures/auth';
+
+/**
+ * "Enregistrer une campagne" flow on the campaigns list: a two-step DSFR modal
+ * (select a group → create a campaign from it).
+ *
+ * This lives in a real browser on purpose. The step 1 → step 2 transition
+ * depends on DSFR initialising the step-2 `<dialog>` asynchronously after it
+ * mounts; opening it too early throws `Cannot read properties of null (reading
+ * 'modal')` and the whole flow crashes. jsdom cannot reproduce this — its
+ * `window.dsfr` shim always returns a ready modal — so a component test would
+ * stay green while the feature is broken. `expect(step 2).toBeVisible()` after
+ * selecting a group is the regression guard.
+ *
+ * Requires the default user (`CYPRESS_EMAIL`) to be Usual/Admin (Visitors don't
+ * see the button) with at least one eligible group (not archived, ≥1 housing).
+ * Skips gracefully when no such group is seeded.
+ */
+test.describe('Save a campaign from a group', () => {
+  const step1 = (page: Page) =>
+    page.getByRole('dialog').filter({ hasText: 'Étape 1 sur 2' });
+  const step2 = (page: Page) =>
+    page.getByRole('dialog').filter({ hasText: 'Étape 2 sur 2' });
+
+  /**
+   * Opens step 1 and returns the first group's "Sélectionner" button plus
+   * whether the establishment actually has an eligible group (the table renders
+   * empty otherwise, and the caller skips).
+   */
+  async function openStep1(page: Page) {
+    await page
+      .getByRole('button', { name: 'Enregistrer une campagne' })
+      .click();
+    await expect(step1(page)).toBeVisible();
+
+    const firstGroup = step1(page)
+      .getByRole('button', { name: /^Sélectionner le groupe/ })
+      .first();
+    const hasGroup = await firstGroup
+      .waitFor({ state: 'visible', timeout: 5_000 })
+      .then(() => true)
+      .catch(() => false);
+
+    return { firstGroup, hasGroup };
+  }
+
+  test('creates a campaign through the two-step modal', async ({
+    signedInPage: page
+  }) => {
+    await page.goto('/campagnes');
+    await expect(
+      page.getByRole('button', { name: 'Enregistrer une campagne' })
+    ).toBeVisible();
+
+    const { firstGroup, hasGroup } = await openStep1(page);
+    test.skip(
+      !hasGroup,
+      'The default user has no eligible group — seed a non-archived group with housing to run this test.'
+    );
+
+    await firstGroup.click();
+
+    // Regression guard: selecting a group must open step 2. This previously
+    // crashed because step 2 was conditionally mounted and opened before its
+    // DSFR `<dialog>` had initialised.
+    await expect(step2(page)).toBeVisible();
+
+    const name = `E2E save-campaign ${Date.now()}`;
+    await step2(page).getByLabel(/^Nom/).fill(name);
+
+    const created = page.waitForResponse(
+      (response) =>
+        response.request().method() === 'POST' &&
+        /\/groups\/[^/]+\/campaigns$/.test(response.url())
+    );
+    await step2(page).getByRole('button', { name: 'Confirmer' }).click();
+    expect((await created).ok()).toBe(true);
+
+    // Success: toast, modal closes, and the campaign lands in the list. The
+    // flow deliberately stays on /campagnes (unlike the group-page flow, which
+    // navigates to the new campaign).
+    await expect(page.getByText('La campagne a été ajoutée')).toBeVisible();
+    await expect(step2(page)).toBeHidden();
+
+    // The new campaign is in the list — its delete button carries a unique,
+    // exact accessible name, so it's a reliable per-campaign anchor.
+    const deleteButton = page.getByRole('button', {
+      name: `Supprimer la campagne ${name}`
+    });
+    await expect(deleteButton).toBeVisible();
+
+    // Cleanup so the run is repeatable and doesn't pollute the environment.
+    await deleteButton.click();
+    await page
+      .getByRole('dialog')
+      .filter({ hasText: /Supprimer la campagne/ })
+      .getByRole('button', { name: 'Confirmer' })
+      .click();
+    await expect(deleteButton).toHaveCount(0);
+  });
+
+  test('reopens step 2 when the same group is re-selected after cancelling', async ({
+    signedInPage: page
+  }) => {
+    await page.goto('/campagnes');
+
+    const { firstGroup, hasGroup } = await openStep1(page);
+    test.skip(
+      !hasGroup,
+      'The default user has no eligible group — seed a non-archived group with housing to run this test.'
+    );
+
+    // Remember which group we picked so we re-select the SAME one.
+    const groupLabel = await firstGroup.getAttribute('aria-label');
+    expect(groupLabel).not.toBeNull();
+    await firstGroup.click();
+    await expect(step2(page)).toBeVisible();
+
+    // Cancel step 2 without submitting.
+    await page.keyboard.press('Escape');
+    await expect(step2(page)).toBeHidden();
+
+    // Re-run the flow and pick the same group again. This regressed once: the
+    // reopen was a dead click because the step-2 open hung on a stale selection.
+    await page
+      .getByRole('button', { name: 'Enregistrer une campagne' })
+      .click();
+    await expect(step1(page)).toBeVisible();
+    await step1(page)
+      .getByRole('button', { name: groupLabel as string })
+      .click();
+
+    await expect(step2(page)).toBeVisible();
+  });
+});

--- a/apps/front-e2e-pw/tests/save-campaign.spec.ts
+++ b/apps/front-e2e-pw/tests/save-campaign.spec.ts
@@ -81,7 +81,7 @@ test.describe('Save a campaign from a group', () => {
     // Success: toast, modal closes, and the campaign lands in the list. The
     // flow deliberately stays on /campagnes (unlike the group-page flow, which
     // navigates to the new campaign).
-    await expect(page.getByText('La campagne a été ajoutée')).toBeVisible();
+    await expect(page.getByText('Campagne créée !')).toBeVisible();
     await expect(step2(page)).toBeHidden();
 
     // The new campaign is in the list — its delete button carries a unique,

--- a/apps/front-e2e-pw/tests/save-campaign.spec.ts
+++ b/apps/front-e2e-pw/tests/save-campaign.spec.ts
@@ -14,6 +14,9 @@ import { expect, test } from '../fixtures/auth';
  * stay green while the feature is broken. `expect(step 2).toBeVisible()` after
  * selecting a group is the regression guard.
  *
+ * On success the flow redirects to the new campaign's own page
+ * (`/campagnes/:id`), matching the group-page flow.
+ *
  * Requires the default user (`CYPRESS_EMAIL`) to be Usual/Admin (Visitors don't
  * see the button) with at least one eligible group (not archived, ≥1 housing).
  * Skips gracefully when no such group is seeded.
@@ -76,22 +79,21 @@ test.describe('Save a campaign from a group', () => {
         /\/groups\/[^/]+\/campaigns$/.test(response.url())
     );
     await step2(page).getByRole('button', { name: 'Confirmer' }).click();
-    expect((await created).ok()).toBe(true);
+    const createdResponse = await created;
+    expect(createdResponse.ok()).toBe(true);
+    const { id: campaignId } = await createdResponse.json();
 
-    // Success: toast, modal closes, and the campaign lands in the list. The
-    // flow deliberately stays on /campagnes (unlike the group-page flow, which
-    // navigates to the new campaign).
+    // Success: redirected to the new campaign's own page, matching the
+    // group-page flow.
+    await page.waitForURL(`**/campagnes/${campaignId}`);
     await expect(page.getByText('Campagne créée !')).toBeVisible();
-    await expect(step2(page)).toBeHidden();
 
-    // The new campaign is in the list — its delete button carries a unique,
-    // exact accessible name, so it's a reliable per-campaign anchor.
+    // Cleanup so the run is repeatable and doesn't pollute the environment.
+    await page.goto('/campagnes');
     const deleteButton = page.getByRole('button', {
       name: `Supprimer la campagne ${name}`
     });
     await expect(deleteButton).toBeVisible();
-
-    // Cleanup so the run is repeatable and doesn't pollute the environment.
     await deleteButton.click();
     await page
       .getByRole('dialog')

--- a/docs/superpowers/plans/2026-07-17-save-campaign.md
+++ b/docs/superpowers/plans/2026-07-17-save-campaign.md
@@ -1,0 +1,1197 @@
+# Save a Campaign from the Campaigns List — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an "Enregistrer une campagne" button to the campaigns list that opens a 2-step modal (search & select a group, then create a campaign from it), and close a pre-existing permission gap where any authenticated user — including a read-only Visitor — can currently create campaigns.
+
+**Architecture:** Two independently-created DSFR modal instances (`SelectGroupModal` for step 1, the existing `CreateCampaignFromGroupModal` for step 2) chained via a new orchestrator component (`SaveCampaignFlow`), mirroring the codebase's only existing multi-step-modal precedent (`HousingCreationModal.tsx`). The orchestrator is mounted self-contained inside `CampaignTable.tsx`. A pre-existing role-check gap on campaign creation is fixed at the backend (`hasRole` middleware) and mirrored on both frontend entry points (the new button and the existing group-page button).
+
+**Tech Stack:** React, TypeScript, `@codegouvfr/react-dsfr`, MUI, `react-hook-form` + yup, RTK Query, Vitest + Testing Library + MSW (frontend); Express, Knex, Vitest + supertest (backend).
+
+**Design spec:** `docs/superpowers/specs/2026-07-17-save-campaign-design.md`
+
+## Global Constraints
+
+- Follow `.claude/rules/frontend-conventions.md`: DSFR components first, direct MUI imports, `Readonly<Props>`, `~` import alias, `react-hook-form` + yup for forms, MSW handlers for tests (never `vi.mock` for network data), French apostrophe `’`.
+- Follow `.claude/rules/backend-conventions.md`: validation only in routers, no try-catch in controllers, `constants` from `node:http2` for status codes.
+- RGAA accessibility is mandatory for every frontend change (`.claude/rules/rgaa-accessibility.md`). Each frontend task below notes the specific criteria it touches.
+- TDD is mandatory project-wide: write the failing test before the implementation in every task.
+- Run `yarn nx test frontend -- <pattern>` / `yarn nx test server -- <pattern>` to scope test runs; run `yarn nx typecheck frontend` / `yarn nx typecheck server` after touching shared types.
+
+---
+
+### Task 1: Backend — restrict campaign creation to Usual/Admin
+
+**Files:**
+
+- Modify: `server/src/routers/protected.ts:295-302` (the `POST /groups/:id/campaigns` route)
+- Test: `server/src/controllers/test/campaign-api.test.ts`
+
+**Interfaces:**
+
+- Consumes: existing `hasRole(roles: UserRole[])` middleware from `~/middlewares/auth` (already imported in `protected.ts` at line 32); existing `genUserApi(establishmentId: string): UserApi` and `tokenProvider(user: UserApi)` test helpers.
+- Produces: nothing new — this is a router-level guard with no new exports.
+
+- [ ] **Step 1: Write the failing test**
+
+In `server/src/controllers/test/campaign-api.test.ts`, add `UserRole` to the existing `@zerologementvacant/models` import (currently lines 5-12):
+
+```ts
+import {
+  CampaignDTO,
+  CampaignRemovalPayload,
+  CampaignUpdatePayload,
+  HOUSING_STATUS_VALUES,
+  HousingStatus,
+  UserRole,
+  type CampaignCreationPayload,
+  type UserDTO
+} from '@zerologementvacant/models';
+```
+
+Then, inside `describe('POST /groups/{id}/campaigns', ...)` (starting at line 344), insert this test right after the `'should throw if the group has been archived'` test (which ends at line 430) and before `'should create the campaign'` (line 432):
+
+```ts
+it('should be forbidden for a visitor', async () => {
+  const visitor: UserApi = {
+    ...genUserApi(establishment.id),
+    role: UserRole.VISITOR
+  };
+  await Users().insert(toUserDBO(visitor));
+  const payload: CampaignCreationPayload = {
+    title: 'Logements prioritaires',
+    description: 'Campagne pour les logements prioritaires',
+    sentAt: null
+  };
+
+  const { status } = await request(url)
+    .post(testRoute(group.id))
+    .send(payload)
+    .type('json')
+    .use(tokenProvider(visitor));
+
+  expect(status).toBe(constants.HTTP_STATUS_FORBIDDEN);
+});
+```
+
+This requires `UserApi` to be imported — it already is, via `import { GroupApi } from '~/models/GroupApi';`... no, check: the file does not currently import `UserApi`. Add it:
+
+```ts
+import { UserApi } from '~/models/UserApi';
+```
+
+Add this import alongside the existing `import { GroupApi } from '~/models/GroupApi';` line (line 21).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `yarn nx test server -- campaign-api.test.ts -t "should be forbidden for a visitor"`
+Expected: FAIL — the request currently succeeds (`HTTP_STATUS_CREATED`), not `HTTP_STATUS_FORBIDDEN`, because no role check exists on this route yet.
+
+- [ ] **Step 3: Implement the route guard**
+
+In `server/src/routers/protected.ts`, change the `POST /groups/:id/campaigns` route (lines 295-302) from:
+
+```ts
+router.post(
+  '/groups/:id/campaigns',
+  validator.validate({
+    body: schemas.campaignCreationPayload,
+    params: object({ id: schemas.id })
+  }),
+  campaignController.createFromGroup
+);
+```
+
+to:
+
+```ts
+router.post(
+  '/groups/:id/campaigns',
+  hasRole([UserRole.USUAL, UserRole.ADMIN]),
+  validator.validate({
+    body: schemas.campaignCreationPayload,
+    params: object({ id: schemas.id })
+  }),
+  campaignController.createFromGroup
+);
+```
+
+(`hasRole` and `UserRole` are already imported at the top of this file — see lines 1-6 and line 32 — no new imports needed here.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `yarn nx test server -- campaign-api.test.ts`
+Expected: PASS — all tests in the `POST /groups/{id}/campaigns` block pass, including the new visitor test and the pre-existing `'should validate inputs'`/`'should create the campaign'` tests (which authenticate as `user`, a `USUAL` role, so remain unaffected).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/routers/protected.ts server/src/controllers/test/campaign-api.test.ts
+git commit -m "fix: restrict campaign creation from a group to Usual/Admin roles"
+```
+
+---
+
+### Task 2: Frontend — customizable page size on `AdvancedTable`
+
+**Files:**
+
+- Modify: `frontend/src/components/AdvancedTable/AdvancedTable.tsx`
+- Test: `frontend/src/components/AdvancedTable/test/AdvancedTable.test.tsx` (new)
+
+**Interfaces:**
+
+- Consumes: nothing new.
+- Produces: two new optional props on `AdvancedTableProps<Data>`: `perPageOptions?: number[]` (default `[10, 50, 200, 500]`, unchanged from today) and `defaultPageSize?: number` (default `50`, unchanged from today). Task 5 (`SelectGroupModal`) passes `perPageOptions={[5, 10, 50]}` and `defaultPageSize={5}`.
+
+This task exists because the step-1 mockup shows "5 lignes par page" as the table's default page size, but `AdvancedTable`'s per-page options are currently hardcoded to `[10, 50, 200, 500]` with no way to change them per call site.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/src/components/AdvancedTable/test/AdvancedTable.test.tsx`:
+
+```tsx
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createColumnHelper } from '@tanstack/react-table';
+
+import AdvancedTable from '~/components/AdvancedTable/AdvancedTable';
+
+interface Row {
+  id: string;
+  name: string;
+}
+
+const columnHelper = createColumnHelper<Row>();
+const columns = [columnHelper.accessor('name', { header: 'Nom' })];
+
+function buildRows(count: number): Row[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: String(i),
+    name: `Row ${i}`
+  }));
+}
+
+describe('AdvancedTable', () => {
+  const user = userEvent.setup();
+
+  it('should default to 50 results per page when perPageOptions is not provided', async () => {
+    render(<AdvancedTable columns={columns} data={buildRows(3)} />);
+
+    await screen.findByRole('table');
+    expect(
+      screen.getByDisplayValue('50 résultats par page')
+    ).toBeInTheDocument();
+  });
+
+  it('should use a custom default page size and per-page options', async () => {
+    render(
+      <AdvancedTable
+        columns={columns}
+        data={buildRows(7)}
+        perPageOptions={[5, 10, 50]}
+        defaultPageSize={5}
+      />
+    );
+
+    const table = await screen.findByRole('table');
+    expect(
+      screen.getByDisplayValue('5 résultats par page')
+    ).toBeInTheDocument();
+    // 1 header row + 5 data rows
+    expect(within(table).getAllByRole('row')).toHaveLength(6);
+
+    const select = screen.getByDisplayValue('5 résultats par page');
+    await user.selectOptions(select, '10');
+
+    // 1 header row + remaining 7 data rows (only 7 total)
+    expect(within(table).getAllByRole('row')).toHaveLength(8);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `yarn nx test frontend -- AdvancedTable.test.tsx`
+Expected: The first test passes already (current default behavior). The second test FAILS with a TypeScript error / `perPageOptions`/`defaultPageSize` not recognized, or (if TS is loose) the `5 résultats par page` option never renders because the component ignores those props.
+
+- [ ] **Step 3: Implement the props**
+
+In `frontend/src/components/AdvancedTable/AdvancedTable.tsx`, update the `PaginationProps` interface (lines 67-76):
+
+```ts
+interface PaginationProps {
+  /**
+   * @default true
+   */
+  paginate?: boolean;
+  /**
+   * You must define this when using server-side pagination.
+   */
+  pageCount?: number;
+  /**
+   * Options shown in the "results per page" selector.
+   * @default [10, 50, 200, 500]
+   */
+  perPageOptions?: number[];
+  /**
+   * Initial/uncontrolled page size.
+   * @default 50
+   */
+  defaultPageSize?: number;
+}
+```
+
+Update the constant and initial state (lines 78-102):
+
+```ts
+const ROW_SIZE = 64;
+const PER_PAGE_OPTIONS = [10, 50, 200, 500];
+const DEFAULT_PAGE_SIZE = 50;
+
+function AdvancedTable<Data extends object>(props: AdvancedTableProps<Data>) {
+  // Map our selection to the @tanstack/table internal selection state
+  const rowSelection: RowSelectionState =
+    props.selection?.ids?.reduce<RowSelectionState>((acc, id) => {
+      acc[id] = true;
+      return acc;
+    }, {}) ?? {};
+  const all = props.selection?.all ?? false;
+  function setAll(value: boolean): void {
+    props.onSelectionChange?.({
+      all: value,
+      ids: []
+    });
+  }
+
+  const enableSelection = props.selection !== undefined;
+
+  const paginate = props.paginate ?? true;
+  const perPageOptions = props.perPageOptions ?? PER_PAGE_OPTIONS;
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: props.defaultPageSize ?? DEFAULT_PAGE_SIZE
+  });
+```
+
+Update the `<SelectNext>` options (inside the `paginate ? (...) : null` block, currently lines 322-337):
+
+```tsx
+<SelectNext
+  label={null}
+  options={perPageOptions.map((option) => ({
+    label: `${option} résultats par page`,
+    value: String(option)
+  }))}
+  nativeSelectProps={{
+    value: String(table.getState().pagination.pageSize),
+    onChange: (event) => {
+      const value = Number(event.target.value);
+      if (value !== null) {
+        table.setPageSize(value);
+      }
+    }
+  }}
+/>
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `yarn nx test frontend -- AdvancedTable.test.tsx`
+Expected: PASS — both tests pass; existing consumers (`CampaignTable.tsx`, `GeoPerimetersTable.tsx`) pass neither prop, so they keep the exact same `[10, 50, 200, 500]` / `50` behavior.
+
+Run: `yarn nx test frontend -- CampaignListView.test.tsx`
+Expected: PASS — the existing pagination tests (`'should render a page size selector'`, `'should limit visible rows according to page size'`, `'should navigate to the next page'`) still pass unchanged.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/AdvancedTable/AdvancedTable.tsx frontend/src/components/AdvancedTable/test/AdvancedTable.test.tsx
+git commit -m "feat: allow AdvancedTable callers to customize page size options"
+```
+
+---
+
+### Task 3: Frontend — hide "Créer une campagne" on the group page for Visitors
+
+**Files:**
+
+- Modify: `frontend/src/components/Group/GroupNext.tsx`
+- Test: `frontend/src/components/Group/test/GroupNext.test.tsx` (new)
+
+**Interfaces:**
+
+- Consumes: `useUser()` from `~/hooks/useUser` (existing, returns `{ isAdmin, isUsual, ... }`).
+- Produces: no change to `GroupProps` — this is purely an internal render guard.
+
+This task fixes the frontend half of the same gap Task 1 fixed at the backend, on the pre-existing group-page entry point.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/src/components/Group/test/GroupNext.test.tsx`:
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import { UserRole } from '@zerologementvacant/models';
+import {
+  genEstablishmentDTO,
+  genGroupDTO,
+  genHousingDTO,
+  genUserDTO
+} from '@zerologementvacant/models/fixtures';
+import { Provider } from 'react-redux';
+
+import GroupNext from '~/components/Group/GroupNext';
+import { fromEstablishmentDTO } from '~/models/Establishment';
+import { fromGroupDTO } from '~/models/Group';
+import { fromUserDTO } from '~/models/User';
+import { genAuthUser } from '~/test/fixtures';
+import configureTestStore from '~/utils/storeUtils';
+
+describe('GroupNext', () => {
+  const establishment = genEstablishmentDTO();
+  const creator = genUserDTO(UserRole.USUAL, establishment);
+  const group = fromGroupDTO(genGroupDTO(creator, [genHousingDTO()]));
+
+  function renderGroup(role: UserRole) {
+    const authDTO = genUserDTO(role, establishment);
+    const store = configureTestStore({
+      auth: genAuthUser(
+        fromUserDTO(authDTO),
+        fromEstablishmentDTO(establishment)
+      )
+    });
+
+    render(
+      <Provider store={store}>
+        <GroupNext
+          group={group}
+          onCreateCampaign={vi.fn()}
+          onExport={vi.fn()}
+          onUpdate={vi.fn()}
+          onRemove={vi.fn()}
+        />
+      </Provider>
+    );
+  }
+
+  it('should hide the "Créer une campagne" button for a visitor', () => {
+    renderGroup(UserRole.VISITOR);
+
+    expect(
+      screen.queryByRole('button', { name: 'Créer une campagne' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('should show the "Créer une campagne" button for a usual user', async () => {
+    renderGroup(UserRole.USUAL);
+
+    expect(
+      await screen.findByRole('button', { name: 'Créer une campagne' })
+    ).toBeInTheDocument();
+  });
+
+  it('should show the "Créer une campagne" button for an admin', async () => {
+    renderGroup(UserRole.ADMIN);
+
+    expect(
+      await screen.findByRole('button', { name: 'Créer une campagne' })
+    ).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `yarn nx test frontend -- GroupNext.test.tsx`
+Expected: FAIL on the first test — the button is currently always rendered regardless of role, so `queryByRole` finds it and the `not.toBeInTheDocument()` assertion fails.
+
+- [ ] **Step 3: Implement the guard**
+
+In `frontend/src/components/Group/GroupNext.tsx`, add the import (alongside the other `~/` imports, e.g. after `import FullWidthButton from '~/components/ui/FullWidthButton';`):
+
+```ts
+import { useUser } from '~/hooks/useUser';
+```
+
+Inside `function Group(props: Readonly<GroupProps>) {`, right after the existing `const findCampaignsQuery = useFindCampaignsQuery(...)` line, add:
+
+```ts
+const { isAdmin, isUsual } = useUser();
+const canCreateCampaign = isAdmin || isUsual;
+```
+
+Then wrap the "Créer une campagne" `<li>` (currently lines 185-193):
+
+```tsx
+{
+  canCreateCampaign ? (
+    <li style={{ width: '100%' }}>
+      <FullWidthButton
+        priority="primary"
+        onClick={campaignFromGroupModal.open}
+        disabled={props.group.housingCount === 0}
+      >
+        Créer une campagne
+      </FullWidthButton>
+    </li>
+  ) : null;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `yarn nx test frontend -- GroupNext.test.tsx`
+Expected: PASS — all three tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/Group/GroupNext.tsx frontend/src/components/Group/test/GroupNext.test.tsx
+git commit -m "fix: hide the group page's campaign creation button for Visitors"
+```
+
+---
+
+### Task 4: Frontend — optional stepper on `CreateCampaignFromGroupModal`
+
+**Files:**
+
+- Modify: `frontend/src/components/Group/CreateCampaignFromGroupModal.tsx`
+- Test: `frontend/src/components/Group/test/CreateCampaignFromGroupModal.test.tsx` (new)
+
+**Interfaces:**
+
+- Consumes: DSFR's `Stepper` (`@codegouvfr/react-dsfr/Stepper`), props `currentStep: number`, `stepCount: number`, `title: ReactNode`.
+- Produces: a new optional prop on `CreateCampaignFromGroupModalProps`: `stepper?: { currentStep: number; stepCount: number }`. Task 6 (`SaveCampaignFlow`) passes `{ currentStep: 2, stepCount: 2 }`; the existing `GroupNext.tsx` call site (Task 3) passes nothing, so its rendering is unchanged.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/src/components/Group/test/CreateCampaignFromGroupModal.test.tsx`:
+
+```tsx
+import { render, screen, within } from '@testing-library/react';
+import {
+  genGroupDTO,
+  genHousingDTO,
+  genUserDTO
+} from '@zerologementvacant/models/fixtures';
+import { Provider } from 'react-redux';
+
+import { createCampaignFromGroupModal } from '~/components/Group/CreateCampaignFromGroupModal';
+import { fromGroupDTO } from '~/models/Group';
+import configureTestStore from '~/utils/storeUtils';
+
+const modal = createCampaignFromGroupModal();
+const creator = genUserDTO();
+const group = fromGroupDTO(genGroupDTO(creator, [genHousingDTO()]));
+
+describe('CreateCampaignFromGroupModal', () => {
+  function renderModal(stepper?: { currentStep: number; stepCount: number }) {
+    render(
+      <Provider store={configureTestStore()}>
+        <modal.Component group={group} stepper={stepper} onSubmit={vi.fn()} />
+      </Provider>
+    );
+    modal.open();
+  }
+
+  it('should not render a stepper by default', async () => {
+    renderModal();
+
+    const dialog = await screen.findByRole('dialog');
+    expect(
+      within(dialog).queryByText(/Étape \d sur \d/)
+    ).not.toBeInTheDocument();
+  });
+
+  it('should render a stepper when the stepper prop is provided', async () => {
+    renderModal({ currentStep: 2, stepCount: 2 });
+
+    const dialog = await screen.findByRole('dialog');
+    expect(within(dialog).getByText('Étape 2 sur 2')).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `yarn nx test frontend -- CreateCampaignFromGroupModal.test.tsx`
+Expected: FAIL on the second test — `stepper` is not a recognized prop yet, and no `Stepper` is rendered.
+
+- [ ] **Step 3: Implement the prop**
+
+In `frontend/src/components/Group/CreateCampaignFromGroupModal.tsx`, add the import (alongside the other `@codegouvfr/react-dsfr` imports at the top):
+
+```ts
+import Stepper from '@codegouvfr/react-dsfr/Stepper';
+```
+
+Update `CreateCampaignFromGroupModalProps` (lines 24-30):
+
+```ts
+export type CreateCampaignFromGroupModalProps = Omit<
+  ConfirmationModalProps,
+  'title' | 'children' | 'onSubmit'
+> & {
+  group: Group;
+  stepper?: { currentStep: number; stepCount: number };
+  onSubmit(campaign: Pick<Campaign, 'title' | 'description' | 'sentAt'>): void;
+};
+```
+
+Update the destructure inside `Component` (line 51):
+
+```ts
+const { group, stepper, onSubmit, ...rest } = props;
+```
+
+Insert the `Stepper` right after the opening `<modal.Component ...>` tag and before the housing/owner-count `Stack` (currently lines 74-87):
+
+```tsx
+      const component = (
+        <form onSubmit={form.handleSubmit(handleSubmit)}>
+          <modal.Component
+            size="large"
+            {...rest}
+            onClose={form.reset}
+            title="Créer une campagne"
+          >
+            {stepper && (
+              <Stepper
+                currentStep={stepper.currentStep}
+                stepCount={stepper.stepCount}
+                title="Créer une campagne"
+              />
+            )}
+
+            <Stack
+              direction="row"
+              spacing="1rem"
+              useFlexGap
+              sx={{ mt: '-1rem', mb: '0.5rem' }}
+            >
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `yarn nx test frontend -- CreateCampaignFromGroupModal.test.tsx`
+Expected: PASS — both tests pass.
+
+Run: `yarn nx test frontend -- GroupView.test.tsx`
+Expected: PASS — the existing "Create a campaign from the group" tests are unaffected since `GroupNext.tsx` doesn't pass `stepper`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/Group/CreateCampaignFromGroupModal.tsx frontend/src/components/Group/test/CreateCampaignFromGroupModal.test.tsx
+git commit -m "feat: support an optional stepper header in CreateCampaignFromGroupModal"
+```
+
+---
+
+### Task 5: Frontend — `SelectGroupModal` (step 1: search & select a group)
+
+**Files:**
+
+- Create: `frontend/src/components/Campaign/SelectGroupModal.tsx`
+- Test: `frontend/src/components/Campaign/test/SelectGroupModal.test.tsx` (new)
+
+**Interfaces:**
+
+- Consumes: `useFindGroupsQuery()` from `~/services/group.service` (existing, returns `{ data?: Group[] }`); `AppSearchBar` from `~/components/_app/AppSearchBar/AppSearchBar` (prop `onSearch(text: string): void`); `AdvancedTable` from `~/components/AdvancedTable/AdvancedTable` with the new `perPageOptions`/`defaultPageSize` props from Task 2; `createExtendedModal` from `~/components/modals/ConfirmationModal/ExtendedModal`; DSFR `Stepper`.
+- Produces: `createSelectGroupModal(options?): { Component(props: { onSelect(group: Group): void }): JSX.Element; open(): void; close(): void; id: string }`. Task 6 imports `createSelectGroupModal` as the default export and calls `.open()`/`.close()`/renders `.Component`.
+
+RGAA notes for this task: the table's "Action" column re-uses `AdvancedTable`'s existing `<th scope="col">` header semantics (criterion 5.6/5.7, already satisfied by `AdvancedTable`); each row's "Sélectionner" button gets a distinguishing `aria-label` (criterion 6.1/11.9 — a screen reader user tabbing through rows must be able to tell them apart, not hear "Sélectionner" repeated identically); the search input's label comes from `AppSearchBar`'s existing `<label htmlFor>` wiring (criterion 11.1/11.4, already satisfied).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `frontend/src/components/Campaign/test/SelectGroupModal.test.tsx`:
+
+```tsx
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {
+  genGroupDTO,
+  genHousingDTO,
+  genUserDTO
+} from '@zerologementvacant/models/fixtures';
+import { Provider } from 'react-redux';
+
+import createSelectGroupModal from '~/components/Campaign/SelectGroupModal';
+import data from '~/mocks/handlers/data';
+import configureTestStore from '~/utils/storeUtils';
+
+const selectGroupModal = createSelectGroupModal();
+const creator = genUserDTO();
+
+describe('SelectGroupModal', () => {
+  const user = userEvent.setup();
+
+  function renderModal(onSelect = vi.fn()) {
+    render(
+      <Provider store={configureTestStore()}>
+        <selectGroupModal.Component onSelect={onSelect} />
+      </Provider>
+    );
+    selectGroupModal.open();
+  }
+
+  it('should exclude archived and empty groups from the list', async () => {
+    const housings = [genHousingDTO()];
+    const eligible = genGroupDTO(creator, housings);
+    const archived = {
+      ...genGroupDTO(creator, housings),
+      archivedAt: new Date().toJSON()
+    };
+    const empty = genGroupDTO(creator, []);
+    data.groups.push(eligible, archived, empty);
+
+    renderModal();
+
+    const dialog = await screen.findByRole('dialog');
+    await within(dialog).findByText(eligible.title);
+    expect(within(dialog).queryByText(archived.title)).not.toBeInTheDocument();
+    expect(within(dialog).queryByText(empty.title)).not.toBeInTheDocument();
+  });
+
+  it('should filter groups by a case-insensitive substring match on submit', async () => {
+    const housings = [genHousingDTO()];
+    const match = { ...genGroupDTO(creator, housings), title: 'URBA-EXP' };
+    const nonMatch = {
+      ...genGroupDTO(creator, housings),
+      title: 'CITE-AVENIR'
+    };
+    data.groups.push(match, nonMatch);
+
+    renderModal();
+
+    const dialog = await screen.findByRole('dialog');
+    await within(dialog).findByText(match.title);
+    const input = within(dialog).getByRole('searchbox', {
+      name: 'Rechercher un groupe'
+    });
+    await user.type(input, 'urba');
+    const searchButton = within(dialog).getByRole('button', {
+      name: 'Rechercher'
+    });
+    await user.click(searchButton);
+
+    await within(dialog).findByText(match.title);
+    expect(within(dialog).queryByText(nonMatch.title)).not.toBeInTheDocument();
+  });
+
+  it('should sort groups by creation date, most recent first', async () => {
+    const housings = [genHousingDTO()];
+    const oldest = {
+      ...genGroupDTO(creator, housings),
+      title: 'Oldest',
+      createdAt: new Date('2024-01-01').toJSON()
+    };
+    const newest = {
+      ...genGroupDTO(creator, housings),
+      title: 'Newest',
+      createdAt: new Date('2024-06-01').toJSON()
+    };
+    const middle = {
+      ...genGroupDTO(creator, housings),
+      title: 'Middle',
+      createdAt: new Date('2024-03-01').toJSON()
+    };
+    data.groups.push(oldest, newest, middle);
+
+    renderModal();
+
+    const dialog = await screen.findByRole('dialog');
+    const table = await within(dialog).findByRole('table');
+    await within(table).findByText('Newest');
+    const rows = within(table).getAllByRole('row').slice(1);
+    const titles = rows.map((row) => row.textContent);
+    expect(titles[0]).toContain('Newest');
+    expect(titles[1]).toContain('Middle');
+    expect(titles[2]).toContain('Oldest');
+  });
+
+  it('should show no rows when the search matches nothing', async () => {
+    const housings = [genHousingDTO()];
+    data.groups.push({
+      ...genGroupDTO(creator, housings),
+      title: 'URBA-EXP'
+    });
+
+    renderModal();
+
+    const dialog = await screen.findByRole('dialog');
+    const table = await within(dialog).findByRole('table');
+    const input = within(dialog).getByRole('searchbox', {
+      name: 'Rechercher un groupe'
+    });
+    await user.type(input, 'no-match-at-all');
+    const searchButton = within(dialog).getByRole('button', {
+      name: 'Rechercher'
+    });
+    await user.click(searchButton);
+
+    expect(within(table).queryAllByRole('row')).toHaveLength(1); // header row only
+  });
+
+  it('should call onSelect with the chosen group', async () => {
+    const housings = [genHousingDTO()];
+    const group = genGroupDTO(creator, housings);
+    data.groups.push(group);
+    const onSelect = vi.fn();
+
+    renderModal(onSelect);
+
+    const dialog = await screen.findByRole('dialog');
+    const selectButton = await within(dialog).findByRole('button', {
+      name: `Sélectionner le groupe ${group.title}`
+    });
+    await user.click(selectButton);
+
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ id: group.id, title: group.title })
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `yarn nx test frontend -- SelectGroupModal.test.tsx`
+Expected: FAIL — the module `~/components/Campaign/SelectGroupModal` does not exist yet.
+
+- [ ] **Step 3: Implement `SelectGroupModal`**
+
+Create `frontend/src/components/Campaign/SelectGroupModal.tsx`:
+
+```tsx
+import Button from '@codegouvfr/react-dsfr/Button';
+import Stepper from '@codegouvfr/react-dsfr/Stepper';
+import { createColumnHelper } from '@tanstack/react-table';
+import { useMemo, useState } from 'react';
+
+import AppSearchBar from '~/components/_app/AppSearchBar/AppSearchBar';
+import AdvancedTable from '~/components/AdvancedTable/AdvancedTable';
+import {
+  createExtendedModal,
+  type ExtendedModalOptions
+} from '~/components/modals/ConfirmationModal/ExtendedModal';
+import type { Group } from '~/models/Group';
+import { useFindGroupsQuery } from '~/services/group.service';
+
+export type SelectGroupModalOptions = Partial<ExtendedModalOptions>;
+
+export interface SelectGroupModalProps {
+  onSelect(group: Group): void;
+}
+
+const columnHelper = createColumnHelper<Group>();
+
+function isEligible(group: Group): boolean {
+  return group.archivedAt === null && group.housingCount > 0;
+}
+
+export function createSelectGroupModal(
+  options?: Readonly<SelectGroupModalOptions>
+) {
+  const modal = createExtendedModal({
+    id: options?.id ?? 'select-group-modal',
+    isOpenedByDefault: options?.isOpenedByDefault ?? false
+  });
+
+  return {
+    ...modal,
+    Component(props: Readonly<SelectGroupModalProps>) {
+      const { data: groups } = useFindGroupsQuery();
+      const [searchText, setSearchText] = useState<string>('');
+
+      const filteredGroups = useMemo(() => {
+        const eligible = (groups ?? []).filter(isEligible);
+        const matches = searchText
+          ? eligible.filter((group) =>
+              group.title.toLowerCase().includes(searchText.toLowerCase())
+            )
+          : eligible;
+        return [...matches].sort(
+          (a, b) => b.createdAt.getTime() - a.createdAt.getTime()
+        );
+      }, [groups, searchText]);
+
+      const columns = useMemo(
+        () => [
+          columnHelper.accessor('title', {
+            header: 'Nom du groupe'
+          }),
+          columnHelper.display({
+            id: 'actions',
+            header: 'Action',
+            cell: ({ row }) => (
+              <Button
+                priority="secondary"
+                size="small"
+                title={`Sélectionner le groupe ${row.original.title}`}
+                nativeButtonProps={{
+                  'aria-label': `Sélectionner le groupe ${row.original.title}`
+                }}
+                onClick={() => props.onSelect(row.original)}
+              >
+                Sélectionner
+              </Button>
+            )
+          })
+        ],
+        [props]
+      );
+
+      function search(text: string): void {
+        setSearchText(text);
+      }
+
+      return (
+        <modal.Component
+          title="Enregistrer une campagne"
+          size="large"
+          onClose={() => setSearchText('')}
+        >
+          <Stepper
+            currentStep={1}
+            stepCount={2}
+            title="Sélectionner le groupe de logements"
+            nextTitle="Créer une campagne"
+          />
+
+          <AppSearchBar label="Rechercher un groupe" onSearch={search} />
+
+          <AdvancedTable
+            caption="Groupes de logements"
+            columns={columns}
+            data={filteredGroups}
+            perPageOptions={[5, 10, 50]}
+            defaultPageSize={5}
+            tableProps={{ noCaption: true }}
+          />
+        </modal.Component>
+      );
+    }
+  };
+}
+
+export default createSelectGroupModal;
+```
+
+Note: `modal.Component`'s `buttons` prop is intentionally omitted — DSFR's `ModalProps['buttons']` type does not accept an empty array, and the step-1 mockup's action zone has no footer buttons (selection happens per-row via "Sélectionner").
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `yarn nx test frontend -- SelectGroupModal.test.tsx`
+Expected: PASS — all five tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/Campaign/SelectGroupModal.tsx frontend/src/components/Campaign/test/SelectGroupModal.test.tsx
+git commit -m "feat: add SelectGroupModal for searching and selecting a group"
+```
+
+---
+
+### Task 6: Frontend — `SaveCampaignFlow` orchestrator + entry point
+
+**Files:**
+
+- Create: `frontend/src/components/Campaign/SaveCampaignFlow.tsx`
+- Modify: `frontend/src/components/Campaign/CampaignTable.tsx`
+- Test: `frontend/src/components/Campaign/test/SaveCampaignFlow.test.tsx` (new)
+
+**Interfaces:**
+
+- Consumes: `createSelectGroupModal` (default export, Task 5); `createCampaignFromGroupModal` from `~/components/Group/CreateCampaignFromGroupModal` (existing, extended in Task 4); `useCreateCampaignFromGroupMutation` from `~/services/campaign.service` (existing); `useUser()` from `~/hooks/useUser`; `useNotification` from `~/hooks/useNotification`.
+- Produces: `SaveCampaignFlow` — a self-contained default-exported component with no props, rendering its own trigger button and both modal instances. `CampaignTable.tsx` mounts `<SaveCampaignFlow />` with no wiring required.
+
+RGAA notes: the new button follows the same DSFR `Button` + `iconId` pattern already used throughout the app (criterion 1.1, decorative icon paired with visible text, no bare icon-only button); the two chained modals rely on DSFR's own focus-trap/`aria-modal` handling for each dialog (criterion 7.1/7.3/12.8), unchanged from the existing `HousingCreationModal.tsx` precedent — no custom focus management is introduced.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `frontend/src/components/Campaign/test/SaveCampaignFlow.test.tsx`:
+
+```tsx
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { UserRole } from '@zerologementvacant/models';
+import {
+  genEstablishmentDTO,
+  genGroupDTO,
+  genHousingDTO,
+  genUserDTO
+} from '@zerologementvacant/models/fixtures';
+import { Provider } from 'react-redux';
+
+import SaveCampaignFlow from '~/components/Campaign/SaveCampaignFlow';
+import data from '~/mocks/handlers/data';
+import { fromEstablishmentDTO } from '~/models/Establishment';
+import { fromUserDTO } from '~/models/User';
+import { genAuthUser } from '~/test/fixtures';
+import configureTestStore from '~/utils/storeUtils';
+
+describe('SaveCampaignFlow', () => {
+  const user = userEvent.setup();
+  const establishment = genEstablishmentDTO();
+  const creator = genUserDTO(UserRole.USUAL, establishment);
+
+  function renderFlow(role: UserRole = UserRole.USUAL) {
+    const authDTO = genUserDTO(role, establishment);
+    const store = configureTestStore({
+      auth: genAuthUser(
+        fromUserDTO(authDTO),
+        fromEstablishmentDTO(establishment)
+      )
+    });
+
+    render(
+      <Provider store={store}>
+        <SaveCampaignFlow />
+      </Provider>
+    );
+  }
+
+  it('should hide the button for a visitor', () => {
+    renderFlow(UserRole.VISITOR);
+
+    expect(
+      screen.queryByRole('button', { name: 'Enregistrer une campagne' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('should show the button for a usual user', () => {
+    renderFlow(UserRole.USUAL);
+
+    expect(
+      screen.getByRole('button', { name: 'Enregistrer une campagne' })
+    ).toBeInTheDocument();
+  });
+
+  it('should create a campaign from a group selected in step 1', async () => {
+    const group = genGroupDTO(creator, [genHousingDTO()]);
+    data.groups.push(group);
+
+    renderFlow();
+
+    const openButton = screen.getByRole('button', {
+      name: 'Enregistrer une campagne'
+    });
+    await user.click(openButton);
+
+    const selectDialog = await screen.findByRole('dialog');
+    const selectButton = await within(selectDialog).findByRole('button', {
+      name: `Sélectionner le groupe ${group.title}`
+    });
+    await user.click(selectButton);
+
+    const createDialog = await screen.findByRole('dialog');
+    await within(createDialog).findByText('Étape 2 sur 2');
+    const title = await within(createDialog).findByLabelText(/^Nom/);
+    await user.type(title, 'Ma campagne');
+    const confirm = await within(createDialog).findByText('Confirmer');
+    await user.click(confirm);
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+    expect(data.campaigns).toContainEqual(
+      expect.objectContaining({
+        title: 'Ma campagne',
+        groupId: group.id
+      })
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `yarn nx test frontend -- SaveCampaignFlow.test.tsx`
+Expected: FAIL — the module `~/components/Campaign/SaveCampaignFlow` does not exist yet.
+
+- [ ] **Step 3: Implement `SaveCampaignFlow`**
+
+Create `frontend/src/components/Campaign/SaveCampaignFlow.tsx`:
+
+```tsx
+import Button from '@codegouvfr/react-dsfr/Button';
+import { useState } from 'react';
+
+import { createCampaignFromGroupModal } from '~/components/Group/CreateCampaignFromGroupModal';
+import { useNotification } from '~/hooks/useNotification';
+import { useUser } from '~/hooks/useUser';
+import type { Campaign } from '~/models/Campaign';
+import type { Group } from '~/models/Group';
+import { useCreateCampaignFromGroupMutation } from '~/services/campaign.service';
+
+import createSelectGroupModal from './SelectGroupModal';
+
+const selectGroupModal = createSelectGroupModal();
+const campaignFromGroupModal = createCampaignFromGroupModal({
+  id: 'save-campaign-from-group-modal'
+});
+
+function SaveCampaignFlow() {
+  const { isAdmin, isUsual } = useUser();
+  const canCreateCampaign = isAdmin || isUsual;
+
+  const [selectedGroup, setSelectedGroup] = useState<Group | null>(null);
+
+  const [createCampaignFromGroup, createCampaignFromGroupMutation] =
+    useCreateCampaignFromGroupMutation();
+
+  useNotification({
+    toastId: 'save-campaign-from-group',
+    isError: createCampaignFromGroupMutation.isError,
+    isLoading: createCampaignFromGroupMutation.isLoading,
+    isSuccess: createCampaignFromGroupMutation.isSuccess,
+    message: {
+      error: 'Erreur lors de la création de la campagne',
+      loading: 'Création de la campagne...',
+      success: 'La campagne a été ajoutée'
+    }
+  });
+
+  function handleGroupSelect(group: Group): void {
+    setSelectedGroup(group);
+    selectGroupModal.close();
+    campaignFromGroupModal.open();
+  }
+
+  function handleCampaignSubmit(
+    campaign: Pick<Campaign, 'title' | 'description' | 'sentAt'>
+  ): void {
+    if (selectedGroup) {
+      createCampaignFromGroup({ campaign, group: selectedGroup })
+        .unwrap()
+        .then(() => {
+          campaignFromGroupModal.close();
+          setSelectedGroup(null);
+        });
+    }
+  }
+
+  if (!canCreateCampaign) {
+    return null;
+  }
+
+  return (
+    <>
+      <Button
+        iconId="fr-icon-save-line"
+        priority="primary"
+        onClick={selectGroupModal.open}
+      >
+        Enregistrer une campagne
+      </Button>
+
+      <selectGroupModal.Component onSelect={handleGroupSelect} />
+
+      {selectedGroup && (
+        <campaignFromGroupModal.Component
+          group={selectedGroup}
+          stepper={{ currentStep: 2, stepCount: 2 }}
+          onSubmit={handleCampaignSubmit}
+        />
+      )}
+    </>
+  );
+}
+
+export default SaveCampaignFlow;
+```
+
+Then, in `frontend/src/components/Campaign/CampaignTable.tsx`, add the import (alongside the other local imports at the bottom of the import block):
+
+```ts
+import SaveCampaignFlow from './SaveCampaignFlow';
+```
+
+And mount it as a second child of the toolbar `Stack` (currently lines 197-216):
+
+```tsx
+<Stack
+  direction="row"
+  sx={{
+    justifyContent: 'space-between',
+    alignItems: 'flex-end',
+    mb: '-1rem'
+  }}
+>
+  {campaigns && (
+    <Typography
+      variant="body2"
+      sx={{ color: fr.colors.decisions.text.mention.grey.default }}
+    >
+      {displayCount(campaigns.length, 'campagne', {
+        capitalize: true,
+        feminine: true
+      })}
+    </Typography>
+  )}
+
+  <SaveCampaignFlow />
+</Stack>
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `yarn nx test frontend -- SaveCampaignFlow.test.tsx`
+Expected: PASS — all three tests pass.
+
+Run: `yarn nx test frontend -- CampaignListView.test.tsx`
+Expected: PASS — the existing `CampaignListView` tests are unaffected (the new button renders for the `USUAL` auth user those tests already use, but none of them assert on the toolbar's exact children count).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/Campaign/SaveCampaignFlow.tsx frontend/src/components/Campaign/CampaignTable.tsx frontend/src/components/Campaign/test/SaveCampaignFlow.test.tsx
+git commit -m "feat: add \"Enregistrer une campagne\" button to the campaigns list"
+```
+
+---
+
+### Task 7: Full regression pass + RGAA self-review
+
+**Files:** none (verification only)
+
+**Interfaces:** none
+
+- [ ] **Step 1: Run the full frontend suite**
+
+Run: `yarn nx test frontend`
+Expected: PASS — no regressions in `CampaignListView.test.tsx`, `GroupView.test.tsx`, `GroupHeader.test.tsx`, or any other suite touching `AdvancedTable`, `CreateCampaignFromGroupModal`, or `GroupNext`.
+
+- [ ] **Step 2: Run the full backend suite**
+
+Run: `yarn nx test server -- campaign-api.test.ts`
+Expected: PASS — all `Campaign API` tests, including the new visitor-forbidden case.
+
+- [ ] **Step 3: Typecheck both workspaces**
+
+Run: `yarn nx typecheck frontend` and `yarn nx typecheck server`
+Expected: PASS — no type errors from the new `stepper`/`perPageOptions`/`defaultPageSize` optional props.
+
+- [ ] **Step 4: Manual RGAA self-review**
+
+Per `.claude/rules/rgaa-accessibility.md`, manually verify in a running dev server (`yarn workspace @zerologementvacant/front dev`):
+
+- Keyboard-only navigation through both modal steps (Tab/Shift+Tab/Enter/Escape) — no keyboard trap, focus lands sensibly in step 2 after step 1 closes (criteria 7.1, 7.3, 12.8, 12.9).
+- Focus indicator visibility on the search input, table row buttons, and stepper (criterion 10.7).
+- Screen-reader announcement of the two distinct "Sélectionner le groupe X" button labels (criterion 6.1, 11.9).
+- Visual comparison of both modal steps against the Figma screenshots (`16477:62849`, `16477:64023`) for 1:1 parity.
+
+Report any finding using the format mandated in `.claude/rules/rgaa-accessibility.md` (`⚠️ RGAA (critère N.M — sujet)`).
+
+- [ ] **Step 5: Commit (if any fixes were needed)**
+
+Only if Step 4 surfaced an issue requiring a code change:
+
+```bash
+git add <changed files>
+git commit -m "fix: address RGAA finding in save-campaign flow"
+```

--- a/docs/superpowers/specs/2026-07-17-save-campaign-design.md
+++ b/docs/superpowers/specs/2026-07-17-save-campaign-design.md
@@ -1,7 +1,7 @@
 # Save a Campaign from the Campaigns List — Design Spec
 
 **Date:** 2026-07-17
-**Scope:** Frontend only
+**Scope:** Frontend + one backend authorization guard
 **Ticket:** [GEN-1431] [Campagnes] Enregistrer une campagne
 
 ## Context
@@ -42,17 +42,22 @@ Three Figma frames (file `kfEYtoHqhonLyCDTcDm5wu`):
 7. **Modal architecture:** two separate, fully independent modal instances (step 1: new `SelectGroupModal`; step 2: existing `CreateCampaignFromGroupModal` unmodified) chained via a parent's `useState`, mirroring `HousingCreationModal.tsx` exactly. Considered and rejected a single-modal-with-internal-step-switch approach (avoids a possible close/reopen flicker, but requires extracting the existing modal's form into a headless component) in favor of simplicity and reuse of already-shipped code.
 8. **No back button** from step 2 to step 1 — Annuler/Fermer/click-outside on step 2 closes the entire flow rather than returning to step 1 (matches the ticket's spec text; deliberately differs from `HousingCreationModal`'s back-button precedent).
 9. **Post-creation behavior:** on success, close the modal, show a toast ("La campagne a été ajoutée"), and stay on `/campagnes` (list auto-refreshes via the existing `invalidatesTags` on the `Campaign` list). Deliberately differs from the group-page flow (`GroupView.tsx`), which navigates to the new campaign's detail page — this flow keeps the user on the page they started from, per the Figma annotation on the "Confirmer" button.
+10. **Only Usual/Admin can create campaigns — fixed at the backend, for both entry points.** The codebase survey found that campaign creation has *no* role check anywhere today: neither the existing "Créer une campagne" button (`GroupNext.tsx`) nor the endpoint it calls (`POST /groups/:id/campaigns`) restrict by role, so a VISITOR can currently create a campaign. Since both the existing and the new flow share that endpoint, the fix is applied at the backend (authoritative) and mirrored on both frontend entry points — a frontend-only check would leave the API callable directly by a Visitor.
+11. **Visitors don't see either "create campaign" button at all** (not shown-disabled) — matches the existing hide-based convention for permission gating elsewhere (`DocumentsTab.tsx`, `HousingView.tsx`), as opposed to the disabled-with-tooltip pattern which has no precedent in this codebase for permission (as opposed to data-availability) gating.
+12. **Scope of the guard is creation only.** `PUT/DELETE /campaigns/:id` (update, delete, send) have the same missing-role-check gap but are explicitly out of scope for this ticket — flagged as a separate follow-up, not fixed here.
 
 ## Architecture
 
-**Entry point:** a new `Button` ("Enregistrer une campagne", primary/MD, icon-left) added to the existing toolbar `Stack` in `CampaignTable.tsx`. No changes to `CampaignListView.tsx`.
+**Entry point:** a new `Button` ("Enregistrer une campagne", primary/MD, icon-left) added to the existing toolbar `Stack` in `CampaignTable.tsx`, rendered only when `isAdmin || isUsual` (via `useUser()`) — hidden entirely for VISITOR. No changes to `CampaignListView.tsx`.
 
 **New files:**
 - `frontend/src/components/Campaign/SelectGroupModal.tsx` — exports `createSelectGroupModal()`, a `createExtendedModal` (no confirm footer — selection happens per-row). Renders: `Stepper` (step 1/2), `AppSearchBar` (submit-only), `AdvancedTable` of eligible groups with a "Sélectionner" action column.
 - `frontend/src/components/Campaign/SaveCampaignFlow.tsx` — orchestrator component, parallel to `HousingCreationModal.tsx`. Creates both modal instances, holds `selectedGroup` state, wires the step transition and the submit handler. Mounted directly inside `CampaignTable.tsx`, self-contained (no prop drilling from `CampaignListView.tsx`).
 
-**Modified file:**
+**Modified files:**
 - `frontend/src/components/Group/CreateCampaignFromGroupModal.tsx` — add one optional prop, e.g. `stepper?: { currentStep: number; stepCount: number }`, rendering a `Stepper` at the top of the modal content when present. Omitted (no behavior change) for the existing `GroupNext.tsx` call site; passed `{ currentStep: 2, stepCount: 2 }` from the new flow. Purely additive — no changes to the existing schema, fields, or submit logic.
+- `frontend/src/components/Group/GroupNext.tsx` — wrap the existing "Créer une campagne" `FullWidthButton` in `const { isAdmin, isUsual } = useUser(); const canCreateCampaign = isAdmin || isUsual;`, hiding it entirely (not just disabling) for VISITOR. Same one-line convention as `DocumentsTab.tsx`/`HousingView.tsx`.
+- `server/src/routers/protected.ts` — add `hasRole([UserRole.USUAL, UserRole.ADMIN])` middleware to the `POST /groups/:id/campaigns` route (~line 295), matching the existing convention used for documents/notes/housing-update routes. This is the authoritative fix; it protects both the existing group-page flow and the new list-page flow since they share this endpoint. No other campaign routes are touched (see Decisions #12 and Out of Scope).
 
 ## Data Flow
 
@@ -84,13 +89,15 @@ handleGroupSelected(group):
 
 - `useFindGroupsQuery` failure or empty/no-match result: reuse the existing generic table error/empty-state convention (no new pattern invented).
 - `useCreateCampaignFromGroupMutation` failure: error toast; modal stays open with data intact.
+- 403 from the new `hasRole` guard: shouldn't be reachable through the UI (the button is hidden for VISITOR), but if hit directly (e.g. stale session, role changed mid-session) it's just another mutation failure — same error-toast handling as above, no special case needed.
 
 ## Testing (TDD — written before implementation)
 
 - `SelectGroupModal.test.tsx`: excludes archived/empty groups; substring search is case-insensitive; results sorted by `createdAt` descending; 5/page pagination; "Sélectionner" fires the callback with the correct group; empty/no-match state renders.
 - `SaveCampaignFlow.test.tsx`: button opens step 1; selecting a group closes step 1 and opens step 2 with that group; submit calls the mutation with `{ campaign, group }`, shows the success toast, closes the modal, does not navigate; mutation failure keeps the modal open and shows an error toast.
 - `CreateCampaignFromGroupModal.test.tsx` (existing file): add a case for the new `stepper` prop rendering/not-rendering — regression guard for the existing group-page flow.
-- No backend tests — frontend-only, reusing existing endpoints unmodified.
+- `CampaignTable.test.tsx` / `GroupNext.test.tsx`: assert the respective "create campaign" button is absent for a VISITOR user and present for USUAL/ADMIN, using the existing `useUser`-mocking convention from `DocumentsTab.test.tsx`/`HousingView.test.tsx`.
+- `server/src/routers/test/protected.test.ts` (or wherever `hasRole` is tested for other routes, e.g. `auth.test.ts`'s pattern): add a case asserting `POST /groups/:id/campaigns` returns 403 for a VISITOR and succeeds for USUAL/ADMIN.
 
 ## Accessibility (RGAA)
 
@@ -102,6 +109,7 @@ To verify explicitly during implementation against `.claude/rules/rgaa-accessibi
 
 ## Out of Scope
 
-- Any backend/API changes (`GET /groups` search, new campaign-creation endpoints).
-- Changing the group-page ("Créer une campagne" from `/groupes/:id`) flow's behavior.
+- Backend/API changes beyond the one `hasRole` guard on `POST /groups/:id/campaigns` — no `GET /groups` search endpoint, no new campaign-creation endpoints.
+- Extending the Usual/Admin-only guard to `PUT/DELETE /campaigns/:id` (update, delete, send) — same pre-existing gap, explicitly deferred as a follow-up (Decision #12).
+- Changing the group-page ("Créer une campagne" from `/groupes/:id`) flow's behavior, beyond adding the same permission guard (Decision #10/#11).
 - A "back" button from step 2 to step 1.

--- a/docs/superpowers/specs/2026-07-17-save-campaign-design.md
+++ b/docs/superpowers/specs/2026-07-17-save-campaign-design.md
@@ -1,0 +1,107 @@
+# Save a Campaign from the Campaigns List — Design Spec
+
+**Date:** 2026-07-17
+**Scope:** Frontend only
+**Ticket:** [GEN-1431] [Campagnes] Enregistrer une campagne
+
+## Context
+
+Today, a campaign can only be created from a single group's detail page (`/groupes/:id`), via a "Créer une campagne" button that opens `CreateCampaignFromGroupModal`. There is no way to create a campaign directly from the campaigns list page (`/campagnes`) — the user first has to find and open the right group.
+
+This feature adds a "Enregistrer une campagne" button to the campaigns list, which opens a 2-step modal: step 1 lets the user search for and select a group, step 2 reuses the existing campaign-creation form to create the campaign from that group.
+
+## User Story
+
+As a [user], I want to save a campaign from the campaigns list, in order to convert a group into a campaign.
+
+## Mockups
+
+Three Figma frames (file `kfEYtoHqhonLyCDTcDm5wu`):
+- `16477:53770` — Campaigns list page, new "Enregistrer une campagne" button in the toolbar.
+- `16477:62849` — Step 1 modal: "Sélectionner le groupe de logements".
+- `16477:64023` — Step 2 modal: "Créer une campagne" (existing form + new stepper).
+
+## Existing Building Blocks (confirmed by codebase survey)
+
+- `frontend/src/components/Group/CreateCampaignFromGroupModal.tsx` — the existing campaign-creation modal. Takes `group: Group` + `onSubmit(campaign)`, built on `createConfirmationModal`. Fields: Nom (required), Description (optional), Date d'envoi (optional). Already exactly matches step 2's needs — no logic changes required.
+- `frontend/src/services/campaign.service.ts` — `useCreateCampaignFromGroupMutation` → `POST /groups/:id/campaigns`. The only campaign-creation endpoint that exists; campaigns can only ever be created from a group.
+- `frontend/src/components/Campaign/CampaignTable.tsx` — renders the campaigns list and its toolbar (a `Stack` with `justifyContent: space-between` showing the "X campagnes" count, with empty space on the right — the natural slot for the new button).
+- `frontend/src/components/modals/HousingCreationModal/HousingCreationModal.tsx` — the one existing multi-step-modal precedent in the codebase: two separate `createExtendedModal`/`createConfirmationModal` instances, chained via a parent component's `useState` + `.close()`/`.open()` pairs.
+- `frontend/src/services/group.service.ts` — `useFindGroupsQuery()` (`GET /groups`) returns the establishment's full group list, unfiltered — no server-side search parameter exists today.
+- DSFR's `Stepper` (`@codegouvfr/react-dsfr/Stepper`) — used today only in full-page account-creation views, never inside a modal. Its API (`currentStep`, `stepCount`, `title`, `nextTitle`) matches the mockup's stepper exactly.
+- `frontend/src/components/AdvancedTable/AdvancedTable.tsx` — the shared table component with built-in pagination, used by `CampaignTable.tsx` and `GeoPerimetersTable.tsx`. Its default pagination footer is what the step-1 mockup shows.
+
+## Decisions Made During Brainstorming
+
+1. **Group search is client-side.** `GET /groups` has no search param and none will be added — filter the already-fetched, unfiltered list in the browser (matches the existing `PerimetersModal` pattern). No backend changes.
+2. **Excluded groups:** archived groups and groups with `housingCount === 0` are excluded entirely from the results (not shown, not just disabled) — mirrors the existing disabled state of "Créer une campagne" on the group page.
+3. **Pagination is real, not decorative.** The table shows *all* matching/eligible groups, paginated 5/page via `AdvancedTable`'s existing pagination — not just a top-5 cutoff.
+4. **Sort order:** most recently created first (`createdAt` descending).
+5. **Default state (no search yet):** all eligible groups are shown, paginated, immediately when step 1 opens.
+6. **Search trigger:** submit-only (`AppSearchBar`'s `onSearch`, fired on button click or Enter) — no live filter-as-you-type.
+7. **Modal architecture:** two separate, fully independent modal instances (step 1: new `SelectGroupModal`; step 2: existing `CreateCampaignFromGroupModal` unmodified) chained via a parent's `useState`, mirroring `HousingCreationModal.tsx` exactly. Considered and rejected a single-modal-with-internal-step-switch approach (avoids a possible close/reopen flicker, but requires extracting the existing modal's form into a headless component) in favor of simplicity and reuse of already-shipped code.
+8. **No back button** from step 2 to step 1 — Annuler/Fermer/click-outside on step 2 closes the entire flow rather than returning to step 1 (matches the ticket's spec text; deliberately differs from `HousingCreationModal`'s back-button precedent).
+9. **Post-creation behavior:** on success, close the modal, show a toast ("La campagne a été ajoutée"), and stay on `/campagnes` (list auto-refreshes via the existing `invalidatesTags` on the `Campaign` list). Deliberately differs from the group-page flow (`GroupView.tsx`), which navigates to the new campaign's detail page — this flow keeps the user on the page they started from, per the Figma annotation on the "Confirmer" button.
+
+## Architecture
+
+**Entry point:** a new `Button` ("Enregistrer une campagne", primary/MD, icon-left) added to the existing toolbar `Stack` in `CampaignTable.tsx`. No changes to `CampaignListView.tsx`.
+
+**New files:**
+- `frontend/src/components/Campaign/SelectGroupModal.tsx` — exports `createSelectGroupModal()`, a `createExtendedModal` (no confirm footer — selection happens per-row). Renders: `Stepper` (step 1/2), `AppSearchBar` (submit-only), `AdvancedTable` of eligible groups with a "Sélectionner" action column.
+- `frontend/src/components/Campaign/SaveCampaignFlow.tsx` — orchestrator component, parallel to `HousingCreationModal.tsx`. Creates both modal instances, holds `selectedGroup` state, wires the step transition and the submit handler. Mounted directly inside `CampaignTable.tsx`, self-contained (no prop drilling from `CampaignListView.tsx`).
+
+**Modified file:**
+- `frontend/src/components/Group/CreateCampaignFromGroupModal.tsx` — add one optional prop, e.g. `stepper?: { currentStep: number; stepCount: number }`, rendering a `Stepper` at the top of the modal content when present. Omitted (no behavior change) for the existing `GroupNext.tsx` call site; passed `{ currentStep: 2, stepCount: 2 }` from the new flow. Purely additive — no changes to the existing schema, fields, or submit logic.
+
+## Data Flow
+
+**Step 1 — search & select:**
+1. `useFindGroupsQuery()` (existing, unchanged) fetches all establishment groups.
+2. Filter to eligible groups: `archivedAt === null && housingCount > 0`.
+3. If `searchText` is set (updated only on `AppSearchBar` submit/Enter), filter further by case-insensitive substring match on `title`.
+4. Sort by `createdAt` descending.
+5. Render via `AdvancedTable`, which paginates 5/page natively.
+6. Clicking a row's "Sélectionner" button calls `handleGroupSelected(group)`.
+
+**Step transition:**
+```
+handleGroupSelected(group):
+  setSelectedGroup(group)
+  selectGroupModal.close()
+  campaignFromGroupModal.open()
+```
+
+**Step 2 — create:**
+1. Existing form (unchanged): Nom (required), Description (optional), Date d'envoi (optional).
+2. On submit: `useCreateCampaignFromGroupMutation({ campaign: payload, group: selectedGroup })`.
+3. On success: toast "La campagne a été ajoutée", close modal, reset `selectedGroup`/`searchText`/pagination, stay on `/campagnes`.
+4. On failure: error toast, modal stays open with form data intact for retry.
+
+**Reset on cancel:** step 1 resets its own search/pagination state on close (Fermer). Step 2's reset-on-close behavior is already handled by the existing modal.
+
+## Error Handling
+
+- `useFindGroupsQuery` failure or empty/no-match result: reuse the existing generic table error/empty-state convention (no new pattern invented).
+- `useCreateCampaignFromGroupMutation` failure: error toast; modal stays open with data intact.
+
+## Testing (TDD — written before implementation)
+
+- `SelectGroupModal.test.tsx`: excludes archived/empty groups; substring search is case-insensitive; results sorted by `createdAt` descending; 5/page pagination; "Sélectionner" fires the callback with the correct group; empty/no-match state renders.
+- `SaveCampaignFlow.test.tsx`: button opens step 1; selecting a group closes step 1 and opens step 2 with that group; submit calls the mutation with `{ campaign, group }`, shows the success toast, closes the modal, does not navigate; mutation failure keeps the modal open and shows an error toast.
+- `CreateCampaignFromGroupModal.test.tsx` (existing file): add a case for the new `stepper` prop rendering/not-rendering — regression guard for the existing group-page flow.
+- No backend tests — frontend-only, reusing existing endpoints unmodified.
+
+## Accessibility (RGAA)
+
+To verify explicitly during implementation against `.claude/rules/rgaa-accessibility.md`, not deferred to review:
+- `Stepper` ARIA semantics when used inside a modal (first such usage in the codebase).
+- Search input label association (`AppSearchBar`).
+- Table header scoping (`AdvancedTable`).
+- Focus management across the two chained modal instances (focus should land sensibly in step 2 after step 1 closes).
+
+## Out of Scope
+
+- Any backend/API changes (`GET /groups` search, new campaign-creation endpoints).
+- Changing the group-page ("Créer une campagne" from `/groupes/:id`) flow's behavior.
+- A "back" button from step 2 to step 1.

--- a/docs/superpowers/specs/2026-07-17-save-campaign-design.md
+++ b/docs/superpowers/specs/2026-07-17-save-campaign-design.md
@@ -17,6 +17,7 @@ As a [user], I want to save a campaign from the campaigns list, in order to conv
 ## Mockups
 
 Three Figma frames (file `kfEYtoHqhonLyCDTcDm5wu`):
+
 - `16477:53770` — Campaigns list page, new "Enregistrer une campagne" button in the toolbar.
 - `16477:62849` — Step 1 modal: "Sélectionner le groupe de logements".
 - `16477:64023` — Step 2 modal: "Créer une campagne" (existing form + new stepper).
@@ -35,14 +36,14 @@ Three Figma frames (file `kfEYtoHqhonLyCDTcDm5wu`):
 
 1. **Group search is client-side.** `GET /groups` has no search param and none will be added — filter the already-fetched, unfiltered list in the browser (matches the existing `PerimetersModal` pattern). No backend changes.
 2. **Excluded groups:** archived groups and groups with `housingCount === 0` are excluded entirely from the results (not shown, not just disabled) — mirrors the existing disabled state of "Créer une campagne" on the group page.
-3. **Pagination is real, not decorative.** The table shows *all* matching/eligible groups, paginated 5/page via `AdvancedTable`'s existing pagination — not just a top-5 cutoff.
+3. **Pagination is real, not decorative.** The table shows _all_ matching/eligible groups, paginated 5/page via `AdvancedTable`'s existing pagination — not just a top-5 cutoff.
 4. **Sort order:** most recently created first (`createdAt` descending).
 5. **Default state (no search yet):** all eligible groups are shown, paginated, immediately when step 1 opens.
 6. **Search trigger:** submit-only (`AppSearchBar`'s `onSearch`, fired on button click or Enter) — no live filter-as-you-type.
 7. **Modal architecture:** two separate, fully independent modal instances (step 1: new `SelectGroupModal`; step 2: existing `CreateCampaignFromGroupModal` unmodified) chained via a parent's `useState`, mirroring `HousingCreationModal.tsx` exactly. Considered and rejected a single-modal-with-internal-step-switch approach (avoids a possible close/reopen flicker, but requires extracting the existing modal's form into a headless component) in favor of simplicity and reuse of already-shipped code.
 8. **No back button** from step 2 to step 1 — Annuler/Fermer/click-outside on step 2 closes the entire flow rather than returning to step 1 (matches the ticket's spec text; deliberately differs from `HousingCreationModal`'s back-button precedent).
 9. **Post-creation behavior:** on success, close the modal, show a toast ("La campagne a été ajoutée"), and stay on `/campagnes` (list auto-refreshes via the existing `invalidatesTags` on the `Campaign` list). Deliberately differs from the group-page flow (`GroupView.tsx`), which navigates to the new campaign's detail page — this flow keeps the user on the page they started from, per the Figma annotation on the "Confirmer" button.
-10. **Only Usual/Admin can create campaigns — fixed at the backend, for both entry points.** The codebase survey found that campaign creation has *no* role check anywhere today: neither the existing "Créer une campagne" button (`GroupNext.tsx`) nor the endpoint it calls (`POST /groups/:id/campaigns`) restrict by role, so a VISITOR can currently create a campaign. Since both the existing and the new flow share that endpoint, the fix is applied at the backend (authoritative) and mirrored on both frontend entry points — a frontend-only check would leave the API callable directly by a Visitor.
+10. **Only Usual/Admin can create campaigns — fixed at the backend, for both entry points.** The codebase survey found that campaign creation has _no_ role check anywhere today: neither the existing "Créer une campagne" button (`GroupNext.tsx`) nor the endpoint it calls (`POST /groups/:id/campaigns`) restrict by role, so a VISITOR can currently create a campaign. Since both the existing and the new flow share that endpoint, the fix is applied at the backend (authoritative) and mirrored on both frontend entry points — a frontend-only check would leave the API callable directly by a Visitor.
 11. **Visitors don't see either "create campaign" button at all** (not shown-disabled) — matches the existing hide-based convention for permission gating elsewhere (`DocumentsTab.tsx`, `HousingView.tsx`), as opposed to the disabled-with-tooltip pattern which has no precedent in this codebase for permission (as opposed to data-availability) gating.
 12. **Scope of the guard is creation only.** `PUT/DELETE /campaigns/:id` (update, delete, send) have the same missing-role-check gap but are explicitly out of scope for this ticket — flagged as a separate follow-up, not fixed here.
 
@@ -51,10 +52,12 @@ Three Figma frames (file `kfEYtoHqhonLyCDTcDm5wu`):
 **Entry point:** a new `Button` ("Enregistrer une campagne", primary/MD, icon-left) added to the existing toolbar `Stack` in `CampaignTable.tsx`, rendered only when `isAdmin || isUsual` (via `useUser()`) — hidden entirely for VISITOR. No changes to `CampaignListView.tsx`.
 
 **New files:**
+
 - `frontend/src/components/Campaign/SelectGroupModal.tsx` — exports `createSelectGroupModal()`, a `createExtendedModal` (no confirm footer — selection happens per-row). Renders: `Stepper` (step 1/2), `AppSearchBar` (submit-only), `AdvancedTable` of eligible groups with a "Sélectionner" action column.
 - `frontend/src/components/Campaign/SaveCampaignFlow.tsx` — orchestrator component, parallel to `HousingCreationModal.tsx`. Creates both modal instances, holds `selectedGroup` state, wires the step transition and the submit handler. Mounted directly inside `CampaignTable.tsx`, self-contained (no prop drilling from `CampaignListView.tsx`).
 
 **Modified files:**
+
 - `frontend/src/components/Group/CreateCampaignFromGroupModal.tsx` — add one optional prop, e.g. `stepper?: { currentStep: number; stepCount: number }`, rendering a `Stepper` at the top of the modal content when present. Omitted (no behavior change) for the existing `GroupNext.tsx` call site; passed `{ currentStep: 2, stepCount: 2 }` from the new flow. Purely additive — no changes to the existing schema, fields, or submit logic.
 - `frontend/src/components/Group/GroupNext.tsx` — wrap the existing "Créer une campagne" `FullWidthButton` in `const { isAdmin, isUsual } = useUser(); const canCreateCampaign = isAdmin || isUsual;`, hiding it entirely (not just disabling) for VISITOR. Same one-line convention as `DocumentsTab.tsx`/`HousingView.tsx`.
 - `server/src/routers/protected.ts` — add `hasRole([UserRole.USUAL, UserRole.ADMIN])` middleware to the `POST /groups/:id/campaigns` route (~line 295), matching the existing convention used for documents/notes/housing-update routes. This is the authoritative fix; it protects both the existing group-page flow and the new list-page flow since they share this endpoint. No other campaign routes are touched (see Decisions #12 and Out of Scope).
@@ -62,6 +65,7 @@ Three Figma frames (file `kfEYtoHqhonLyCDTcDm5wu`):
 ## Data Flow
 
 **Step 1 — search & select:**
+
 1. `useFindGroupsQuery()` (existing, unchanged) fetches all establishment groups.
 2. Filter to eligible groups: `archivedAt === null && housingCount > 0`.
 3. If `searchText` is set (updated only on `AppSearchBar` submit/Enter), filter further by case-insensitive substring match on `title`.
@@ -70,6 +74,7 @@ Three Figma frames (file `kfEYtoHqhonLyCDTcDm5wu`):
 6. Clicking a row's "Sélectionner" button calls `handleGroupSelected(group)`.
 
 **Step transition:**
+
 ```
 handleGroupSelected(group):
   setSelectedGroup(group)
@@ -78,6 +83,7 @@ handleGroupSelected(group):
 ```
 
 **Step 2 — create:**
+
 1. Existing form (unchanged): Nom (required), Description (optional), Date d'envoi (optional).
 2. On submit: `useCreateCampaignFromGroupMutation({ campaign: payload, group: selectedGroup })`.
 3. On success: toast "La campagne a été ajoutée", close modal, reset `selectedGroup`/`searchText`/pagination, stay on `/campagnes`.
@@ -102,6 +108,7 @@ handleGroupSelected(group):
 ## Accessibility (RGAA)
 
 To verify explicitly during implementation against `.claude/rules/rgaa-accessibility.md`, not deferred to review:
+
 - `Stepper` ARIA semantics when used inside a modal (first such usage in the codebase).
 - Search input label association (`AppSearchBar`).
 - Table header scoping (`AdvancedTable`).

--- a/frontend/src/components/AdvancedTable/AdvancedTable.tsx
+++ b/frontend/src/components/AdvancedTable/AdvancedTable.tsx
@@ -4,6 +4,7 @@ import SelectNext from '@codegouvfr/react-dsfr/SelectNext';
 import { type TableProps } from '@codegouvfr/react-dsfr/Table';
 import Skeleton from '@mui/material/Skeleton';
 import Stack from '@mui/material/Stack';
+import { styled } from '@mui/material/styles';
 import {
   flexRender,
   getCoreRowModel,
@@ -22,6 +23,8 @@ import { match } from 'ts-pattern';
 import SingleCheckbox from '~/components/_app/AppCheckbox/SingleCheckbox';
 import SortButton from '~/components/AdvancedTable/SortButton';
 import { type Selection } from '~/hooks/useSelection';
+
+import LabelNext from '../Label/LabelNext';
 
 /**
  *
@@ -62,6 +65,21 @@ export type AdvancedTableProps<Data extends object> = Pick<
      * Use alongside noCaption: true in tableProps to preserve DSFR padding.
      */
     caption?: string;
+    /**
+     * Per-slot className overrides, for callers that need to restyle an
+     * internal element (e.g. left-align the pagination footer inside a modal).
+     */
+    classes?: {
+      /** Pagination footer slots. */
+      pagination?: {
+        /**
+         * The row wrapping the page-size control and the pagination buttons.
+         * When provided, this class owns the row's horizontal alignment (the
+         * default `justify-content: center` is dropped so the override wins).
+         */
+        container?: string;
+      };
+    };
   };
 
 interface PaginationProps {
@@ -96,6 +114,16 @@ interface PaginationProps {
 const ROW_SIZE = 64;
 const PER_PAGE_OPTIONS = [10, 50, 200, 500];
 const DEFAULT_PAGE_SIZE = 50;
+
+// Slot defaults live in a styled() component (not instance `sx`) so that, under
+// this app's `StyledEngineProvider injectFirst`, they are injected first and a
+// caller-supplied `classes.pagination.container` class — appended below —
+// overrides them by injection order. This mirrors how MUI's own `classes` work.
+const PaginationFooter = styled(Stack)({
+  justifyContent: 'center',
+  alignItems: 'center',
+  flexWrap: 'wrap'
+});
 
 function AdvancedTable<Data extends object>(props: AdvancedTableProps<Data>) {
   // Map our selection to the @tanstack/table internal selection state
@@ -330,21 +358,17 @@ function AdvancedTable<Data extends object>(props: AdvancedTableProps<Data>) {
       </div>
 
       {paginate ? (
-        <Stack
+        <PaginationFooter
           direction="row"
-          spacing={staticPageSize ? '0.75rem' : '1rem'}
+          spacing="1rem"
           useFlexGap
-          sx={{
-            justifyContent: 'center',
-            alignItems: 'center',
-            flexWrap: staticPageSize ? 'nowrap' : 'wrap'
-          }}
+          className={props.classes?.pagination?.container}
         >
           {staticPageSize ? (
-            <span className={fr.cx('fr-text--sm')}>
+            <LabelNext>
               {table.getState().pagination.pageSize} ligne
               {table.getState().pagination.pageSize > 1 ? 's' : ''} par page
-            </span>
+            </LabelNext>
           ) : (
             <SelectNext
               label={null}
@@ -376,7 +400,7 @@ function AdvancedTable<Data extends object>(props: AdvancedTableProps<Data>) {
             })}
             showFirstLast
           />
-        </Stack>
+        </PaginationFooter>
       ) : null}
     </Stack>
   );

--- a/frontend/src/components/AdvancedTable/AdvancedTable.tsx
+++ b/frontend/src/components/AdvancedTable/AdvancedTable.tsx
@@ -73,10 +73,21 @@ interface PaginationProps {
    * You must define this when using server-side pagination.
    */
   pageCount?: number;
+  /**
+   * Options shown in the "results per page" selector.
+   * @default [10, 50, 200, 500]
+   */
+  perPageOptions?: number[];
+  /**
+   * Initial/uncontrolled page size.
+   * @default 50
+   */
+  defaultPageSize?: number;
 }
 
 const ROW_SIZE = 64;
 const PER_PAGE_OPTIONS = [10, 50, 200, 500];
+const DEFAULT_PAGE_SIZE = 50;
 
 function AdvancedTable<Data extends object>(props: AdvancedTableProps<Data>) {
   // Map our selection to the @tanstack/table internal selection state
@@ -96,9 +107,10 @@ function AdvancedTable<Data extends object>(props: AdvancedTableProps<Data>) {
   const enableSelection = props.selection !== undefined;
 
   const paginate = props.paginate ?? true;
+  const perPageOptions = props.perPageOptions ?? PER_PAGE_OPTIONS;
   const [pagination, setPagination] = useState<PaginationState>({
     pageIndex: 0,
-    pageSize: 50
+    pageSize: props.defaultPageSize ?? DEFAULT_PAGE_SIZE
   });
 
   const table = useReactTable<Data>({
@@ -321,7 +333,7 @@ function AdvancedTable<Data extends object>(props: AdvancedTableProps<Data>) {
         >
           <SelectNext
             label={null}
-            options={PER_PAGE_OPTIONS.map((option) => ({
+            options={perPageOptions.map((option) => ({
               label: `${option} résultats par page`,
               value: String(option)
             }))}

--- a/frontend/src/components/AdvancedTable/AdvancedTable.tsx
+++ b/frontend/src/components/AdvancedTable/AdvancedTable.tsx
@@ -365,7 +365,7 @@ function AdvancedTable<Data extends object>(props: AdvancedTableProps<Data>) {
           className={props.classes?.pagination?.container}
         >
           {staticPageSize ? (
-            <LabelNext>
+            <LabelNext sx={{ fontWeight: 'normal' }}>
               {table.getState().pagination.pageSize} ligne
               {table.getState().pagination.pageSize > 1 ? 's' : ''} par page
             </LabelNext>

--- a/frontend/src/components/AdvancedTable/AdvancedTable.tsx
+++ b/frontend/src/components/AdvancedTable/AdvancedTable.tsx
@@ -83,6 +83,14 @@ interface PaginationProps {
    * @default 50
    */
   defaultPageSize?: number;
+  /**
+   * When true, the "results per page" control is rendered as static,
+   * non-editable text ("N lignes par page") to the left of the pagination
+   * instead of an editable select. Use for small, fixed-size tables (e.g.
+   * inside a modal) where changing the page size is not meaningful.
+   * @default false
+   */
+  staticPageSize?: boolean;
 }
 
 const ROW_SIZE = 64;
@@ -107,6 +115,7 @@ function AdvancedTable<Data extends object>(props: AdvancedTableProps<Data>) {
   const enableSelection = props.selection !== undefined;
 
   const paginate = props.paginate ?? true;
+  const staticPageSize = props.staticPageSize ?? false;
   const perPageOptions = props.perPageOptions ?? PER_PAGE_OPTIONS;
   const [pagination, setPagination] = useState<PaginationState>({
     pageIndex: 0,
@@ -323,30 +332,37 @@ function AdvancedTable<Data extends object>(props: AdvancedTableProps<Data>) {
       {paginate ? (
         <Stack
           direction="row"
-          spacing="1rem"
+          spacing={staticPageSize ? '0.75rem' : '1rem'}
           useFlexGap
           sx={{
             justifyContent: 'center',
             alignItems: 'center',
-            flexWrap: 'wrap'
+            flexWrap: staticPageSize ? 'nowrap' : 'wrap'
           }}
         >
-          <SelectNext
-            label={null}
-            options={perPageOptions.map((option) => ({
-              label: `${option} résultats par page`,
-              value: String(option)
-            }))}
-            nativeSelectProps={{
-              value: String(table.getState().pagination.pageSize),
-              onChange: (event) => {
-                const value = Number(event.target.value);
-                if (value !== null) {
-                  table.setPageSize(value);
+          {staticPageSize ? (
+            <span className={fr.cx('fr-text--sm')}>
+              {table.getState().pagination.pageSize} ligne
+              {table.getState().pagination.pageSize > 1 ? 's' : ''} par page
+            </span>
+          ) : (
+            <SelectNext
+              label={null}
+              options={perPageOptions.map((option) => ({
+                label: `${option} résultats par page`,
+                value: String(option)
+              }))}
+              nativeSelectProps={{
+                value: String(table.getState().pagination.pageSize),
+                onChange: (event) => {
+                  const value = Number(event.target.value);
+                  if (value !== null) {
+                    table.setPageSize(value);
+                  }
                 }
-              }
-            }}
-          />
+              }}
+            />
+          )}
 
           <TablePagination
             count={table.getPageCount()}

--- a/frontend/src/components/AdvancedTable/AdvancedTable.tsx
+++ b/frontend/src/components/AdvancedTable/AdvancedTable.tsx
@@ -365,7 +365,7 @@ function AdvancedTable<Data extends object>(props: AdvancedTableProps<Data>) {
           className={props.classes?.pagination?.container}
         >
           {staticPageSize ? (
-            <LabelNext sx={{ fontWeight: 'normal' }}>
+            <LabelNext sx={{ fontWeight: 'normal', mb: '1rem' }}>
               {table.getState().pagination.pageSize} ligne
               {table.getState().pagination.pageSize > 1 ? 's' : ''} par page
             </LabelNext>

--- a/frontend/src/components/AdvancedTable/test/AdvancedTable.test.tsx
+++ b/frontend/src/components/AdvancedTable/test/AdvancedTable.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createColumnHelper } from '@tanstack/react-table';
+
+import AdvancedTable from '~/components/AdvancedTable/AdvancedTable';
+
+interface Row {
+  id: string;
+  name: string;
+}
+
+const columnHelper = createColumnHelper<Row>();
+const columns = [columnHelper.accessor('name', { header: 'Nom' })];
+
+function buildRows(count: number): Row[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: String(i),
+    name: `Row ${i}`
+  }));
+}
+
+describe('AdvancedTable', () => {
+  const user = userEvent.setup();
+
+  it('should default to 50 results per page when perPageOptions is not provided', async () => {
+    render(<AdvancedTable columns={columns} data={buildRows(3)} />);
+
+    await screen.findByRole('table');
+    expect(
+      screen.getByDisplayValue('50 résultats par page')
+    ).toBeInTheDocument();
+  });
+
+  it('should use a custom default page size and per-page options', async () => {
+    render(
+      <AdvancedTable
+        columns={columns}
+        data={buildRows(7)}
+        perPageOptions={[5, 10, 50]}
+        defaultPageSize={5}
+      />
+    );
+
+    const table = await screen.findByRole('table');
+    expect(
+      screen.getByDisplayValue('5 résultats par page')
+    ).toBeInTheDocument();
+    // 1 header row + 5 data rows
+    expect(within(table).getAllByRole('row')).toHaveLength(6);
+
+    const select = screen.getByDisplayValue('5 résultats par page');
+    await user.selectOptions(select, '10');
+
+    // 1 header row + remaining 7 data rows (only 7 total)
+    expect(within(table).getAllByRole('row')).toHaveLength(8);
+  });
+});

--- a/frontend/src/components/AdvancedTable/test/AdvancedTable.test.tsx
+++ b/frontend/src/components/AdvancedTable/test/AdvancedTable.test.tsx
@@ -1,6 +1,6 @@
+import { createColumnHelper } from '@tanstack/react-table';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { createColumnHelper } from '@tanstack/react-table';
 
 import AdvancedTable from '~/components/AdvancedTable/AdvancedTable';
 

--- a/frontend/src/components/Campaign/CampaignTable.tsx
+++ b/frontend/src/components/Campaign/CampaignTable.tsx
@@ -16,6 +16,7 @@ import { toPercentage } from '~/utils/number-utils';
 import { displayCount } from '~/utils/stringUtils';
 
 import AppLink from '../_app/AppLink/AppLink';
+import SaveCampaignFlow from './SaveCampaignFlow';
 import WaitingBadge from './WaitingBadge';
 
 export interface CampaignTableProps {
@@ -213,6 +214,8 @@ function CampaignTable(props: CampaignTableProps) {
             })}
           </Typography>
         )}
+
+        <SaveCampaignFlow />
       </Stack>
 
       <AdvancedTable

--- a/frontend/src/components/Campaign/SaveCampaignFlow.tsx
+++ b/frontend/src/components/Campaign/SaveCampaignFlow.tsx
@@ -16,10 +16,13 @@ const campaignFromGroupModal = createCampaignFromGroupModal({
 });
 
 function SaveCampaignFlow() {
-  const { isAdmin, isUsual } = useUser();
-  const canCreateCampaign = isAdmin || isUsual;
+  const { canCreateCampaign } = useUser();
 
   const [selectedGroup, setSelectedGroup] = useState<Group | null>(null);
+  // Bumped every time the flow is (re)opened. Passed to SelectGroupModal to
+  // defer the groups query until the flow is first opened, and to re-key its
+  // search input so a reopen starts blank.
+  const [openCount, setOpenCount] = useState(0);
 
   const [createCampaignFromGroup, createCampaignFromGroupMutation] =
     useCreateCampaignFromGroupMutation();
@@ -81,12 +84,18 @@ function SaveCampaignFlow() {
       <Button
         iconId="fr-icon-save-line"
         priority="primary"
-        onClick={selectGroupModal.open}
+        onClick={() => {
+          setOpenCount((count) => count + 1);
+          selectGroupModal.open();
+        }}
       >
         Enregistrer une campagne
       </Button>
 
-      <selectGroupModal.Component onSelect={handleGroupSelect} />
+      <selectGroupModal.Component
+        openCount={openCount}
+        onSelect={handleGroupSelect}
+      />
 
       <campaignFromGroupModal.Component
         group={selectedGroup}

--- a/frontend/src/components/Campaign/SaveCampaignFlow.tsx
+++ b/frontend/src/components/Campaign/SaveCampaignFlow.tsx
@@ -1,0 +1,93 @@
+import Button from '@codegouvfr/react-dsfr/Button';
+import { useEffect, useState } from 'react';
+
+import { createCampaignFromGroupModal } from '~/components/Group/CreateCampaignFromGroupModal';
+import { useNotification } from '~/hooks/useNotification';
+import { useUser } from '~/hooks/useUser';
+import type { Campaign } from '~/models/Campaign';
+import type { Group } from '~/models/Group';
+import { useCreateCampaignFromGroupMutation } from '~/services/campaign.service';
+
+import createSelectGroupModal from './SelectGroupModal';
+
+const selectGroupModal = createSelectGroupModal();
+const campaignFromGroupModal = createCampaignFromGroupModal({
+  id: 'save-campaign-from-group-modal'
+});
+
+function SaveCampaignFlow() {
+  const { isAdmin, isUsual } = useUser();
+  const canCreateCampaign = isAdmin || isUsual;
+
+  const [selectedGroup, setSelectedGroup] = useState<Group | null>(null);
+
+  const [createCampaignFromGroup, createCampaignFromGroupMutation] =
+    useCreateCampaignFromGroupMutation();
+
+  useNotification({
+    toastId: 'save-campaign-from-group',
+    isError: createCampaignFromGroupMutation.isError,
+    isLoading: createCampaignFromGroupMutation.isLoading,
+    isSuccess: createCampaignFromGroupMutation.isSuccess,
+    message: {
+      error: 'Erreur lors de la création de la campagne',
+      loading: 'Création de la campagne...',
+      success: 'La campagne a été ajoutée'
+    }
+  });
+
+  // `campaignFromGroupModal`'s dialog is only mounted once `selectedGroup`
+  // is set, so `.open()` must run after that render commits (not
+  // synchronously in the click handler) or its DOM node won't exist yet.
+  useEffect(() => {
+    if (selectedGroup) {
+      campaignFromGroupModal.open();
+    }
+  }, [selectedGroup]);
+
+  function handleGroupSelect(group: Group): void {
+    setSelectedGroup(group);
+    selectGroupModal.close();
+  }
+
+  function handleCampaignSubmit(
+    campaign: Pick<Campaign, 'title' | 'description' | 'sentAt'>
+  ): void {
+    if (selectedGroup) {
+      createCampaignFromGroup({ campaign, group: selectedGroup })
+        .unwrap()
+        .then(() => {
+          campaignFromGroupModal.close();
+          setSelectedGroup(null);
+        });
+    }
+  }
+
+  if (!canCreateCampaign) {
+    return null;
+  }
+
+  return (
+    <>
+      <Button
+        iconId="fr-icon-save-line"
+        priority="primary"
+        onClick={selectGroupModal.open}
+      >
+        Enregistrer une campagne
+      </Button>
+
+      <selectGroupModal.Component onSelect={handleGroupSelect} />
+
+      {selectedGroup && (
+        <campaignFromGroupModal.Component
+          group={selectedGroup}
+          stepper={{ currentStep: 2, stepCount: 2 }}
+          onSubmit={handleCampaignSubmit}
+        />
+      )}
+    </>
+  );
+}
+
+export default SaveCampaignFlow;

--- a/frontend/src/components/Campaign/SaveCampaignFlow.tsx
+++ b/frontend/src/components/Campaign/SaveCampaignFlow.tsx
@@ -82,10 +82,19 @@ function SaveCampaignFlow() {
     if (selectedGroup) {
       createCampaignFromGroup({ campaign, group: selectedGroup })
         .unwrap()
-        .then(() => {
-          campaignFromGroupModal.close();
-          setSelectedGroup(null);
-        });
+        .then(
+          () => {
+            campaignFromGroupModal.close();
+            setSelectedGroup(null);
+          },
+          // Swallow the rejection so a failed submit doesn't surface as an
+          // unhandled promise rejection. No recovery is needed here: on failure
+          // the modal stays open and `selectedGroup` is untouched (the success
+          // branch above never runs), letting the user retry, and the error
+          // toast is already driven by `useNotification` watching the
+          // mutation's `isError`.
+          () => {}
+        );
     }
   }
 

--- a/frontend/src/components/Campaign/SaveCampaignFlow.tsx
+++ b/frontend/src/components/Campaign/SaveCampaignFlow.tsx
@@ -91,6 +91,7 @@ function SaveCampaignFlow() {
       <campaignFromGroupModal.Component
         group={selectedGroup}
         stepper={{ currentStep: 2, stepCount: 2 }}
+        submitting={createCampaignFromGroupMutation.isLoading}
         onSubmit={handleCampaignSubmit}
       />
     </>

--- a/frontend/src/components/Campaign/SaveCampaignFlow.tsx
+++ b/frontend/src/components/Campaign/SaveCampaignFlow.tsx
@@ -36,13 +36,39 @@ function SaveCampaignFlow() {
     }
   });
 
-  // `campaignFromGroupModal`'s dialog is only mounted once `selectedGroup`
-  // is set, so `.open()` must run after that render commits (not
-  // synchronously in the click handler) or its DOM node won't exist yet.
+  // `campaignFromGroupModal`'s dialog is only mounted once `selectedGroup` is
+  // set, so both opening it and wiring its conceal listener must run after that
+  // render commits (not synchronously in the click handler) — its DOM node
+  // doesn't exist before then.
+  //
+  // Resetting `selectedGroup` to `null` on conceal is mandatory: step 2 is
+  // opened by the edge-triggered `selectedGroup` change below, so a stale group
+  // left here would make re-selecting the SAME group a no-op (stable RTK Query
+  // ref → React bails the update → this effect never re-fires), yielding a dead
+  // "Enregistrer" click after a cancel. Clearing to `null` makes every
+  // selection a fresh `null → group` edge.
+  //
+  // We listen to DSFR's own `dsfr.conceal` event directly on the dialog element
+  // rather than via react-dsfr's `useIsModalOpen`, because this modal renders
+  // through `createPortal`: `useIsModalOpen`'s mount-detection MutationObserver
+  // only sees the top-level portal node (the `<form>`) added to `<body>`, never
+  // the nested `<dialog>`, so its `onConceal` never fires for this instance.
+  // `onClose` is also unavailable — `CreateCampaignFromGroupModal` hard-overrides
+  // it with `form.reset`.
   useEffect(() => {
-    if (selectedGroup) {
-      campaignFromGroupModal.open();
+    if (!selectedGroup) {
+      return;
     }
+
+    campaignFromGroupModal.open();
+
+    const dialog = document.getElementById(campaignFromGroupModal.id);
+    const handleConceal = () => setSelectedGroup(null);
+    dialog?.addEventListener('dsfr.conceal', handleConceal);
+
+    return () => {
+      dialog?.removeEventListener('dsfr.conceal', handleConceal);
+    };
   }, [selectedGroup]);
 
   function handleGroupSelect(group: Group): void {

--- a/frontend/src/components/Campaign/SaveCampaignFlow.tsx
+++ b/frontend/src/components/Campaign/SaveCampaignFlow.tsx
@@ -1,5 +1,5 @@
 import Button from '@codegouvfr/react-dsfr/Button';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 import { createCampaignFromGroupModal } from '~/components/Group/CreateCampaignFromGroupModal';
 import { useNotification } from '~/hooks/useNotification';
@@ -36,44 +36,18 @@ function SaveCampaignFlow() {
     }
   });
 
-  // `campaignFromGroupModal`'s dialog is only mounted once `selectedGroup` is
-  // set, so both opening it and wiring its conceal listener must run after that
-  // render commits (not synchronously in the click handler) — its DOM node
-  // doesn't exist before then.
-  //
-  // Resetting `selectedGroup` to `null` on conceal is mandatory: step 2 is
-  // opened by the edge-triggered `selectedGroup` change below, so a stale group
-  // left here would make re-selecting the SAME group a no-op (stable RTK Query
-  // ref → React bails the update → this effect never re-fires), yielding a dead
-  // "Enregistrer" click after a cancel. Clearing to `null` makes every
-  // selection a fresh `null → group` edge.
-  //
-  // We listen to DSFR's own `dsfr.conceal` event directly on the dialog element
-  // rather than via react-dsfr's `useIsModalOpen`, because this modal renders
-  // through `createPortal`: `useIsModalOpen`'s mount-detection MutationObserver
-  // only sees the top-level portal node (the `<form>`) added to `<body>`, never
-  // the nested `<dialog>`, so its `onConceal` never fires for this instance.
-  // `onClose` is also unavailable — `CreateCampaignFromGroupModal` hard-overrides
-  // it with `form.reset`.
-  useEffect(() => {
-    if (!selectedGroup) {
-      return;
-    }
-
-    campaignFromGroupModal.open();
-
-    const dialog = document.getElementById(campaignFromGroupModal.id);
-    const handleConceal = () => setSelectedGroup(null);
-    dialog?.addEventListener('dsfr.conceal', handleConceal);
-
-    return () => {
-      dialog?.removeEventListener('dsfr.conceal', handleConceal);
-    };
-  }, [selectedGroup]);
-
+  // Both modals are mounted unconditionally (step 2 tolerates a null group),
+  // mirroring `HousingCreationModal`. This is required: DSFR initialises a
+  // `<dialog>` asynchronously after it mounts, so `.open()` on a dialog that was
+  // *conditionally* mounted in the same interaction throws
+  // `Cannot read properties of null (reading 'modal')`. Keeping step 2 mounted
+  // means it is DSFR-initialised well before the user selects a group, so the
+  // synchronous `.open()` below always works. It also makes re-opening after a
+  // cancel trivial — `.open()` runs on every selection, not on a state edge.
   function handleGroupSelect(group: Group): void {
     setSelectedGroup(group);
     selectGroupModal.close();
+    campaignFromGroupModal.open();
   }
 
   function handleCampaignSubmit(
@@ -114,13 +88,11 @@ function SaveCampaignFlow() {
 
       <selectGroupModal.Component onSelect={handleGroupSelect} />
 
-      {selectedGroup && (
-        <campaignFromGroupModal.Component
-          group={selectedGroup}
-          stepper={{ currentStep: 2, stepCount: 2 }}
-          onSubmit={handleCampaignSubmit}
-        />
-      )}
+      <campaignFromGroupModal.Component
+        group={selectedGroup}
+        stepper={{ currentStep: 2, stepCount: 2 }}
+        onSubmit={handleCampaignSubmit}
+      />
     </>
   );
 }

--- a/frontend/src/components/Campaign/SaveCampaignFlow.tsx
+++ b/frontend/src/components/Campaign/SaveCampaignFlow.tsx
@@ -35,7 +35,7 @@ function SaveCampaignFlow() {
     message: {
       error: 'Erreur lors de la création de la campagne',
       loading: 'Création de la campagne...',
-      success: 'La campagne a été ajoutée'
+      success: 'Campagne créée !'
     }
   });
 

--- a/frontend/src/components/Campaign/SaveCampaignFlow.tsx
+++ b/frontend/src/components/Campaign/SaveCampaignFlow.tsx
@@ -1,5 +1,6 @@
 import Button from '@codegouvfr/react-dsfr/Button';
 import { useState } from 'react';
+import { useNavigate } from 'react-router';
 
 import { createCampaignFromGroupModal } from '~/components/Group/CreateCampaignFromGroupModal';
 import { useNotification } from '~/hooks/useNotification';
@@ -17,6 +18,7 @@ const campaignFromGroupModal = createCampaignFromGroupModal({
 
 function SaveCampaignFlow() {
   const { canCreateCampaign } = useUser();
+  const navigate = useNavigate();
 
   const [selectedGroup, setSelectedGroup] = useState<Group | null>(null);
   // Bumped every time the flow is (re)opened. Passed to SelectGroupModal to
@@ -60,9 +62,10 @@ function SaveCampaignFlow() {
       createCampaignFromGroup({ campaign, group: selectedGroup })
         .unwrap()
         .then(
-          () => {
+          (created) => {
             campaignFromGroupModal.close();
             setSelectedGroup(null);
+            navigate(`/campagnes/${created.id}`);
           },
           // Swallow the rejection so a failed submit doesn't surface as an
           // unhandled promise rejection. No recovery is needed here: on failure

--- a/frontend/src/components/Campaign/SelectGroupModal.tsx
+++ b/frontend/src/components/Campaign/SelectGroupModal.tsx
@@ -1,7 +1,8 @@
+import { fr } from '@codegouvfr/react-dsfr';
 import Button from '@codegouvfr/react-dsfr/Button';
 import Stepper from '@codegouvfr/react-dsfr/Stepper';
 import { createColumnHelper } from '@tanstack/react-table';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import AppSearchBar from '~/components/_app/AppSearchBar/AppSearchBar';
 import AdvancedTable from '~/components/AdvancedTable/AdvancedTable';
@@ -16,6 +17,13 @@ export type SelectGroupModalOptions = Partial<ExtendedModalOptions>;
 
 export interface SelectGroupModalProps {
   onSelect(group: Group): void;
+  /**
+   * Incremented by the parent each time the flow is (re)opened. When omitted
+   * (standalone usage) the groups query runs immediately. When provided, the
+   * query is skipped until the first open (`0` = not yet opened), and the value
+   * re-keys the search input so every reopen starts blank.
+   */
+  openCount?: number;
 }
 
 const columnHelper = createColumnHelper<Group>();
@@ -35,8 +43,17 @@ export function createSelectGroupModal(
   return {
     ...modal,
     Component(props: Readonly<SelectGroupModalProps>) {
-      const { data: groups } = useFindGroupsQuery();
+      const { openCount } = props;
+      const queryEnabled = openCount === undefined || openCount > 0;
+      const { data: groups, isFetching } = useFindGroupsQuery(undefined, {
+        skip: !queryEnabled
+      });
       const [searchText, setSearchText] = useState<string>('');
+
+      // Reset the search filter each time the flow is reopened.
+      useEffect(() => {
+        setSearchText('');
+      }, [openCount]);
 
       const filteredGroups = useMemo(() => {
         const eligible = (groups ?? []).filter(isEligible);
@@ -80,12 +97,17 @@ export function createSelectGroupModal(
         setSearchText(text);
       }
 
+      const groupCount = filteredGroups.length;
+      const statusMessage = isFetching
+        ? ''
+        : groupCount === 0
+          ? 'Aucun groupe trouvé'
+          : `${groupCount} groupe${groupCount > 1 ? 's' : ''} trouvé${
+              groupCount > 1 ? 's' : ''
+            }`;
+
       return (
-        <modal.Component
-          title="Enregistrer une campagne"
-          size="large"
-          onClose={() => setSearchText('')}
-        >
+        <modal.Component title="Enregistrer une campagne" size="large">
           <Stepper
             currentStep={1}
             stepCount={2}
@@ -93,7 +115,15 @@ export function createSelectGroupModal(
             nextTitle="Créer une campagne"
           />
 
-          <AppSearchBar label="Rechercher un groupe" onSearch={search} />
+          <AppSearchBar
+            key={openCount}
+            label="Rechercher un groupe"
+            onSearch={search}
+          />
+
+          <p role="status" className={fr.cx('fr-sr-only')}>
+            {statusMessage}
+          </p>
 
           <AdvancedTable
             caption="Groupes de logements"

--- a/frontend/src/components/Campaign/SelectGroupModal.tsx
+++ b/frontend/src/components/Campaign/SelectGroupModal.tsx
@@ -1,9 +1,11 @@
+import { ClassNames } from '@emotion/react';
 import { fr } from '@codegouvfr/react-dsfr';
 import Alert from '@codegouvfr/react-dsfr/Alert';
 import Button from '@codegouvfr/react-dsfr/Button';
 import Stepper from '@codegouvfr/react-dsfr/Stepper';
 import Stack from '@mui/material/Stack';
 import { createColumnHelper } from '@tanstack/react-table';
+import { Array, Order, pipe } from 'effect';
 import { useEffect, useMemo, useState } from 'react';
 
 import AppSearchBar from '~/components/_app/AppSearchBar/AppSearchBar';
@@ -14,6 +16,8 @@ import {
 } from '~/components/modals/ConfirmationModal/ExtendedModal';
 import type { Group } from '~/models/Group';
 import { useFindGroupsQuery } from '~/services/group.service';
+
+import LabelNext from '../Label/LabelNext';
 
 export type SelectGroupModalOptions = Partial<ExtendedModalOptions>;
 
@@ -63,14 +67,17 @@ export function createSelectGroupModal(
       }, [openCount]);
 
       const filteredGroups = useMemo(() => {
-        const eligible = (groups ?? []).filter(isEligible);
-        const matches = searchText
-          ? eligible.filter((group) =>
-              group.title.toLowerCase().includes(searchText.toLowerCase())
-            )
-          : eligible;
-        return [...matches].sort(
-          (a, b) => b.createdAt.getTime() - a.createdAt.getTime()
+        return pipe(
+          groups ?? [],
+          Array.filter(isEligible),
+          (groups) =>
+            searchText
+              ? groups.filter((group) =>
+                  group.title.toLowerCase().includes(searchText.toLowerCase())
+                )
+              : groups,
+          // Most recent first: reverse the ascending Date order.
+          Array.sortWith((group) => group.createdAt, Order.reverse(Order.Date))
         );
       }, [groups, searchText]);
 
@@ -129,6 +136,7 @@ export function createSelectGroupModal(
             stepCount={2}
             title="Sélectionner le groupe de logements"
             nextTitle="Créer une campagne"
+            className="fr-mb-2w"
           />
 
           {isError ? (
@@ -151,28 +159,38 @@ export function createSelectGroupModal(
               </Button>
             </>
           ) : (
-            <>
+            <Stack>
               <AppSearchBar
                 key={openCount}
                 label="Rechercher un groupe"
                 allowEmptySearch
                 onSearch={search}
+                className='fr-mb-2w'
               />
 
-              <p role="status" className={fr.cx('fr-text--bold', 'fr-mb-0')}>
+              <LabelNext role="status" sx={{ fontWeight: 'normal' }}>
                 {statusMessage}
-              </p>
+              </LabelNext>
 
-              <AdvancedTable
-                caption="Groupes de logements"
-                columns={columns}
-                data={filteredGroups}
-                perPageOptions={[5, 10, 50]}
-                defaultPageSize={5}
-                staticPageSize
-                tableProps={{ noCaption: true }}
-              />
-            </>
+              <ClassNames>
+                {({ css }) => (
+                  <AdvancedTable
+                    caption="Groupes de logements"
+                    columns={columns}
+                    data={filteredGroups}
+                    perPageOptions={[5, 10, 50]}
+                    defaultPageSize={5}
+                    staticPageSize
+                    classes={{
+                      pagination: {
+                        container: css({ justifyContent: 'flex-start' })
+                      }
+                    }}
+                    tableProps={{ noCaption: true }}
+                  />
+                )}
+              </ClassNames>
+            </Stack>
           )}
         </modal.Component>
       );

--- a/frontend/src/components/Campaign/SelectGroupModal.tsx
+++ b/frontend/src/components/Campaign/SelectGroupModal.tsx
@@ -2,6 +2,7 @@ import { fr } from '@codegouvfr/react-dsfr';
 import Alert from '@codegouvfr/react-dsfr/Alert';
 import Button from '@codegouvfr/react-dsfr/Button';
 import Stepper from '@codegouvfr/react-dsfr/Stepper';
+import Stack from '@mui/material/Stack';
 import { createColumnHelper } from '@tanstack/react-table';
 import { useEffect, useMemo, useState } from 'react';
 
@@ -80,19 +81,28 @@ export function createSelectGroupModal(
           }),
           columnHelper.display({
             id: 'actions',
-            header: 'Action',
-            cell: ({ row }) => (
-              <Button
-                priority="secondary"
-                size="small"
-                title={`Sélectionner le groupe ${row.original.title}`}
-                nativeButtonProps={{
-                  'aria-label': `Sélectionner le groupe ${row.original.title}`
-                }}
-                onClick={() => props.onSelect(row.original)}
+            header: () => (
+              <Stack
+                direction="row"
+                sx={{ justifyContent: 'flex-end', fontWeight: 'normal' }}
               >
-                Sélectionner
-              </Button>
+                Action
+              </Stack>
+            ),
+            cell: ({ row }) => (
+              <Stack direction="row" sx={{ justifyContent: 'flex-end' }}>
+                <Button
+                  priority="secondary"
+                  size="small"
+                  title={`Sélectionner le groupe ${row.original.title}`}
+                  nativeButtonProps={{
+                    'aria-label': `Sélectionner le groupe ${row.original.title}`
+                  }}
+                  onClick={() => props.onSelect(row.original)}
+                >
+                  Sélectionner
+                </Button>
+              </Stack>
             )
           })
         ],
@@ -149,7 +159,7 @@ export function createSelectGroupModal(
                 onSearch={search}
               />
 
-              <p role="status" className={fr.cx('fr-sr-only')}>
+              <p role="status" className={fr.cx('fr-text--bold', 'fr-mb-0')}>
                 {statusMessage}
               </p>
 
@@ -159,6 +169,7 @@ export function createSelectGroupModal(
                 data={filteredGroups}
                 perPageOptions={[5, 10, 50]}
                 defaultPageSize={5}
+                staticPageSize
                 tableProps={{ noCaption: true }}
               />
             </>

--- a/frontend/src/components/Campaign/SelectGroupModal.tsx
+++ b/frontend/src/components/Campaign/SelectGroupModal.tsx
@@ -118,6 +118,7 @@ export function createSelectGroupModal(
           <AppSearchBar
             key={openCount}
             label="Rechercher un groupe"
+            allowEmptySearch
             onSearch={search}
           />
 

--- a/frontend/src/components/Campaign/SelectGroupModal.tsx
+++ b/frontend/src/components/Campaign/SelectGroupModal.tsx
@@ -1,8 +1,8 @@
-import { ClassNames } from '@emotion/react';
 import { fr } from '@codegouvfr/react-dsfr';
 import Alert from '@codegouvfr/react-dsfr/Alert';
 import Button from '@codegouvfr/react-dsfr/Button';
 import Stepper from '@codegouvfr/react-dsfr/Stepper';
+import { ClassNames } from '@emotion/react';
 import Stack from '@mui/material/Stack';
 import { createColumnHelper } from '@tanstack/react-table';
 import { Array, Order, pipe } from 'effect';
@@ -165,7 +165,7 @@ export function createSelectGroupModal(
                 label="Rechercher un groupe"
                 allowEmptySearch
                 onSearch={search}
-                className='fr-mb-2w'
+                className="fr-mb-2w"
               />
 
               <LabelNext role="status" sx={{ fontWeight: 'normal' }}>

--- a/frontend/src/components/Campaign/SelectGroupModal.tsx
+++ b/frontend/src/components/Campaign/SelectGroupModal.tsx
@@ -1,4 +1,5 @@
 import { fr } from '@codegouvfr/react-dsfr';
+import Alert from '@codegouvfr/react-dsfr/Alert';
 import Button from '@codegouvfr/react-dsfr/Button';
 import Stepper from '@codegouvfr/react-dsfr/Stepper';
 import { createColumnHelper } from '@tanstack/react-table';
@@ -45,7 +46,12 @@ export function createSelectGroupModal(
     Component(props: Readonly<SelectGroupModalProps>) {
       const { openCount } = props;
       const queryEnabled = openCount === undefined || openCount > 0;
-      const { data: groups, isFetching } = useFindGroupsQuery(undefined, {
+      const {
+        data: groups,
+        isFetching,
+        isError,
+        refetch
+      } = useFindGroupsQuery(undefined, {
         skip: !queryEnabled
       });
       const [searchText, setSearchText] = useState<string>('');
@@ -115,25 +121,48 @@ export function createSelectGroupModal(
             nextTitle="Créer une campagne"
           />
 
-          <AppSearchBar
-            key={openCount}
-            label="Rechercher un groupe"
-            allowEmptySearch
-            onSearch={search}
-          />
+          {isError ? (
+            // A failed load must be distinguished from a genuine empty result:
+            // show the error (announced via the Alert's own `role="alert"`) and
+            // offer a retry, instead of falling through to « Aucun groupe
+            // trouvé », which would misreport a technical failure as "no data".
+            <>
+              <Alert
+                severity="error"
+                title="Impossible de charger les groupes"
+                description="Une erreur est survenue lors du chargement des groupes."
+              />
+              <Button
+                className={fr.cx('fr-mt-2w')}
+                priority="secondary"
+                onClick={() => refetch()}
+              >
+                Réessayer
+              </Button>
+            </>
+          ) : (
+            <>
+              <AppSearchBar
+                key={openCount}
+                label="Rechercher un groupe"
+                allowEmptySearch
+                onSearch={search}
+              />
 
-          <p role="status" className={fr.cx('fr-sr-only')}>
-            {statusMessage}
-          </p>
+              <p role="status" className={fr.cx('fr-sr-only')}>
+                {statusMessage}
+              </p>
 
-          <AdvancedTable
-            caption="Groupes de logements"
-            columns={columns}
-            data={filteredGroups}
-            perPageOptions={[5, 10, 50]}
-            defaultPageSize={5}
-            tableProps={{ noCaption: true }}
-          />
+              <AdvancedTable
+                caption="Groupes de logements"
+                columns={columns}
+                data={filteredGroups}
+                perPageOptions={[5, 10, 50]}
+                defaultPageSize={5}
+                tableProps={{ noCaption: true }}
+              />
+            </>
+          )}
         </modal.Component>
       );
     }

--- a/frontend/src/components/Campaign/SelectGroupModal.tsx
+++ b/frontend/src/components/Campaign/SelectGroupModal.tsx
@@ -1,0 +1,112 @@
+import Button from '@codegouvfr/react-dsfr/Button';
+import Stepper from '@codegouvfr/react-dsfr/Stepper';
+import { createColumnHelper } from '@tanstack/react-table';
+import { useMemo, useState } from 'react';
+
+import AppSearchBar from '~/components/_app/AppSearchBar/AppSearchBar';
+import AdvancedTable from '~/components/AdvancedTable/AdvancedTable';
+import {
+  createExtendedModal,
+  type ExtendedModalOptions
+} from '~/components/modals/ConfirmationModal/ExtendedModal';
+import type { Group } from '~/models/Group';
+import { useFindGroupsQuery } from '~/services/group.service';
+
+export type SelectGroupModalOptions = Partial<ExtendedModalOptions>;
+
+export interface SelectGroupModalProps {
+  onSelect(group: Group): void;
+}
+
+const columnHelper = createColumnHelper<Group>();
+
+function isEligible(group: Group): boolean {
+  return group.archivedAt === null && group.housingCount > 0;
+}
+
+export function createSelectGroupModal(
+  options?: Readonly<SelectGroupModalOptions>
+) {
+  const modal = createExtendedModal({
+    id: options?.id ?? 'select-group-modal',
+    isOpenedByDefault: options?.isOpenedByDefault ?? false
+  });
+
+  return {
+    ...modal,
+    Component(props: Readonly<SelectGroupModalProps>) {
+      const { data: groups } = useFindGroupsQuery();
+      const [searchText, setSearchText] = useState<string>('');
+
+      const filteredGroups = useMemo(() => {
+        const eligible = (groups ?? []).filter(isEligible);
+        const matches = searchText
+          ? eligible.filter((group) =>
+              group.title.toLowerCase().includes(searchText.toLowerCase())
+            )
+          : eligible;
+        return [...matches].sort(
+          (a, b) => b.createdAt.getTime() - a.createdAt.getTime()
+        );
+      }, [groups, searchText]);
+
+      const columns = useMemo(
+        () => [
+          columnHelper.accessor('title', {
+            header: 'Nom du groupe'
+          }),
+          columnHelper.display({
+            id: 'actions',
+            header: 'Action',
+            cell: ({ row }) => (
+              <Button
+                priority="secondary"
+                size="small"
+                title={`Sélectionner le groupe ${row.original.title}`}
+                nativeButtonProps={{
+                  'aria-label': `Sélectionner le groupe ${row.original.title}`
+                }}
+                onClick={() => props.onSelect(row.original)}
+              >
+                Sélectionner
+              </Button>
+            )
+          })
+        ],
+        [props]
+      );
+
+      function search(text: string): void {
+        setSearchText(text);
+      }
+
+      return (
+        <modal.Component
+          title="Enregistrer une campagne"
+          size="large"
+          onClose={() => setSearchText('')}
+        >
+          <Stepper
+            currentStep={1}
+            stepCount={2}
+            title="Sélectionner le groupe de logements"
+            nextTitle="Créer une campagne"
+          />
+
+          <AppSearchBar label="Rechercher un groupe" onSearch={search} />
+
+          <AdvancedTable
+            caption="Groupes de logements"
+            columns={columns}
+            data={filteredGroups}
+            perPageOptions={[5, 10, 50]}
+            defaultPageSize={5}
+            tableProps={{ noCaption: true }}
+          />
+        </modal.Component>
+      );
+    }
+  };
+}
+
+export default createSelectGroupModal;

--- a/frontend/src/components/Campaign/test/SaveCampaignFlow.test.tsx
+++ b/frontend/src/components/Campaign/test/SaveCampaignFlow.test.tsx
@@ -2,12 +2,13 @@ import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { UserRole } from '@zerologementvacant/models';
 import {
+  genCampaignDTO,
   genEstablishmentDTO,
   genGroupDTO,
   genHousingDTO,
   genUserDTO
 } from '@zerologementvacant/models/fixtures';
-import { http, HttpResponse } from 'msw';
+import { delay, http, HttpResponse } from 'msw';
 import { Provider } from 'react-redux';
 
 import SaveCampaignFlow from '~/components/Campaign/SaveCampaignFlow';
@@ -184,5 +185,47 @@ describe('SaveCampaignFlow', () => {
     expect(data.campaigns).not.toContainEqual(
       expect.objectContaining({ title: 'Ma campagne', groupId: group.id })
     );
+  });
+
+  it('should disable Confirmer while the create request is in flight, preventing a double-submit', async () => {
+    const group = genGroupDTO(creator, [genHousingDTO()]);
+    data.groups.push(group);
+
+    let posts = 0;
+    mockAPI.use(
+      http.post(`${config.apiEndpoint}/groups/:id/campaigns`, async () => {
+        posts += 1;
+        await delay(80);
+        return HttpResponse.json(genCampaignDTO(group), { status: 201 });
+      })
+    );
+
+    renderFlow();
+
+    await user.click(
+      screen.getByRole('button', { name: 'Enregistrer une campagne' })
+    );
+    const selectDialog = await screen.findByRole('dialog');
+    await user.click(
+      await within(selectDialog).findByRole('button', {
+        name: `Sélectionner le groupe ${group.title}`
+      })
+    );
+
+    const createDialog = await screen.findByRole('dialog');
+    await within(createDialog).findByText('Étape 2 sur 2');
+    await user.type(
+      await within(createDialog).findByLabelText(/^Nom/),
+      'Ma campagne'
+    );
+    const confirmer = await within(createDialog).findByRole('button', {
+      name: 'Confirmer'
+    });
+    await user.click(confirmer);
+
+    // While the POST is in flight the Confirmer is disabled, so a second click
+    // cannot fire a second create mutation.
+    await waitFor(() => expect(confirmer).toBeDisabled());
+    expect(posts).toBe(1);
   });
 });

--- a/frontend/src/components/Campaign/test/SaveCampaignFlow.test.tsx
+++ b/frontend/src/components/Campaign/test/SaveCampaignFlow.test.tsx
@@ -7,13 +7,16 @@ import {
   genHousingDTO,
   genUserDTO
 } from '@zerologementvacant/models/fixtures';
+import { http, HttpResponse } from 'msw';
 import { Provider } from 'react-redux';
 
 import SaveCampaignFlow from '~/components/Campaign/SaveCampaignFlow';
 import data from '~/mocks/handlers/data';
+import { mockAPI } from '~/mocks/mock-api';
 import { fromEstablishmentDTO } from '~/models/Establishment';
 import { fromUserDTO } from '~/models/User';
 import { genAuthUser } from '~/test/fixtures';
+import config from '~/utils/config';
 import configureTestStore from '~/utils/storeUtils';
 
 describe('SaveCampaignFlow', () => {
@@ -131,5 +134,51 @@ describe('SaveCampaignFlow', () => {
     );
 
     expect(await screen.findByText('Étape 2 sur 2')).toBeInTheDocument();
+  });
+
+  it('should keep step 2 open and create no campaign when the submission fails', async () => {
+    const group = genGroupDTO(creator, [genHousingDTO()]);
+    data.groups.push(group);
+
+    let submitted = false;
+    mockAPI.use(
+      http.post(`${config.apiEndpoint}/groups/:id/campaigns`, () => {
+        submitted = true;
+        return HttpResponse.json(
+          { name: 'InternalError', message: 'Boom' },
+          { status: 500 }
+        );
+      })
+    );
+
+    renderFlow();
+
+    await user.click(
+      screen.getByRole('button', { name: 'Enregistrer une campagne' })
+    );
+    const selectDialog = await screen.findByRole('dialog');
+    await user.click(
+      await within(selectDialog).findByRole('button', {
+        name: `Sélectionner le groupe ${group.title}`
+      })
+    );
+
+    const createDialog = await screen.findByRole('dialog');
+    await within(createDialog).findByText('Étape 2 sur 2');
+    await user.type(
+      await within(createDialog).findByLabelText(/^Nom/),
+      'Ma campagne'
+    );
+    await user.click(await within(createDialog).findByText('Confirmer'));
+
+    await waitFor(() => {
+      expect(submitted).toBe(true);
+    });
+
+    // The modal stays open so the user can retry, and nothing is persisted.
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(data.campaigns).not.toContainEqual(
+      expect.objectContaining({ title: 'Ma campagne', groupId: group.id })
+    );
   });
 });

--- a/frontend/src/components/Campaign/test/SaveCampaignFlow.test.tsx
+++ b/frontend/src/components/Campaign/test/SaveCampaignFlow.test.tsx
@@ -111,18 +111,21 @@ describe('SaveCampaignFlow', () => {
     const createDialog = await screen.findByRole('dialog');
     await within(createDialog).findByText('Étape 2 sur 2');
 
-    // Cancel step 2 without submitting. DSFR emits a `dsfr.conceal` event on
-    // the dialog for every dismissal (Annuler / Escape / backdrop click); the
-    // DSFR runtime that emits it is absent in jsdom, so we simulate that exact
-    // signal — the same one react-dsfr's own `useIsModalOpen` listens for.
-    createDialog.dispatchEvent(new CustomEvent('dsfr.conceal'));
+    // Cancel step 2 without submitting. The step-2 modal is rendered
+    // unconditionally, so a dismissal only conceals its <dialog> (it stays
+    // mounted). The DSFR runtime that would remove `open`/`aria-modal` on
+    // Escape/Annuler/backdrop is absent in jsdom, so we conceal the dialog
+    // directly, exactly as that runtime would.
+    const step2 = document.getElementById('save-campaign-from-group-modal');
+    step2?.removeAttribute('open');
+    step2?.removeAttribute('aria-modal');
     await waitFor(() => {
-      expect(
-        document.getElementById('save-campaign-from-group-modal')
-      ).not.toBeInTheDocument();
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     });
 
-    // Re-run the flow and select the SAME group again (stable RTK Query ref).
+    // Re-run the flow and select the SAME group again (stable RTK Query ref):
+    // step 2 must reopen, because `.open()` runs on every selection rather than
+    // on a `selectedGroup` state edge.
     await user.click(
       screen.getByRole('button', { name: 'Enregistrer une campagne' })
     );
@@ -133,7 +136,8 @@ describe('SaveCampaignFlow', () => {
       })
     );
 
-    expect(await screen.findByText('Étape 2 sur 2')).toBeInTheDocument();
+    const reopened = await screen.findByRole('dialog');
+    expect(within(reopened).getByText('Étape 2 sur 2')).toBeInTheDocument();
   });
 
   it('should keep step 2 open and create no campaign when the submission fails', async () => {

--- a/frontend/src/components/Campaign/test/SaveCampaignFlow.test.tsx
+++ b/frontend/src/components/Campaign/test/SaveCampaignFlow.test.tsx
@@ -14,9 +14,7 @@ import { Provider } from 'react-redux';
 import SaveCampaignFlow from '~/components/Campaign/SaveCampaignFlow';
 import data from '~/mocks/handlers/data';
 import { mockAPI } from '~/mocks/mock-api';
-import { fromEstablishmentDTO } from '~/models/Establishment';
-import { fromUserDTO } from '~/models/User';
-import { genAuthUser } from '~/test/fixtures';
+import { MockAuthProvider } from '~/test/auth';
 import config from '~/utils/config';
 import configureTestStore from '~/utils/storeUtils';
 
@@ -29,16 +27,13 @@ describe('SaveCampaignFlow', () => {
     const authDTO = genUserDTO(role, establishment);
     data.establishments.push(establishment);
     data.users.push(authDTO);
-    const store = configureTestStore({
-      auth: genAuthUser(
-        fromUserDTO(authDTO),
-        fromEstablishmentDTO(establishment)
-      )
-    });
+    const store = configureTestStore();
 
     render(
       <Provider store={store}>
-        <SaveCampaignFlow />
+        <MockAuthProvider options={{ user: authDTO, establishment }}>
+          <SaveCampaignFlow />
+        </MockAuthProvider>
       </Provider>
     );
   }

--- a/frontend/src/components/Campaign/test/SaveCampaignFlow.test.tsx
+++ b/frontend/src/components/Campaign/test/SaveCampaignFlow.test.tsx
@@ -223,4 +223,28 @@ describe('SaveCampaignFlow', () => {
     await waitFor(() => expect(confirmer).toBeDisabled());
     expect(posts).toBe(1);
   });
+
+  it('should clear the group search input when the flow is reopened', async () => {
+    const group = genGroupDTO(creator, [genHousingDTO()]);
+    data.groups.push(group);
+
+    renderFlow();
+
+    await user.click(
+      screen.getByRole('button', { name: 'Enregistrer une campagne' })
+    );
+    const searchbox = await screen.findByRole('searchbox', {
+      name: 'Rechercher un groupe'
+    });
+    await user.type(searchbox, 'zzz');
+    expect(searchbox).toHaveValue('zzz');
+
+    // Reopening the flow re-keys the search input, so it starts blank again.
+    await user.click(
+      screen.getByRole('button', { name: 'Enregistrer une campagne' })
+    );
+    expect(
+      screen.getByRole('searchbox', { name: 'Rechercher un groupe' })
+    ).toHaveValue('');
+  });
 });

--- a/frontend/src/components/Campaign/test/SaveCampaignFlow.test.tsx
+++ b/frontend/src/components/Campaign/test/SaveCampaignFlow.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { UserRole } from '@zerologementvacant/models';
+import {
+  genEstablishmentDTO,
+  genGroupDTO,
+  genHousingDTO,
+  genUserDTO
+} from '@zerologementvacant/models/fixtures';
+import { Provider } from 'react-redux';
+
+import SaveCampaignFlow from '~/components/Campaign/SaveCampaignFlow';
+import data from '~/mocks/handlers/data';
+import { fromEstablishmentDTO } from '~/models/Establishment';
+import { fromUserDTO } from '~/models/User';
+import { genAuthUser } from '~/test/fixtures';
+import configureTestStore from '~/utils/storeUtils';
+
+describe('SaveCampaignFlow', () => {
+  const user = userEvent.setup();
+  const establishment = genEstablishmentDTO();
+  const creator = genUserDTO(UserRole.USUAL, establishment);
+
+  function renderFlow(role: UserRole = UserRole.USUAL) {
+    const authDTO = genUserDTO(role, establishment);
+    data.establishments.push(establishment);
+    data.users.push(authDTO);
+    const store = configureTestStore({
+      auth: genAuthUser(
+        fromUserDTO(authDTO),
+        fromEstablishmentDTO(establishment)
+      )
+    });
+
+    render(
+      <Provider store={store}>
+        <SaveCampaignFlow />
+      </Provider>
+    );
+  }
+
+  it('should hide the button for a visitor', () => {
+    renderFlow(UserRole.VISITOR);
+
+    expect(
+      screen.queryByRole('button', { name: 'Enregistrer une campagne' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('should show the button for a usual user', () => {
+    renderFlow(UserRole.USUAL);
+
+    expect(
+      screen.getByRole('button', { name: 'Enregistrer une campagne' })
+    ).toBeInTheDocument();
+  });
+
+  it('should create a campaign from a group selected in step 1', async () => {
+    const group = genGroupDTO(creator, [genHousingDTO()]);
+    data.groups.push(group);
+
+    renderFlow();
+
+    const openButton = screen.getByRole('button', {
+      name: 'Enregistrer une campagne'
+    });
+    await user.click(openButton);
+
+    const selectDialog = await screen.findByRole('dialog');
+    const selectButton = await within(selectDialog).findByRole('button', {
+      name: `Sélectionner le groupe ${group.title}`
+    });
+    await user.click(selectButton);
+
+    const createDialog = await screen.findByRole('dialog');
+    await within(createDialog).findByText('Étape 2 sur 2');
+    const title = await within(createDialog).findByLabelText(/^Nom/);
+    await user.type(title, 'Ma campagne');
+    const confirm = await within(createDialog).findByText('Confirmer');
+    await user.click(confirm);
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+    expect(data.campaigns).toContainEqual(
+      expect.objectContaining({
+        title: 'Ma campagne',
+        groupId: group.id
+      })
+    );
+  });
+});

--- a/frontend/src/components/Campaign/test/SaveCampaignFlow.test.tsx
+++ b/frontend/src/components/Campaign/test/SaveCampaignFlow.test.tsx
@@ -89,4 +89,47 @@ describe('SaveCampaignFlow', () => {
       })
     );
   });
+
+  it('should reopen step 2 when the same group is re-selected after cancelling', async () => {
+    const group = genGroupDTO(creator, [genHousingDTO()]);
+    data.groups.push(group);
+
+    renderFlow();
+
+    await user.click(
+      screen.getByRole('button', { name: 'Enregistrer une campagne' })
+    );
+    const firstSelectDialog = await screen.findByRole('dialog');
+    await user.click(
+      await within(firstSelectDialog).findByRole('button', {
+        name: `Sélectionner le groupe ${group.title}`
+      })
+    );
+    const createDialog = await screen.findByRole('dialog');
+    await within(createDialog).findByText('Étape 2 sur 2');
+
+    // Cancel step 2 without submitting. DSFR emits a `dsfr.conceal` event on
+    // the dialog for every dismissal (Annuler / Escape / backdrop click); the
+    // DSFR runtime that emits it is absent in jsdom, so we simulate that exact
+    // signal — the same one react-dsfr's own `useIsModalOpen` listens for.
+    createDialog.dispatchEvent(new CustomEvent('dsfr.conceal'));
+    await waitFor(() => {
+      expect(
+        document.getElementById('save-campaign-from-group-modal')
+      ).not.toBeInTheDocument();
+    });
+
+    // Re-run the flow and select the SAME group again (stable RTK Query ref).
+    await user.click(
+      screen.getByRole('button', { name: 'Enregistrer une campagne' })
+    );
+    const secondSelectDialog = await screen.findByRole('dialog');
+    await user.click(
+      await within(secondSelectDialog).findByRole('button', {
+        name: `Sélectionner le groupe ${group.title}`
+      })
+    );
+
+    expect(await screen.findByText('Étape 2 sur 2')).toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/Campaign/test/SaveCampaignFlow.test.tsx
+++ b/frontend/src/components/Campaign/test/SaveCampaignFlow.test.tsx
@@ -8,8 +8,10 @@ import {
   genHousingDTO,
   genUserDTO
 } from '@zerologementvacant/models/fixtures';
+import { addDays, format } from 'date-fns';
 import { delay, http, HttpResponse } from 'msw';
 import { Provider } from 'react-redux';
+import { createMemoryRouter, RouterProvider } from 'react-router';
 
 import SaveCampaignFlow from '~/components/Campaign/SaveCampaignFlow';
 import data from '~/mocks/handlers/data';
@@ -29,13 +31,23 @@ describe('SaveCampaignFlow', () => {
     data.users.push(authDTO);
     const store = configureTestStore();
 
+    const router = createMemoryRouter(
+      [
+        { path: '/campagnes', element: <SaveCampaignFlow /> },
+        { path: '/campagnes/:id', element: 'Campagne' }
+      ],
+      { initialEntries: ['/campagnes'] }
+    );
+
     render(
       <Provider store={store}>
         <MockAuthProvider options={{ user: authDTO, establishment }}>
-          <SaveCampaignFlow />
+          <RouterProvider router={router} />
         </MockAuthProvider>
       </Provider>
     );
+
+    return { router };
   }
 
   it('should hide the button for a visitor', () => {
@@ -58,7 +70,7 @@ describe('SaveCampaignFlow', () => {
     const group = genGroupDTO(creator, [genHousingDTO()]);
     data.groups.push(group);
 
-    renderFlow();
+    const { router } = renderFlow();
 
     const openButton = screen.getByRole('button', {
       name: 'Enregistrer une campagne'
@@ -87,6 +99,48 @@ describe('SaveCampaignFlow', () => {
         groupId: group.id
       })
     );
+    expect(router.state.location.pathname).toMatch(/^\/campagnes\/.+/);
+  });
+
+  it('should create a campaign with a sending date from a group selected in step 1', async () => {
+    const group = genGroupDTO(creator, [genHousingDTO()]);
+    data.groups.push(group);
+    const sentAt = format(addDays(new Date(), 7), 'yyyy-MM-dd');
+
+    const { router } = renderFlow();
+
+    const openButton = screen.getByRole('button', {
+      name: 'Enregistrer une campagne'
+    });
+    await user.click(openButton);
+
+    const selectDialog = await screen.findByRole('dialog');
+    const selectButton = await within(selectDialog).findByRole('button', {
+      name: `Sélectionner le groupe ${group.title}`
+    });
+    await user.click(selectButton);
+
+    const createDialog = await screen.findByRole('dialog');
+    await within(createDialog).findByText('Étape 2 sur 2');
+    const title = await within(createDialog).findByLabelText(/^Nom/);
+    await user.type(title, 'Ma campagne programmée');
+    const sentAtInput =
+      await within(createDialog).findByLabelText(/Date d’envoi/);
+    await user.type(sentAtInput, sentAt);
+    const confirm = await within(createDialog).findByText('Confirmer');
+    await user.click(confirm);
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+    expect(data.campaigns).toContainEqual(
+      expect.objectContaining({
+        title: 'Ma campagne programmée',
+        groupId: group.id,
+        sentAt
+      })
+    );
+    expect(router.state.location.pathname).toMatch(/^\/campagnes\/.+/);
   });
 
   it('should reopen step 2 when the same group is re-selected after cancelling', async () => {
@@ -151,7 +205,7 @@ describe('SaveCampaignFlow', () => {
       })
     );
 
-    renderFlow();
+    const { router } = renderFlow();
 
     await user.click(
       screen.getByRole('button', { name: 'Enregistrer une campagne' })
@@ -180,6 +234,7 @@ describe('SaveCampaignFlow', () => {
     expect(data.campaigns).not.toContainEqual(
       expect.objectContaining({ title: 'Ma campagne', groupId: group.id })
     );
+    expect(router.state.location.pathname).toBe('/campagnes');
   });
 
   it('should disable Confirmer while the create request is in flight, preventing a double-submit', async () => {

--- a/frontend/src/components/Campaign/test/SelectGroupModal.test.tsx
+++ b/frontend/src/components/Campaign/test/SelectGroupModal.test.tsx
@@ -5,10 +5,13 @@ import {
   genHousingDTO,
   genUserDTO
 } from '@zerologementvacant/models/fixtures';
+import { http, HttpResponse } from 'msw';
 import { Provider } from 'react-redux';
 
 import createSelectGroupModal from '~/components/Campaign/SelectGroupModal';
 import data from '~/mocks/handlers/data';
+import { mockAPI } from '~/mocks/mock-api';
+import config from '~/utils/config';
 import configureTestStore from '~/utils/storeUtils';
 
 const selectGroupModal = createSelectGroupModal();
@@ -176,6 +179,55 @@ describe('SelectGroupModal', () => {
     const dialog = await screen.findByRole('dialog');
     const status = await within(dialog).findByRole('status');
     await waitFor(() => expect(status).toHaveTextContent('2 groupes trouvés'));
+  });
+
+  it('should show an error with a retry action, not an empty result, when loading groups fails', async () => {
+    mockAPI.use(
+      http.get(`${config.apiEndpoint}/groups`, () =>
+        HttpResponse.json({ message: 'Boom' }, { status: 500 })
+      )
+    );
+
+    renderModal(vi.fn(), 1);
+
+    const dialog = await screen.findByRole('dialog');
+    await within(dialog).findByText('Impossible de charger les groupes');
+    expect(
+      within(dialog).getByRole('button', { name: 'Réessayer' })
+    ).toBeInTheDocument();
+    // A technical failure must not be announced as a genuine empty result.
+    expect(
+      within(dialog).queryByText('Aucun groupe trouvé')
+    ).not.toBeInTheDocument();
+  });
+
+  it('should reload the groups when the user retries after a failure', async () => {
+    const group = genGroupDTO(creator, [genHousingDTO()]);
+    data.groups.push(group);
+
+    let calls = 0;
+    mockAPI.use(
+      http.get(`${config.apiEndpoint}/groups`, () => {
+        calls += 1;
+        return calls === 1
+          ? HttpResponse.json({ message: 'Boom' }, { status: 500 })
+          : HttpResponse.json(data.groups);
+      })
+    );
+
+    renderModal(vi.fn(), 1);
+
+    const dialog = await screen.findByRole('dialog');
+    await within(dialog).findByText('Impossible de charger les groupes');
+
+    await user.click(
+      within(dialog).getByRole('button', { name: 'Réessayer' })
+    );
+
+    await within(dialog).findByText(group.title);
+    expect(
+      within(dialog).queryByText('Impossible de charger les groupes')
+    ).not.toBeInTheDocument();
   });
 
   it('should restore the full list when an empty search is submitted', async () => {

--- a/frontend/src/components/Campaign/test/SelectGroupModal.test.tsx
+++ b/frontend/src/components/Campaign/test/SelectGroupModal.test.tsx
@@ -230,6 +230,33 @@ describe('SelectGroupModal', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('should show the page size as static text instead of an editable select', async () => {
+    const housings = [genHousingDTO()];
+    data.groups.push(genGroupDTO(creator, housings));
+
+    renderModal(vi.fn(), 1);
+
+    const dialog = await screen.findByRole('dialog');
+    await within(dialog).findByText('5 lignes par page');
+    expect(within(dialog).queryByRole('combobox')).not.toBeInTheDocument();
+  });
+
+  it('should display the group count as visible text above the table', async () => {
+    const housings = [genHousingDTO()];
+    data.groups.push(
+      genGroupDTO(creator, housings),
+      genGroupDTO(creator, housings)
+    );
+
+    renderModal(vi.fn(), 1);
+
+    const dialog = await screen.findByRole('dialog');
+    const status = await within(dialog).findByRole('status');
+    await waitFor(() => expect(status).toHaveTextContent('2 groupes trouvés'));
+    // The count must be visible, not screen-reader-only.
+    expect(status).not.toHaveClass('fr-sr-only');
+  });
+
   it('should restore the full list when an empty search is submitted', async () => {
     const housings = [genHousingDTO()];
     const match = { ...genGroupDTO(creator, housings), title: 'URBA-EXP' };

--- a/frontend/src/components/Campaign/test/SelectGroupModal.test.tsx
+++ b/frontend/src/components/Campaign/test/SelectGroupModal.test.tsx
@@ -1,0 +1,145 @@
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {
+  genGroupDTO,
+  genHousingDTO,
+  genUserDTO
+} from '@zerologementvacant/models/fixtures';
+import { Provider } from 'react-redux';
+
+import createSelectGroupModal from '~/components/Campaign/SelectGroupModal';
+import data from '~/mocks/handlers/data';
+import configureTestStore from '~/utils/storeUtils';
+
+const selectGroupModal = createSelectGroupModal();
+const creator = genUserDTO();
+
+describe('SelectGroupModal', () => {
+  const user = userEvent.setup();
+
+  function renderModal(onSelect = vi.fn()) {
+    render(
+      <Provider store={configureTestStore()}>
+        <selectGroupModal.Component onSelect={onSelect} />
+      </Provider>
+    );
+    selectGroupModal.open();
+  }
+
+  it('should exclude archived and empty groups from the list', async () => {
+    const housings = [genHousingDTO()];
+    const eligible = genGroupDTO(creator, housings);
+    const archived = {
+      ...genGroupDTO(creator, housings),
+      archivedAt: new Date().toJSON()
+    };
+    const empty = genGroupDTO(creator, []);
+    data.groups.push(eligible, archived, empty);
+
+    renderModal();
+
+    const dialog = await screen.findByRole('dialog');
+    await within(dialog).findByText(eligible.title);
+    expect(within(dialog).queryByText(archived.title)).not.toBeInTheDocument();
+    expect(within(dialog).queryByText(empty.title)).not.toBeInTheDocument();
+  });
+
+  it('should filter groups by a case-insensitive substring match on submit', async () => {
+    const housings = [genHousingDTO()];
+    const match = { ...genGroupDTO(creator, housings), title: 'URBA-EXP' };
+    const nonMatch = {
+      ...genGroupDTO(creator, housings),
+      title: 'CITE-AVENIR'
+    };
+    data.groups.push(match, nonMatch);
+
+    renderModal();
+
+    const dialog = await screen.findByRole('dialog');
+    await within(dialog).findByText(match.title);
+    const input = within(dialog).getByRole('searchbox', {
+      name: 'Rechercher un groupe'
+    });
+    await user.type(input, 'urba');
+    const searchButton = within(dialog).getByRole('button', {
+      name: 'Rechercher'
+    });
+    await user.click(searchButton);
+
+    await within(dialog).findByText(match.title);
+    expect(within(dialog).queryByText(nonMatch.title)).not.toBeInTheDocument();
+  });
+
+  it('should sort groups by creation date, most recent first', async () => {
+    const housings = [genHousingDTO()];
+    const oldest = {
+      ...genGroupDTO(creator, housings),
+      title: 'Oldest',
+      createdAt: new Date('2024-01-01').toJSON()
+    };
+    const newest = {
+      ...genGroupDTO(creator, housings),
+      title: 'Newest',
+      createdAt: new Date('2024-06-01').toJSON()
+    };
+    const middle = {
+      ...genGroupDTO(creator, housings),
+      title: 'Middle',
+      createdAt: new Date('2024-03-01').toJSON()
+    };
+    data.groups.push(oldest, newest, middle);
+
+    renderModal();
+
+    const dialog = await screen.findByRole('dialog');
+    const table = await within(dialog).findByRole('table');
+    await within(table).findByText('Newest');
+    const rows = within(table).getAllByRole('row').slice(1);
+    const titles = rows.map((row) => row.textContent);
+    expect(titles[0]).toContain('Newest');
+    expect(titles[1]).toContain('Middle');
+    expect(titles[2]).toContain('Oldest');
+  });
+
+  it('should show no rows when the search matches nothing', async () => {
+    const housings = [genHousingDTO()];
+    data.groups.push({
+      ...genGroupDTO(creator, housings),
+      title: 'URBA-EXP'
+    });
+
+    renderModal();
+
+    const dialog = await screen.findByRole('dialog');
+    const table = await within(dialog).findByRole('table');
+    const input = within(dialog).getByRole('searchbox', {
+      name: 'Rechercher un groupe'
+    });
+    await user.type(input, 'no-match-at-all');
+    const searchButton = within(dialog).getByRole('button', {
+      name: 'Rechercher'
+    });
+    await user.click(searchButton);
+
+    expect(within(table).queryAllByRole('row')).toHaveLength(1); // header row only
+  });
+
+  it('should call onSelect with the chosen group', async () => {
+    const housings = [genHousingDTO()];
+    const group = genGroupDTO(creator, housings);
+    data.groups.push(group);
+    const onSelect = vi.fn();
+
+    renderModal(onSelect);
+
+    const dialog = await screen.findByRole('dialog');
+    const selectButton = await within(dialog).findByRole('button', {
+      name: `Sélectionner le groupe ${group.title}`
+    });
+    await user.click(selectButton);
+
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ id: group.id, title: group.title })
+    );
+  });
+});

--- a/frontend/src/components/Campaign/test/SelectGroupModal.test.tsx
+++ b/frontend/src/components/Campaign/test/SelectGroupModal.test.tsx
@@ -220,9 +220,7 @@ describe('SelectGroupModal', () => {
     const dialog = await screen.findByRole('dialog');
     await within(dialog).findByText('Impossible de charger les groupes');
 
-    await user.click(
-      within(dialog).getByRole('button', { name: 'Réessayer' })
-    );
+    await user.click(within(dialog).getByRole('button', { name: 'Réessayer' }));
 
     await within(dialog).findByText(group.title);
     expect(

--- a/frontend/src/components/Campaign/test/SelectGroupModal.test.tsx
+++ b/frontend/src/components/Campaign/test/SelectGroupModal.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {
   genGroupDTO,
@@ -17,10 +17,10 @@ const creator = genUserDTO();
 describe('SelectGroupModal', () => {
   const user = userEvent.setup();
 
-  function renderModal(onSelect = vi.fn()) {
+  function renderModal(onSelect = vi.fn(), openCount?: number) {
     render(
       <Provider store={configureTestStore()}>
-        <selectGroupModal.Component onSelect={onSelect} />
+        <selectGroupModal.Component onSelect={onSelect} openCount={openCount} />
       </Provider>
     );
     selectGroupModal.open();
@@ -141,5 +141,40 @@ describe('SelectGroupModal', () => {
     expect(onSelect).toHaveBeenCalledWith(
       expect.objectContaining({ id: group.id, title: group.title })
     );
+  });
+
+  it('should not query groups until the flow has been opened', async () => {
+    const group = genGroupDTO(creator, [genHousingDTO()]);
+    data.groups.push(group);
+
+    renderModal(vi.fn(), 0);
+
+    const dialog = await screen.findByRole('dialog');
+    // openCount 0 → the groups query is skipped, so nothing loads.
+    expect(within(dialog).queryByText(group.title)).not.toBeInTheDocument();
+  });
+
+  it('should query groups once the flow has been opened', async () => {
+    const group = genGroupDTO(creator, [genHousingDTO()]);
+    data.groups.push(group);
+
+    renderModal(vi.fn(), 1);
+
+    const dialog = await screen.findByRole('dialog');
+    await within(dialog).findByText(group.title);
+  });
+
+  it('should announce the result count in a status region', async () => {
+    const housings = [genHousingDTO()];
+    data.groups.push(
+      genGroupDTO(creator, housings),
+      genGroupDTO(creator, housings)
+    );
+
+    renderModal(vi.fn(), 1);
+
+    const dialog = await screen.findByRole('dialog');
+    const status = await within(dialog).findByRole('status');
+    await waitFor(() => expect(status).toHaveTextContent('2 groupes trouvés'));
   });
 });

--- a/frontend/src/components/Campaign/test/SelectGroupModal.test.tsx
+++ b/frontend/src/components/Campaign/test/SelectGroupModal.test.tsx
@@ -177,4 +177,34 @@ describe('SelectGroupModal', () => {
     const status = await within(dialog).findByRole('status');
     await waitFor(() => expect(status).toHaveTextContent('2 groupes trouvés'));
   });
+
+  it('should restore the full list when an empty search is submitted', async () => {
+    const housings = [genHousingDTO()];
+    const match = { ...genGroupDTO(creator, housings), title: 'URBA-EXP' };
+    const other = { ...genGroupDTO(creator, housings), title: 'CITE-AVENIR' };
+    data.groups.push(match, other);
+
+    renderModal();
+
+    const dialog = await screen.findByRole('dialog');
+    await within(dialog).findByText(other.title);
+    const input = within(dialog).getByRole('searchbox', {
+      name: 'Rechercher un groupe'
+    });
+    const searchButton = within(dialog).getByRole('button', {
+      name: 'Rechercher'
+    });
+
+    // Filter down to a single group.
+    await user.type(input, 'urba');
+    await user.click(searchButton);
+    await within(dialog).findByText(match.title);
+    expect(within(dialog).queryByText(other.title)).not.toBeInTheDocument();
+
+    // Submitting an empty search brings the whole list back.
+    await user.clear(input);
+    await user.click(searchButton);
+    await within(dialog).findByText(other.title);
+    expect(within(dialog).getByText(match.title)).toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/Group/CreateCampaignFromGroupModal.tsx
+++ b/frontend/src/components/Group/CreateCampaignFromGroupModal.tsx
@@ -1,3 +1,4 @@
+import Stepper from '@codegouvfr/react-dsfr/Stepper';
 import { yupResolver } from '@hookform/resolvers/yup';
 import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
@@ -26,6 +27,7 @@ export type CreateCampaignFromGroupModalProps = Omit<
   'title' | 'children' | 'onSubmit'
 > & {
   group: Group;
+  stepper?: { currentStep: number; stepCount: number };
   onSubmit(campaign: Pick<Campaign, 'title' | 'description' | 'sentAt'>): void;
 };
 
@@ -48,7 +50,7 @@ export function createCampaignFromGroupModal(
   return {
     ...modal,
     Component(props: Readonly<CreateCampaignFromGroupModalProps>) {
-      const { group, onSubmit, ...rest } = props;
+      const { group, stepper, onSubmit, ...rest } = props;
 
       const housing = pluralize(group.housingCount)('logement');
       const owners = pluralize(group.ownerCount)('propriétaire');
@@ -79,6 +81,14 @@ export function createCampaignFromGroupModal(
             onClose={form.reset}
             title="Créer une campagne"
           >
+            {stepper && (
+              <Stepper
+                currentStep={stepper.currentStep}
+                stepCount={stepper.stepCount}
+                title="Créer une campagne"
+              />
+            )}
+
             <Stack
               direction="row"
               spacing="1rem"

--- a/frontend/src/components/Group/CreateCampaignFromGroupModal.tsx
+++ b/frontend/src/components/Group/CreateCampaignFromGroupModal.tsx
@@ -26,7 +26,7 @@ export type CreateCampaignFromGroupModalProps = Omit<
   ConfirmationModalProps,
   'title' | 'children' | 'onSubmit'
 > & {
-  group: Group;
+  group: Group | null;
   stepper?: { currentStep: number; stepCount: number };
   onSubmit(campaign: Pick<Campaign, 'title' | 'description' | 'sentAt'>): void;
 };
@@ -52,8 +52,8 @@ export function createCampaignFromGroupModal(
     Component(props: Readonly<CreateCampaignFromGroupModalProps>) {
       const { group, stepper, onSubmit, ...rest } = props;
 
-      const housing = pluralize(group.housingCount)('logement');
-      const owners = pluralize(group.ownerCount)('propriétaire');
+      const housing = group ? pluralize(group.housingCount)('logement') : '';
+      const owners = group ? pluralize(group.ownerCount)('propriétaire') : '';
 
       const form = useForm<FormSchema>({
         resolver: yupResolver(schema),
@@ -89,35 +89,37 @@ export function createCampaignFromGroupModal(
               />
             )}
 
-            <Stack
-              direction="row"
-              spacing="1rem"
-              useFlexGap
-              sx={{ mt: '-1rem', mb: '0.5rem' }}
-            >
+            {group && (
               <Stack
                 direction="row"
-                spacing="0.25rem"
+                spacing="1rem"
                 useFlexGap
-                sx={{ alignItems: 'center' }}
+                sx={{ mt: '-1rem', mb: '0.5rem' }}
               >
-                <Icon name="ri-home-2-line" size="sm" color="inherit" />
-                <Typography component="span" variant="body2">
-                  {group.housingCount} {housing}
-                </Typography>
+                <Stack
+                  direction="row"
+                  spacing="0.25rem"
+                  useFlexGap
+                  sx={{ alignItems: 'center' }}
+                >
+                  <Icon name="ri-home-2-line" size="sm" color="inherit" />
+                  <Typography component="span" variant="body2">
+                    {group.housingCount} {housing}
+                  </Typography>
+                </Stack>
+                <Stack
+                  direction="row"
+                  spacing="0.25rem"
+                  useFlexGap
+                  sx={{ alignItems: 'center' }}
+                >
+                  <Icon name="ri-user-line" size="sm" color="inherit" />
+                  <Typography component="span" variant="body2">
+                    {group.ownerCount} {owners}
+                  </Typography>
+                </Stack>
               </Stack>
-              <Stack
-                direction="row"
-                spacing="0.25rem"
-                useFlexGap
-                sx={{ alignItems: 'center' }}
-              >
-                <Icon name="ri-user-line" size="sm" color="inherit" />
-                <Typography component="span" variant="body2">
-                  {group.ownerCount} {owners}
-                </Typography>
-              </Stack>
-            </Stack>
+            )}
 
             <Typography variant="body2" sx={{ mb: '0.25rem' }}>
               Une fois la campagne créée, les logements « Non suivi » passeront

--- a/frontend/src/components/Group/CreateCampaignFromGroupModal.tsx
+++ b/frontend/src/components/Group/CreateCampaignFromGroupModal.tsx
@@ -121,11 +121,6 @@ export function createCampaignFromGroupModal(
               </Stack>
             )}
 
-            <Typography variant="body2" sx={{ mb: '0.25rem' }}>
-              Une fois la campagne créée, les logements « Non suivi » passeront
-              « En attente de retour ».
-            </Typography>
-
             <Box sx={{ '& .fr-input-group': { marginBottom: '0.75rem' } }}>
               <AppTextInputNext<FormSchema>
                 label="Nom (obligatoire)"

--- a/frontend/src/components/Group/GroupNext.tsx
+++ b/frontend/src/components/Group/GroupNext.tsx
@@ -42,8 +42,7 @@ function Group(props: Readonly<GroupProps>) {
     filters: { groupIds: [props.group.id] }
   });
 
-  const { isAdmin, isUsual } = useUser();
-  const canCreateCampaign = isAdmin || isUsual;
+  const { canCreateCampaign } = useUser();
 
   const housing = pluralize(props.group.housingCount)('logement');
   const owners = pluralize(props.group.ownerCount)('propriétaire');

--- a/frontend/src/components/Group/GroupNext.tsx
+++ b/frontend/src/components/Group/GroupNext.tsx
@@ -13,6 +13,7 @@ import { createRemoveGroupModal } from '~/components/Group/RemoveGroupModal';
 import { createRenameGroupModal } from '~/components/Group/RenameGroupModal';
 import FullWidthButton from '~/components/ui/FullWidthButton';
 import Icon from '~/components/ui/Icon';
+import { useUser } from '~/hooks/useUser';
 import type { Campaign } from '~/models/Campaign';
 import type { Group as GroupModel } from '~/models/Group';
 import type { GroupPayload } from '~/models/GroupPayload';
@@ -40,6 +41,9 @@ function Group(props: Readonly<GroupProps>) {
   const findCampaignsQuery = useFindCampaignsQuery({
     filters: { groupIds: [props.group.id] }
   });
+
+  const { isAdmin, isUsual } = useUser();
+  const canCreateCampaign = isAdmin || isUsual;
 
   const housing = pluralize(props.group.housingCount)('logement');
   const owners = pluralize(props.group.ownerCount)('propriétaire');
@@ -182,15 +186,17 @@ function Group(props: Readonly<GroupProps>) {
                 alignItems: 'flex-end'
               }}
             >
-              <li style={{ width: '100%' }}>
-                <FullWidthButton
-                  priority="primary"
-                  onClick={campaignFromGroupModal.open}
-                  disabled={props.group.housingCount === 0}
-                >
-                  Créer une campagne
-                </FullWidthButton>
-              </li>
+              {canCreateCampaign ? (
+                <li style={{ width: '100%' }}>
+                  <FullWidthButton
+                    priority="primary"
+                    onClick={campaignFromGroupModal.open}
+                    disabled={props.group.housingCount === 0}
+                  >
+                    Créer une campagne
+                  </FullWidthButton>
+                </li>
+              ) : null}
 
               <li style={{ width: '100%' }}>
                 <FullWidthButton

--- a/frontend/src/components/Group/test/CreateCampaignFromGroupModal.test.tsx
+++ b/frontend/src/components/Group/test/CreateCampaignFromGroupModal.test.tsx
@@ -39,4 +39,24 @@ describe('CreateCampaignFromGroupModal', () => {
     const dialog = await screen.findByRole('dialog');
     expect(within(dialog).getByText('Étape 2 sur 2')).toBeInTheDocument();
   });
+
+  it('should render without crashing when no group is provided', async () => {
+    render(
+      <Provider store={configureTestStore()}>
+        <modal.Component
+          group={null}
+          stepper={{ currentStep: 2, stepCount: 2 }}
+          onSubmit={vi.fn()}
+        />
+      </Provider>
+    );
+    modal.open();
+
+    const dialog = await screen.findByRole('dialog');
+    // The modal shell still renders; the group-dependent housing/owner counts
+    // are omitted. This guards the always-mounted usage in SaveCampaignFlow,
+    // where the step-2 modal is rendered with a null group until one is picked.
+    expect(within(dialog).getByText('Étape 2 sur 2')).toBeInTheDocument();
+    expect(within(dialog).queryByText(/propriétaire/)).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/Group/test/CreateCampaignFromGroupModal.test.tsx
+++ b/frontend/src/components/Group/test/CreateCampaignFromGroupModal.test.tsx
@@ -40,6 +40,29 @@ describe('CreateCampaignFromGroupModal', () => {
     expect(within(dialog).getByText('Étape 2 sur 2')).toBeInTheDocument();
   });
 
+  it('should disable the "Confirmer" button while submitting', async () => {
+    render(
+      <Provider store={configureTestStore()}>
+        <modal.Component group={group} submitting onSubmit={vi.fn()} />
+      </Provider>
+    );
+    modal.open();
+
+    const dialog = await screen.findByRole('dialog');
+    expect(
+      within(dialog).getByRole('button', { name: 'Confirmer' })
+    ).toBeDisabled();
+  });
+
+  it('should keep the "Confirmer" button enabled when not submitting', async () => {
+    renderModal();
+
+    const dialog = await screen.findByRole('dialog');
+    expect(
+      within(dialog).getByRole('button', { name: 'Confirmer' })
+    ).toBeEnabled();
+  });
+
   it('should render without crashing when no group is provided', async () => {
     render(
       <Provider store={configureTestStore()}>

--- a/frontend/src/components/Group/test/CreateCampaignFromGroupModal.test.tsx
+++ b/frontend/src/components/Group/test/CreateCampaignFromGroupModal.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen, within } from '@testing-library/react';
+import {
+  genGroupDTO,
+  genHousingDTO,
+  genUserDTO
+} from '@zerologementvacant/models/fixtures';
+import { Provider } from 'react-redux';
+
+import { createCampaignFromGroupModal } from '~/components/Group/CreateCampaignFromGroupModal';
+import { fromGroupDTO } from '~/models/Group';
+import configureTestStore from '~/utils/storeUtils';
+
+const modal = createCampaignFromGroupModal();
+const creator = genUserDTO();
+const group = fromGroupDTO(genGroupDTO(creator, [genHousingDTO()]));
+
+describe('CreateCampaignFromGroupModal', () => {
+  function renderModal(stepper?: { currentStep: number; stepCount: number }) {
+    render(
+      <Provider store={configureTestStore()}>
+        <modal.Component group={group} stepper={stepper} onSubmit={vi.fn()} />
+      </Provider>
+    );
+    modal.open();
+  }
+
+  it('should not render a stepper by default', async () => {
+    renderModal();
+
+    const dialog = await screen.findByRole('dialog');
+    expect(
+      within(dialog).queryByText(/Étape \d sur \d/)
+    ).not.toBeInTheDocument();
+  });
+
+  it('should render a stepper when the stepper prop is provided', async () => {
+    renderModal({ currentStep: 2, stepCount: 2 });
+
+    const dialog = await screen.findByRole('dialog');
+    expect(within(dialog).getByText('Étape 2 sur 2')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/Group/test/GroupNext.test.tsx
+++ b/frontend/src/components/Group/test/GroupNext.test.tsx
@@ -9,10 +9,8 @@ import {
 import { Provider } from 'react-redux';
 
 import GroupNext from '~/components/Group/GroupNext';
-import { fromEstablishmentDTO } from '~/models/Establishment';
 import { fromGroupDTO } from '~/models/Group';
-import { fromUserDTO } from '~/models/User';
-import { genAuthUser } from '~/test/fixtures';
+import { MockAuthProvider } from '~/test/auth';
 import configureTestStore from '~/utils/storeUtils';
 
 describe('GroupNext', () => {
@@ -22,22 +20,19 @@ describe('GroupNext', () => {
 
   function renderGroup(role: UserRole) {
     const authDTO = genUserDTO(role, establishment);
-    const store = configureTestStore({
-      auth: genAuthUser(
-        fromUserDTO(authDTO),
-        fromEstablishmentDTO(establishment)
-      )
-    });
+    const store = configureTestStore();
 
     render(
       <Provider store={store}>
-        <GroupNext
-          group={group}
-          onCreateCampaign={vi.fn()}
-          onExport={vi.fn()}
-          onUpdate={vi.fn()}
-          onRemove={vi.fn()}
-        />
+        <MockAuthProvider options={{ user: authDTO, establishment }}>
+          <GroupNext
+            group={group}
+            onCreateCampaign={vi.fn()}
+            onExport={vi.fn()}
+            onUpdate={vi.fn()}
+            onRemove={vi.fn()}
+          />
+        </MockAuthProvider>
       </Provider>
     );
   }

--- a/frontend/src/components/Group/test/GroupNext.test.tsx
+++ b/frontend/src/components/Group/test/GroupNext.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from '@testing-library/react';
+import { UserRole } from '@zerologementvacant/models';
+import {
+  genEstablishmentDTO,
+  genGroupDTO,
+  genHousingDTO,
+  genUserDTO
+} from '@zerologementvacant/models/fixtures';
+import { Provider } from 'react-redux';
+
+import GroupNext from '~/components/Group/GroupNext';
+import { fromEstablishmentDTO } from '~/models/Establishment';
+import { fromGroupDTO } from '~/models/Group';
+import { fromUserDTO } from '~/models/User';
+import { genAuthUser } from '~/test/fixtures';
+import configureTestStore from '~/utils/storeUtils';
+
+describe('GroupNext', () => {
+  const establishment = genEstablishmentDTO();
+  const creator = genUserDTO(UserRole.USUAL, establishment);
+  const group = fromGroupDTO(genGroupDTO(creator, [genHousingDTO()]));
+
+  function renderGroup(role: UserRole) {
+    const authDTO = genUserDTO(role, establishment);
+    const store = configureTestStore({
+      auth: genAuthUser(
+        fromUserDTO(authDTO),
+        fromEstablishmentDTO(establishment)
+      )
+    });
+
+    render(
+      <Provider store={store}>
+        <GroupNext
+          group={group}
+          onCreateCampaign={vi.fn()}
+          onExport={vi.fn()}
+          onUpdate={vi.fn()}
+          onRemove={vi.fn()}
+        />
+      </Provider>
+    );
+  }
+
+  it('should hide the "Créer une campagne" button for a visitor', () => {
+    renderGroup(UserRole.VISITOR);
+
+    expect(
+      screen.queryByRole('button', { name: 'Créer une campagne' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('should show the "Créer une campagne" button for a usual user', async () => {
+    renderGroup(UserRole.USUAL);
+
+    expect(
+      await screen.findByRole('button', { name: 'Créer une campagne' })
+    ).toBeInTheDocument();
+  });
+
+  it('should show the "Créer une campagne" button for an admin', async () => {
+    renderGroup(UserRole.ADMIN);
+
+    expect(
+      await screen.findByRole('button', { name: 'Créer une campagne' })
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/_app/AppSearchBar/AppSearchBar.tsx
+++ b/frontend/src/components/_app/AppSearchBar/AppSearchBar.tsx
@@ -8,6 +8,11 @@ export interface AppSearchBarProps {
   initialQuery?: string;
   placeholder?: string;
   size?: 'md' | 'xl';
+  /**
+   * Allow submitting an empty query. Off by default; enable it when an empty
+   * submit is a meaningful action (e.g. resetting a filter to "show all").
+   */
+  allowEmptySearch?: boolean;
   onSearch(text: string): void;
   onKeySearch?(text: string): Promise<void>;
 }
@@ -18,7 +23,7 @@ function AppSearchBar(props: AppSearchBarProps) {
 
   return (
     <SearchBar
-      allowEmptySearch={false}
+      allowEmptySearch={props.allowEmptySearch ?? false}
       big={props.size === 'xl'}
       className={props.className}
       clearInputOnSearch

--- a/frontend/src/components/modals/ConfirmationModal/ConfirmationModalNext.tsx
+++ b/frontend/src/components/modals/ConfirmationModal/ConfirmationModalNext.tsx
@@ -13,6 +13,11 @@ export interface ConfirmationModalProps extends Omit<
   'buttons'
 > {
   onSubmit?(): void;
+  /**
+   * Disables the "Confirmer" button, e.g. while an async submission is in
+   * flight, to prevent a double-submit. The button stays enabled by default.
+   */
+  submitting?: boolean;
 }
 
 export function createConfirmationModal(options: ConfirmationModalOptions) {
@@ -21,7 +26,7 @@ export function createConfirmationModal(options: ConfirmationModalOptions) {
   return {
     ...modal,
     Component(props: ConfirmationModalProps): JSX.Element {
-      const { onSubmit, ...rest } = props;
+      const { onSubmit, submitting, ...rest } = props;
 
       return (
         <modal.Component
@@ -39,6 +44,7 @@ export function createConfirmationModal(options: ConfirmationModalOptions) {
             {
               children: 'Confirmer',
               doClosesModal: false,
+              disabled: submitting,
               nativeButtonProps: {
                 type: 'submit'
               },

--- a/frontend/src/dsfr-fix.scss
+++ b/frontend/src/dsfr-fix.scss
@@ -87,6 +87,10 @@ span.fr-icon-checkbox-circle-line.ds-fr-tag-icon {
   box-shadow: none !important;
 }
 
+.fr-table {
+  margin-bottom: 1rem !important;
+}
+
 .table-column-header {
   font-weight: 500 !important;
   font-size: 0.75rem !important;

--- a/frontend/src/hooks/test/useNotification.test.tsx
+++ b/frontend/src/hooks/test/useNotification.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen, waitFor } from '@testing-library/react';
+
+import Notification from '~/components/Notification/Notification';
+import {
+  useNotification,
+  type NotificationProps
+} from '~/hooks/useNotification';
+
+function Harness(props: Readonly<NotificationProps>) {
+  useNotification(props);
+  return <Notification />;
+}
+
+describe('useNotification', () => {
+  it('renders the loading toast as a polite status region', async () => {
+    render(
+      <Harness
+        toastId="notif-loading"
+        isLoading
+        isError={false}
+        isSuccess={false}
+        message={{ loading: 'Chargement…' }}
+      />
+    );
+
+    const status = await screen.findByRole('status');
+
+    expect(status).toHaveTextContent('Chargement…');
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('renders the success toast as a polite status region', async () => {
+    const { rerender } = render(
+      <Harness
+        toastId="notif-success"
+        isLoading
+        isError={false}
+        isSuccess={false}
+        message={{ loading: 'Chargement…', success: 'Enregistré' }}
+      />
+    );
+    await screen.findByText('Chargement…');
+
+    rerender(
+      <Harness
+        toastId="notif-success"
+        isLoading={false}
+        isError={false}
+        isSuccess
+        message={{ loading: 'Chargement…', success: 'Enregistré' }}
+      />
+    );
+
+    const status = await screen.findByRole('status');
+    await waitFor(() => expect(status).toHaveTextContent('Enregistré'));
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('renders the error toast as an assertive alert region', async () => {
+    const { rerender } = render(
+      <Harness
+        toastId="notif-error"
+        isLoading
+        isError={false}
+        isSuccess={false}
+        message={{ loading: 'Chargement…', error: 'Erreur' }}
+      />
+    );
+    await screen.findByText('Chargement…');
+
+    rerender(
+      <Harness
+        toastId="notif-error"
+        isLoading={false}
+        isError
+        isSuccess={false}
+        message={{ loading: 'Chargement…', error: 'Erreur' }}
+      />
+    );
+
+    const alert = await screen.findByRole('alert');
+    await waitFor(() => expect(alert).toHaveTextContent('Erreur'));
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/hooks/test/useUser.test.tsx
+++ b/frontend/src/hooks/test/useUser.test.tsx
@@ -54,4 +54,42 @@ describe('useUser', () => {
     expect(typeof result.current.establishment?.siren).toBe('number');
     expect(result.current.effectiveGeoCodes).toEqual(['01001']);
   });
+
+  it.each([
+    { role: UserRole.USUAL, expected: true },
+    { role: UserRole.ADMIN, expected: true },
+    { role: UserRole.VISITOR, expected: false }
+  ])(
+    'derives canCreateCampaign=$expected for a $role',
+    ({ role, expected }) => {
+      const store = configureTestStore();
+      const userDTO = { ...genUserDTO(), role };
+      const wrapper = ({ children }: PropsWithChildren) => (
+        <Provider store={store}>
+          <MockAuthProvider
+            options={{ user: userDTO, establishment: genEstablishmentDTO() }}
+          >
+            {children}
+          </MockAuthProvider>
+        </Provider>
+      );
+
+      const { result } = renderHook(() => useUser(), { wrapper });
+
+      expect(result.current.canCreateCampaign).toBe(expected);
+    }
+  );
+
+  it('denies canCreateCampaign to a guest', () => {
+    const store = configureTestStore();
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <Provider store={store}>
+        <MockAuthProvider options={{ user: null }}>{children}</MockAuthProvider>
+      </Provider>
+    );
+
+    const { result } = renderHook(() => useUser(), { wrapper });
+
+    expect(result.current.canCreateCampaign).toBe(false);
+  });
 });

--- a/frontend/src/hooks/useNotification.ts
+++ b/frontend/src/hooks/useNotification.ts
@@ -17,11 +17,16 @@ export function useNotification(props: NotificationProps) {
   const toastId: string = props.toastId;
 
   useEffect(() => {
+    // react-toastify defaults every toast to `role="alert"` (assertive), which
+    // interrupts screen readers. Per RGAA 7.5 / WCAG 4.1.3, only errors warrant
+    // that urgency; loading and success are polite status messages, so they use
+    // `role="status"` (`aria-live="polite"`).
     if (props.isLoading) {
       const loading = props.message?.loading || 'Sauvegarde...';
       toast(loading, {
         autoClose: false,
         isLoading: true,
+        role: 'status',
         toastId
       });
     } else if (props.isError) {
@@ -30,6 +35,7 @@ export function useNotification(props: NotificationProps) {
         autoClose: props.autoClose ?? null,
         isLoading: false,
         render: error,
+        role: 'alert',
         type: 'error',
         toastId
       });
@@ -39,6 +45,7 @@ export function useNotification(props: NotificationProps) {
         autoClose: props.autoClose ?? null,
         isLoading: false,
         render: success,
+        role: 'status',
         type: 'success',
         toastId
       });

--- a/frontend/src/hooks/useUser.tsx
+++ b/frontend/src/hooks/useUser.tsx
@@ -47,6 +47,7 @@ function derive(
   const hasMultipleEstablishments = (authorizedEstablishments?.length ?? 0) > 1;
   const canChangeEstablishment =
     isAdmin || isVisitor || (isUsual && hasMultipleEstablishments);
+  const canCreateCampaign = isAdmin || isUsual;
 
   function displayName(): string {
     if (user?.firstName && user?.lastName) {
@@ -64,6 +65,7 @@ function derive(
     isUsual,
     isVisitor,
     canChangeEstablishment,
+    canCreateCampaign,
     displayName
   };
 }

--- a/frontend/src/mocks/handlers/group-handlers.ts
+++ b/frontend/src/mocks/handlers/group-handlers.ts
@@ -8,6 +8,7 @@ import { http, HttpResponse, RequestHandler } from 'msw';
 
 import config from '../../utils/config';
 import data from './data';
+import { filterByHousingIds } from './housing-handlers';
 
 type GroupParams = {
   id: string;
@@ -25,11 +26,18 @@ export const groupHandlers: RequestHandler[] = [
   // Create a group
   http.post<Record<string, never>, GroupPayloadDTO, GroupDTO>(
     `${config.apiEndpoint}/groups`,
-    () => {
+    async ({ request }) => {
       const creator = faker.helpers.arrayElement(data.users);
-      // TODO: use request payload
-      const housings = faker.helpers.arrayElements(data.housings);
-      const group = genGroupDTO(creator, housings);
+      const payload = await request.json();
+      const housings = filterByHousingIds({
+        all: payload.housing.all,
+        housingIds: payload.housing.ids
+      })(data.housings);
+      const group: GroupDTO = {
+        ...genGroupDTO(creator, housings),
+        title: payload.title,
+        description: payload.description
+      };
       data.groups.push(group);
       data.groupHousings.set(group.id, housings);
 

--- a/frontend/src/views/Campaign/test/CampaignListView.test.tsx
+++ b/frontend/src/views/Campaign/test/CampaignListView.test.tsx
@@ -1,5 +1,5 @@
 import { faker } from '@faker-js/faker/locale/fr';
-import { render, screen, within } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {
   UserRole,
@@ -380,6 +380,37 @@ describe('CampaignListView', () => {
       await user.click(confirm);
       const countAfter = await count();
       expect(countAfter).toBe(countBefore ? countBefore - 1 : false);
+    });
+
+    it('should redirect to the campaign page after creating a campaign', async () => {
+      const housings = faker.helpers.multiple(() => genHousingDTO(), {
+        count: { min: 1, max: 5 }
+      });
+      const group = genGroupDTO(auth, housings);
+      data.groups.push(group);
+
+      const { router } = renderView({ campaigns: [] });
+
+      await user.click(
+        screen.getByRole('button', { name: 'Enregistrer une campagne' })
+      );
+      const selectDialog = await screen.findByRole('dialog');
+      await user.click(
+        await within(selectDialog).findByRole('button', {
+          name: `Sélectionner le groupe ${group.title}`
+        })
+      );
+      const createDialog = await screen.findByRole('dialog');
+      await within(createDialog).findByText('Étape 2 sur 2');
+      await user.type(
+        await within(createDialog).findByLabelText(/^Nom/),
+        'Ma campagne'
+      );
+      await user.click(await within(createDialog).findByText('Confirmer'));
+
+      await waitFor(() => {
+        expect(router.state.location.pathname).toMatch(/^\/campagnes\/.+/);
+      });
     });
   });
 });

--- a/frontend/src/views/HousingList/test/HousingListView.campaignFlows.test.tsx
+++ b/frontend/src/views/HousingList/test/HousingListView.campaignFlows.test.tsx
@@ -1,0 +1,222 @@
+import { faker } from '@faker-js/faker/locale/fr';
+import { act, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { UserRole } from '@zerologementvacant/models';
+import {
+  genEstablishmentDTO,
+  genHousingDTO,
+  genHousingOwnerDTO,
+  genOwnerDTO,
+  genUserDTO
+} from '@zerologementvacant/models/fixtures';
+import { addDays, format } from 'date-fns';
+import { Provider } from 'react-redux';
+import { createMemoryRouter, RouterProvider } from 'react-router';
+
+import { HousingFiltersProvider } from '~/hooks/HousingFiltersContext';
+import data from '~/mocks/handlers/data';
+import { MockAuthProvider } from '~/test/auth';
+import configureTestStore from '~/utils/storeUtils';
+import CampaignListView from '~/views/Campaign/CampaignListView';
+import CampaignView from '~/views/Campaign/CampaignView';
+import GroupView from '~/views/Group/GroupView';
+import HousingListTabsProvider from '~/views/HousingList/HousingListTabsProvider';
+import HousingListView from '~/views/HousingList/HousingListView';
+
+describe('Housing list to campaign flows', () => {
+  const user = userEvent.setup();
+
+  function renderApp() {
+    const establishment = genEstablishmentDTO();
+    const auth = genUserDTO(UserRole.USUAL, establishment);
+    const owner = genOwnerDTO();
+    const housings = faker.helpers.multiple(() => genHousingDTO(), {
+      count: { min: 2, max: 4 }
+    });
+    const housingOwners = housings.map((housing) => ({
+      ...genHousingOwnerDTO(owner),
+      housingId: housing.id,
+      ownerId: owner.id,
+      rank: 1 as const
+    }));
+
+    data.establishments.push(establishment);
+    data.users.push(auth);
+    data.owners.push(owner);
+    data.housings.push(...housings);
+    housingOwners.forEach((housingOwner) => {
+      data.housingOwners.set(housingOwner.housingId, [housingOwner]);
+    });
+
+    const store = configureTestStore();
+    const router = createMemoryRouter(
+      [
+        {
+          path: '/parc-de-logements',
+          element: (
+            <HousingListTabsProvider>
+              <HousingListView />
+            </HousingListTabsProvider>
+          )
+        },
+        { path: '/groupes/:id', element: <GroupView /> },
+        { path: '/campagnes', element: <CampaignListView /> },
+        { path: '/campagnes/:id', element: <CampaignView /> }
+      ],
+      { initialEntries: ['/parc-de-logements'] }
+    );
+
+    render(
+      <Provider store={store}>
+        <MockAuthProvider options={{ user: auth, establishment }}>
+          <HousingFiltersProvider>
+            <RouterProvider router={router} />
+          </HousingFiltersProvider>
+        </MockAuthProvider>
+      </Provider>
+    );
+
+    return { router };
+  }
+
+  /**
+   * Selects every housing via the table’s header checkbox, then creates a
+   * new group from that selection, and waits for the redirect to the new
+   * group’s page.
+   */
+  async function selectAllHousingsAndCreateGroup(
+    router: ReturnType<typeof createMemoryRouter>,
+    title: string
+  ) {
+    const selectAll = await screen.findByRole('checkbox', {
+      name: 'Sélectionner tous les éléments'
+    });
+    await user.click(selectAll);
+
+    const addToGroup = await screen.findByRole('button', {
+      name: 'Intégrer dans un groupe'
+    });
+    await user.click(addToGroup);
+
+    const createGroup = await screen.findByRole('button', {
+      name: 'Créer un nouveau groupe'
+    });
+    await user.click(createGroup);
+
+    const groupName = await screen.findByRole('textbox', {
+      name: /Nom du groupe/
+    });
+    await user.type(groupName, title);
+    const groupDescription = await screen.findByRole('textbox', {
+      name: /Description/
+    });
+    await user.type(groupDescription, 'Description du groupe');
+    const confirm = await screen.findByRole('button', {
+      name: /Créer un groupe/
+    });
+    await user.click(confirm);
+
+    await waitFor(() => {
+      expect(router.state.location.pathname).toMatch(/^\/groupes\/.+/);
+    });
+  }
+
+  describe('Create a campaign from the group page', () => {
+    async function createCampaignFromGroupView(sentAt?: string) {
+      const createCampaign = await screen.findByRole('button', {
+        name: /^Créer une campagne/
+      });
+      await user.click(createCampaign);
+      const modal = await screen.findByRole('dialog');
+      const title = await within(modal).findByLabelText(/^Nom/);
+      await user.type(title, 'Campagne depuis le groupe');
+      if (sentAt) {
+        const sentAtInput = await within(modal).findByLabelText(/Date d’envoi/);
+        await user.type(sentAtInput, sentAt);
+      }
+      const confirm = await within(modal).findByText('Confirmer');
+      await user.click(confirm);
+    }
+
+    it('should redirect to the new campaign’s page without a sending date', async () => {
+      const { router } = renderApp();
+
+      await selectAllHousingsAndCreateGroup(router, 'Tous les logements');
+      await createCampaignFromGroupView();
+
+      await waitFor(() => {
+        expect(router.state.location.pathname).toMatch(/^\/campagnes\/.+/);
+      });
+    });
+
+    it('should redirect to the new campaign’s page with a sending date in the near future', async () => {
+      const { router } = renderApp();
+      const sentAt = format(addDays(new Date(), 7), 'yyyy-MM-dd');
+
+      await selectAllHousingsAndCreateGroup(router, 'Tous les logements');
+      await createCampaignFromGroupView(sentAt);
+
+      await waitFor(() => {
+        expect(router.state.location.pathname).toMatch(/^\/campagnes\/.+/);
+      });
+    });
+  });
+
+  describe('Save a campaign from the campaign list view', () => {
+    async function saveCampaignFromGroup(
+      router: ReturnType<typeof createMemoryRouter>,
+      groupTitle: string,
+      sentAt?: string
+    ) {
+      act(() => {
+        router.navigate('/campagnes');
+      });
+
+      const openButton = await screen.findByRole('button', {
+        name: 'Enregistrer une campagne'
+      });
+      await user.click(openButton);
+
+      const selectDialog = await screen.findByRole('dialog');
+      const selectButton = await within(selectDialog).findByRole('button', {
+        name: `Sélectionner le groupe ${groupTitle}`
+      });
+      await user.click(selectButton);
+
+      const createDialog = await screen.findByRole('dialog');
+      await within(createDialog).findByText('Étape 2 sur 2');
+      const title = await within(createDialog).findByLabelText(/^Nom/);
+      await user.type(title, 'Campagne depuis la liste');
+      if (sentAt) {
+        const sentAtInput =
+          await within(createDialog).findByLabelText(/Date d’envoi/);
+        await user.type(sentAtInput, sentAt);
+      }
+      const confirm = await within(createDialog).findByText('Confirmer');
+      await user.click(confirm);
+    }
+
+    it('should redirect to the new campaign’s page without a sending date', async () => {
+      const { router } = renderApp();
+
+      await selectAllHousingsAndCreateGroup(router, 'Logements du groupe');
+      await saveCampaignFromGroup(router, 'Logements du groupe');
+
+      await waitFor(() => {
+        expect(router.state.location.pathname).toMatch(/^\/campagnes\/.+/);
+      });
+    });
+
+    it('should redirect to the new campaign’s page with a sending date in the near future', async () => {
+      const { router } = renderApp();
+      const sentAt = format(addDays(new Date(), 7), 'yyyy-MM-dd');
+
+      await selectAllHousingsAndCreateGroup(router, 'Logements programmés');
+      await saveCampaignFromGroup(router, 'Logements programmés', sentAt);
+
+      await waitFor(() => {
+        expect(router.state.location.pathname).toMatch(/^\/campagnes\/.+/);
+      });
+    });
+  });
+});

--- a/server/src/controllers/test/campaign-api.test.ts
+++ b/server/src/controllers/test/campaign-api.test.ts
@@ -8,6 +8,7 @@ import {
   CampaignUpdatePayload,
   HOUSING_STATUS_VALUES,
   HousingStatus,
+  UserRole,
   type CampaignCreationPayload,
   type UserDTO
 } from '@zerologementvacant/models';
@@ -20,6 +21,7 @@ import { createServer } from '~/infra/server';
 import { CampaignEventApi } from '~/models/EventApi';
 import { GroupApi } from '~/models/GroupApi';
 import { HousingApi } from '~/models/HousingApi';
+import { UserApi } from '~/models/UserApi';
 import {
   CampaignHousingDBO,
   CampaignsHousing,
@@ -427,6 +429,27 @@ describe('Campaign API', () => {
         .use(tokenProvider(user));
 
       expect(status).toBe(constants.HTTP_STATUS_NOT_FOUND);
+    });
+
+    it('should be forbidden for a visitor', async () => {
+      const visitor: UserApi = {
+        ...genUserApi(establishment.id),
+        role: UserRole.VISITOR
+      };
+      await Users().insert(toUserDBO(visitor));
+      const payload: CampaignCreationPayload = {
+        title: 'Logements prioritaires',
+        description: 'Campagne pour les logements prioritaires',
+        sentAt: null
+      };
+
+      const { status } = await request(url)
+        .post(testRoute(group.id))
+        .send(payload)
+        .type('json')
+        .use(tokenProvider(visitor));
+
+      expect(status).toBe(constants.HTTP_STATUS_FORBIDDEN);
     });
 
     it('should create the campaign', async () => {

--- a/server/src/routers/protected.ts
+++ b/server/src/routers/protected.ts
@@ -294,6 +294,7 @@ router.delete(
 );
 router.post(
   '/groups/:id/campaigns',
+  hasRole([UserRole.USUAL, UserRole.ADMIN]),
   validator.validate({
     body: schemas.campaignCreationPayload,
     params: object({ id: schemas.id })


### PR DESCRIPTION
## Summary

Adds an **"Enregistrer une campagne"** button to the campaigns list (`/campagnes`) that opens a 2-step modal flow to create a campaign from an existing group, and closes a pre-existing permission gap on campaign creation.

- **Step 1 — `SelectGroupModal`** (new): search & select an eligible group. Excludes archived and empty groups, case-insensitive submit-only search on title, sorted most-recent-first, 5/page via `AdvancedTable`.
- **Step 2 — `CreateCampaignFromGroupModal`** (existing, extended): now renders an optional DSFR `Stepper` ("Étape 2 sur 2"). Unchanged for its existing group-page call site.
- **`SaveCampaignFlow`** (new): self-contained orchestrator chaining the two modals, mounted in `CampaignTable.tsx` with no wiring. On success: toast + close + stay on `/campagnes`.
- **`AdvancedTable`**: two new *optional* props `perPageOptions`/`defaultPageSize` (defaults unchanged, so existing callers are unaffected).
- **Permission gap fixed (both entry points):** campaign creation was previously callable by any authenticated user, including a read-only Visitor. Now restricted to **Usual/Admin** — authoritatively at the backend (`hasRole([USUAL, ADMIN])` on `POST /groups/:id/campaigns`) and mirrored on both frontend buttons (the new one and the existing group-page one, hidden — not disabled — for Visitors).

Built task-by-task via subagent-driven development: each task written test-first (TDD), task-reviewed for spec + quality, plus a final whole-branch review. One bug caught and fixed in review (re-selecting the same group after cancelling step 2 no longer dead-clicks), and a failed-submit no longer produces an unhandled promise rejection.

## Accessibility (RGAA)

Verified from code: distinct per-row `aria-label`s (6.1/11.9), DSFR-native focus-trap/keyboard with no custom focus management (7.x/12.8/12.9), icon+text button (1.1), table headers (5.x), search/form labels (11.1), stepper semantics.

⚠️ **Still needs a manual browser pass before shipping** (plan Task 7.4): focus-indicator visibility (10.7), focus flow across the step1→step2 transition, and Figma 1:1 visual parity.

Follow-up (separate PR, app-wide): `AdvancedTable`'s per-page `SelectNext` has no `aria-label` (RGAA 11.1) — pre-existing, affects every table.

## Test plan

- [x] `yarn nx test server -- campaign-api.test.ts` — 48/48, incl. new "forbidden for a visitor" (403) case
- [x] `yarn nx test frontend` — 383 tests green (AdvancedTable, GroupNext, CreateCampaignFromGroupModal, SelectGroupModal, SaveCampaignFlow incl. reopen-after-cancel + failed-submit paths, CampaignListView, GroupView)
- [x] `yarn nx typecheck frontend` / `yarn nx typecheck server` — clean
- [x] `yarn lint` / `yarn format` — clean
- [ ] Manual browser RGAA walkthrough (focus flow across modal steps, focus-indicator visibility) + Figma visual parity

🤖 Generated with [Claude Code](https://claude.com/claude-code)