### PR TITLE
feat: add Documents tab to campaigns

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -175,6 +175,8 @@ fileignoreconfig:
   checksum: 7c3d25a7502faeb9fd4e438e7e6bdf39cc18ebd32401f1463420289cda46a4d3
 - filename: docs/rgaa/methodologie-tests.md
   checksum: b396fb5a9d17e2a81cad49491c35cc459db9f2ff494c94dada9f3eeae0efeb53
+- filename: docs/superpowers/specs/2026-07-20-campaign-documents-design.md
+  checksum: 45db32afbf267b94ffb071c725691dad57b28c8bb12554e0b8397a5bf0a9d141
 scopeconfig:
 - scope: node
 allowed_patterns:

--- a/.talismanrc
+++ b/.talismanrc
@@ -123,6 +123,8 @@ fileignoreconfig:
   checksum: 1d816ff7b060a0100cbd90a60182bb7c3e230ab5761909b18871af6ced2a6efb
 - filename: server/src/repositories/documentRepository.ts
   checksum: 08cf7ff79afbf8604d02913f97a4a3a7a5ba21921a104096a6973f293b81d107
+- filename: server/src/repositories/test/campaignDocumentRepository.test.ts
+  checksum: d4b78953d3f5c8b36205457c510a2b351874906e1e71a8cd5d85a1b06eb0f3b1
 - filename: server/src/scripts/import-dpe/import-dpe.py
   checksum: ba1ea278d8321501976c7c9da7e9428fe8819776369f7eef0ff1fbf1ee4ed8bf
 - filename: server/src/scripts/import-dpe/import_dpe_raw.py

--- a/.talismanrc
+++ b/.talismanrc
@@ -177,6 +177,8 @@ fileignoreconfig:
   checksum: b396fb5a9d17e2a81cad49491c35cc459db9f2ff494c94dada9f3eeae0efeb53
 - filename: docs/superpowers/specs/2026-07-20-campaign-documents-design.md
   checksum: 45db32afbf267b94ffb071c725691dad57b28c8bb12554e0b8397a5bf0a9d141
+- filename: docs/superpowers/plans/2026-07-20-campaign-documents.md
+  checksum: 1e3050356fc1503522f81a38384a26cf11310d81881707ccc34df0279ca6b90f
 scopeconfig:
 - scope: node
 allowed_patterns:

--- a/docs/superpowers/plans/2026-07-20-campaign-documents.md
+++ b/docs/superpowers/plans/2026-07-20-campaign-documents.md
@@ -1,0 +1,3254 @@
+# Campaign Documents Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a "Documents" tab to the campaign detail page so users can upload, view, rename, and delete documents attached to a campaign — mirroring the existing housing-documents feature.
+
+**Architecture:** Reuse the existing generic `documents` table/S3 infrastructure. Add a `documents_campaigns` many-to-many junction table (mirrors `documents_housings`), a `campaignDocumentRepository`, three new `documentController` methods, three new routes, and a self-contained `CampaignDocumentsTab` React component wired into `CampaignView.tsx`'s existing DSFR `Tabs`. Reuse `DocumentCard`, `DocumentUpload`, `DocumentFullscreenPreview`, `DocumentDeleteModal`, `DocumentRenameModal` unchanged (all already entity-agnostic).
+
+**Tech Stack:** TypeScript, Express, Knex/PostgreSQL, S3-compatible storage, React, RTK Query, DSFR + MUI, Vitest, MSW, supertest.
+
+Design spec: `docs/superpowers/specs/2026-07-20-campaign-documents-design.md`
+
+## Global Constraints
+
+- TDD is mandatory: write the failing test before the implementation, for every step below.
+- Backend order per `.claude/rules/backend-conventions.md` is Router → Controller test → Controller → Repository test → Repository. **Deviation, stated explicitly**: this plan implements the Repository before the Controller/Router, because the controller integration tests exercise the real repository against the test database (no mocking) and cannot compile or pass until it exists. Within the combined Controller+Router task, the router and controller test are still written before the controller implementation.
+- Run `yarn nx run-many -t typecheck` after any change to `packages/models` or `packages/schemas` (per `.claude/rules/packages-conventions.md`).
+- Run tests via `yarn nx test <project> -- <file-pattern>` from the repo root — never `yarn test` inside a workspace.
+- All user-facing French strings use the French apostrophe `’` (U+2019), never `'`.
+- Frontend: DSFR components first, MUI layout primitives second, Emotion `styled()` third. Direct MUI imports only (`import Box from '@mui/material/Box'`).
+- No new interactive UI patterns are introduced — every reused component (`DocumentCard`, `DocumentUpload`, DSFR `Tabs`/`Dropdown`, delete/rename modals) is already RGAA-compliant in production; the final task re-verifies no regression.
+- Never use `git commit --no-verify`; the repo's Talisman pre-commit hook may flag false-positive "secret patterns" in generated SQL/code comments — if that happens, add the suggested checksum to `.talismanrc` rather than bypass the hook.
+
+---
+
+### Task 1: Shared `canWriteDocument` permission helper + generic upload constants
+
+**Files:**
+
+- Modify: `packages/models/src/DocumentDTO.ts`
+- Modify: `packages/models/src/HousingDocumentDTO.ts`
+- Create: `packages/models/src/test/DocumentDTO.test.ts`
+- Modify: `server/src/controllers/documentController.ts`
+- Modify: `server/src/routers/protected.ts`
+- Modify: `frontend/src/components/FileUpload/HousingDocumentUpload.tsx`
+- Modify: `frontend/src/components/HousingDetails/DocumentCard.tsx`
+
+**Interfaces:**
+
+- Produces: `canWriteDocument(role: UserRole, sameEstablishment: boolean): boolean` from `@zerologementvacant/models`.
+- Produces: `ACCEPTED_DOCUMENT_EXTENSIONS: ReadonlyArray<string>`, `MAX_DOCUMENT_SIZE_IN_MiB: number` from `@zerologementvacant/models` (renamed from `ACCEPTED_HOUSING_DOCUMENT_EXTENSIONS`/`MAX_HOUSING_DOCUMENT_SIZE_IN_MiB`).
+
+- [ ] **Step 1: Write the failing test for `canWriteDocument`**
+
+Create `packages/models/src/test/DocumentDTO.test.ts`:
+
+```ts
+import { canWriteDocument } from '../DocumentDTO';
+import { UserRole } from '../UserRole';
+
+describe('DocumentDTO', () => {
+  describe('canWriteDocument', () => {
+    it('should allow an admin regardless of establishment', () => {
+      expect(canWriteDocument(UserRole.ADMIN, false)).toBe(true);
+      expect(canWriteDocument(UserRole.ADMIN, true)).toBe(true);
+    });
+
+    it('should allow a usual user only in the same establishment', () => {
+      expect(canWriteDocument(UserRole.USUAL, true)).toBe(true);
+      expect(canWriteDocument(UserRole.USUAL, false)).toBe(false);
+    });
+
+    it('should never allow a visitor', () => {
+      expect(canWriteDocument(UserRole.VISITOR, true)).toBe(false);
+      expect(canWriteDocument(UserRole.VISITOR, false)).toBe(false);
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `yarn nx test models -- DocumentDTO.test.ts`
+Expected: FAIL — `canWriteDocument` is not exported from `../DocumentDTO`.
+
+- [ ] **Step 3: Implement `canWriteDocument` and move the generic constants**
+
+Modify `packages/models/src/DocumentDTO.ts` — add the import and function, keeping everything else unchanged:
+
+```ts
+import { Predicate } from 'effect';
+import mime from 'mime';
+
+import type { EstablishmentDTO } from './EstablishmentDTO';
+import type { UserDTO } from './UserDTO';
+import { UserRole } from './UserRole';
+
+export interface DocumentDTO {
+  id: string;
+  filename: string;
+  /*
+   ** Pre-signed URL
+   */
+  url: string;
+  contentType: string;
+  sizeBytes: number;
+  createdAt: string;
+  updatedAt: string | null;
+  establishmentId: EstablishmentDTO['id'];
+  creator: UserDTO;
+}
+
+export type DocumentPayload = Pick<DocumentDTO, 'filename'>;
+
+export const ACCEPTED_DOCUMENT_EXTENSIONS: ReadonlyArray<string> = [
+  'png',
+  'jpg',
+  'heic',
+  'webp',
+  'pdf',
+  'doc',
+  'docx',
+  'xls',
+  'xlsx',
+  'ppt',
+  'pptx'
+];
+
+export const MAX_DOCUMENT_SIZE_IN_MiB = 25;
+
+const IMAGE_TYPES = ['jpeg', 'png', 'webp'];
+
+export function isImage(document: DocumentDTO): boolean {
+  return IMAGE_TYPES.map((type) => mime.getType(type))
+    .filter(Predicate.isNotNull)
+    .includes(document.contentType);
+}
+
+export function isPDF(document: DocumentDTO): boolean {
+  return document.contentType === mime.getType('pdf');
+}
+
+export function canWriteDocument(
+  role: UserRole,
+  sameEstablishment: boolean
+): boolean {
+  return (
+    role === UserRole.ADMIN || (role === UserRole.USUAL && sameEstablishment)
+  );
+}
+```
+
+Modify `packages/models/src/HousingDocumentDTO.ts` — remove the constants (now generic, defined above), keep only the type alias:
+
+```ts
+import type { DocumentDTO } from './DocumentDTO';
+
+export type HousingDocumentDTO = DocumentDTO;
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `yarn nx test models -- DocumentDTO.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Update the 3 remaining call sites of the renamed constants**
+
+Modify `server/src/controllers/documentController.ts` — change the import (line 4-11) and usage (line 82-85):
+
+```ts
+import {
+  ACCEPTED_DOCUMENT_EXTENSIONS,
+  HousingDocumentDTO,
+  MAX_DOCUMENT_SIZE_IN_MiB,
+  type DocumentDTO,
+  type DocumentPayload,
+  type HousingDTO
+} from '@zerologementvacant/models';
+```
+
+```ts
+await validate(file, {
+  accept: ACCEPTED_DOCUMENT_EXTENSIONS,
+  maxSize: MAX_DOCUMENT_SIZE_IN_MiB * 1024 ** 2
+});
+```
+
+Note: `HousingDocumentDTO` is kept in the import (still used as `listByHousing`'s return type) — only the two constants are renamed.
+
+Modify `server/src/routers/protected.ts` — change the import (line 1-5) and usage (line 57-60):
+
+```ts
+import {
+  ACCEPTED_DOCUMENT_EXTENSIONS,
+  MAX_DOCUMENT_SIZE_IN_MiB,
+  UserRole
+} from '@zerologementvacant/models';
+```
+
+```ts
+router.post(
+  '/documents',
+  hasRole([UserRole.USUAL, UserRole.ADMIN]),
+  upload({
+    accept: ACCEPTED_DOCUMENT_EXTENSIONS as string[],
+    multiple: true,
+    maxSizeMiB: MAX_DOCUMENT_SIZE_IN_MiB
+  }),
+  documentController.create
+);
+```
+
+Modify `frontend/src/components/FileUpload/HousingDocumentUpload.tsx` — change the import (line 1-4) and usage (line 27):
+
+```tsx
+import {
+  ACCEPTED_DOCUMENT_EXTENSIONS,
+  type DocumentDTO
+} from '@zerologementvacant/models';
+```
+
+```tsx
+      accept={ACCEPTED_DOCUMENT_EXTENSIONS as string[]}
+```
+
+- [ ] **Step 6: Use `canWriteDocument` in `DocumentCard.tsx`**
+
+Modify `frontend/src/components/HousingDetails/DocumentCard.tsx` — change the import (line 7) and the permission computation (line 67-70):
+
+```tsx
+import {
+  canWriteDocument,
+  UserRole,
+  type DocumentDTO
+} from '@zerologementvacant/models';
+```
+
+```tsx
+const { user, establishment } = useUser();
+const sameEstablishment: boolean =
+  establishment?.id === props.document.establishmentId;
+const canWrite: boolean = canWriteDocument(
+  user?.role ?? UserRole.VISITOR,
+  sameEstablishment
+);
+```
+
+- [ ] **Step 7: Run the full document-related test suites to check for regressions**
+
+Run: `yarn nx test models -- DocumentDTO.test.ts` (expected: PASS)
+Run: `yarn nx test server -- document-api.test.ts` (expected: PASS — behavior unchanged, only import renamed)
+Run: `yarn nx test frontend -- HousingView.test.tsx` (expected: PASS — this is the existing coverage of `DocumentCard`'s permission gating; confirms the `canWriteDocument` extraction is behavior-preserving)
+Run: `yarn nx run-many -t typecheck` (expected: no errors across all workspaces)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/models/src/DocumentDTO.ts packages/models/src/HousingDocumentDTO.ts packages/models/src/test/DocumentDTO.test.ts server/src/controllers/documentController.ts server/src/routers/protected.ts frontend/src/components/FileUpload/HousingDocumentUpload.tsx frontend/src/components/HousingDetails/DocumentCard.tsx
+git commit -m "refactor: extract shared canWriteDocument helper and generalize upload constants"
+```
+
+---
+
+### Task 2: Campaign document types, event types, and payload schema
+
+**Files:**
+
+- Create: `packages/models/src/CampaignDocumentDTO.ts`
+- Modify: `packages/models/src/index.ts`
+- Modify: `packages/models/src/EventType.ts`
+- Modify: `packages/models/src/EventPayloads.ts`
+- Create: `packages/schemas/src/campaign-document-payload.ts`
+- Create: `packages/schemas/src/test/campaign-document-payload.test.ts`
+- Modify: `packages/schemas/src/index.ts`
+
+**Interfaces:**
+
+- Consumes: nothing from Task 1 directly (independent of `canWriteDocument`).
+- Produces: `CampaignDocumentDTO` (alias of `DocumentDTO`), event type strings `'campaign:document-attached' | 'campaign:document-detached' | 'campaign:document-removed'`, `campaignDocumentPayload: ObjectSchema<CampaignDocumentPayload>` where `CampaignDocumentPayload = { documentIds: string[] }` — all consumed by Task 3 and Task 4.
+
+- [ ] **Step 1: Write the failing property-based test for the schema**
+
+Create `packages/schemas/src/test/campaign-document-payload.test.ts`:
+
+```ts
+import { fc, test } from '@fast-check/vitest';
+import { describe, expect } from 'vitest';
+
+import { campaignDocumentPayload } from '../campaign-document-payload';
+
+describe('Campaign document payload', () => {
+  test.prop({
+    documentIds: fc.array(fc.uuid({ version: 4 }), {
+      minLength: 1,
+      maxLength: 10
+    })
+  })('should validate valid document IDs', (payload) => {
+    const validate = () => campaignDocumentPayload.validateSync(payload);
+
+    expect(validate).not.toThrow();
+  });
+
+  test.prop({
+    documentIds: fc.constantFrom([], undefined, null)
+  })('should reject empty or missing document IDs', (documentIds) => {
+    const validate = () =>
+      campaignDocumentPayload.validateSync({ documentIds });
+
+    expect(validate).toThrow();
+  });
+
+  test.prop({
+    documentIds: fc.array(fc.string(), { minLength: 1, maxLength: 5 })
+  })('should reject non-UUID document IDs', (payload) => {
+    const validate = () => campaignDocumentPayload.validateSync(payload);
+
+    expect(validate).toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `yarn nx test schemas -- campaign-document-payload.test.ts`
+Expected: FAIL — cannot find module `../campaign-document-payload`.
+
+- [ ] **Step 3: Implement the schema**
+
+Create `packages/schemas/src/campaign-document-payload.ts`:
+
+```ts
+import { DocumentDTO } from '@zerologementvacant/models';
+import { array, object, type ObjectSchema, string } from 'yup';
+
+export interface CampaignDocumentPayload {
+  documentIds: Array<DocumentDTO['id']>;
+}
+
+export const campaignDocumentPayload: ObjectSchema<CampaignDocumentPayload> =
+  object({
+    documentIds: array().of(string().uuid().required()).min(1).required()
+  });
+```
+
+Modify `packages/schemas/src/index.ts` — add the import, register in the `schemas` object, and export the type:
+
+```ts
+import { buildingFilters } from './building-filters';
+import { campaignCreationPayload } from './campaign-creation-payload';
+import { campaignDocumentPayload } from './campaign-document-payload';
+import { campaignFilters } from './campaign-filters';
+import { campaignUpdateNextPayload } from './campaign-update-next-payload';
+import { dateString } from './date-string';
+import { documentPayload } from './document-payload';
+import { draft } from './draft';
+import {
+  draftCreationPayload,
+  sender,
+  signatory
+} from './draft-creation-payload';
+import { draftUpdatePayload } from './draft-update-payload';
+import { email } from './email';
+import { establishmentFilters } from './establishment-filters';
+import { geoCode } from './geo-code';
+import { groupCreationPayload } from './group-creation-payload';
+import { groupHousingPayload } from './group-housing-payload';
+import { housingBatchUpdatePayload } from './housing-batch-update-payload';
+import { housingDocumentPayload } from './housing-document-payload';
+import { housingFilters } from './housing-filters';
+import { housingUpdatePayload } from './housing-update-payload';
+import { id } from './id';
+import { notePayload } from './note-payload';
+import { ownerFilters } from './owner-filters';
+import { ownerPayload } from './owner-payload';
+import { pagination } from './pagination';
+import { password, passwordConfirmation } from './password';
+import { phone } from './phone';
+import { signIn } from './sign-in';
+import { siren } from './siren';
+import { sort } from './sort';
+import { userFilters } from './user-filters';
+import { userUpdatePayload } from './user-update-payload';
+
+const schemas = {
+  buildingFilters,
+  campaignCreationPayload,
+  campaignDocumentPayload,
+  campaignFilters,
+  campaignUpdateNextPayload,
+  dateString,
+  documentPayload,
+  draft,
+  draftCreationPayload,
+  draftUpdatePayload,
+  email,
+  establishmentFilters,
+  geoCode,
+  groupCreationPayload,
+  groupHousingPayload,
+  housingBatchUpdatePayload,
+  housingDocumentPayload,
+  housingFilters,
+  housingUpdatePayload,
+  id,
+  notePayload,
+  ownerFilters,
+  ownerPayload,
+  pagination,
+  password,
+  passwordConfirmation,
+  phone,
+  sender,
+  signatory,
+  signIn,
+  siren,
+  sort,
+  userFilters,
+  userUpdatePayload
+};
+
+export { GEO_CODE_REGEXP } from './geo-code';
+export { type CampaignDocumentPayload } from './campaign-document-payload';
+export { type HousingDocumentPayload } from './housing-document-payload';
+export { MAX_PER_PAGE } from './pagination';
+export { PHONE_REGEXP } from './phone';
+export { SIREN_REGEXP } from './siren';
+
+export default schemas;
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `yarn nx test schemas -- campaign-document-payload.test.ts`
+Expected: PASS (3 property-based tests).
+
+- [ ] **Step 5: Add `CampaignDocumentDTO`, register it, and add the new event types**
+
+Create `packages/models/src/CampaignDocumentDTO.ts`:
+
+```ts
+import type { DocumentDTO } from './DocumentDTO';
+
+export type CampaignDocumentDTO = DocumentDTO;
+```
+
+Modify `packages/models/src/index.ts` — add the export right after `CampaignDTO`:
+
+```ts
+export * from './CampaignDTO';
+export * from './CampaignDocumentDTO';
+```
+
+Modify `packages/models/src/EventType.ts` — add the 3 new type strings after `'housing:document-removed'`:
+
+```ts
+export const EVENT_TYPE_VALUES = [
+  'housing:created',
+  'housing:updated',
+  'housing:occupancy-updated',
+  'housing:status-updated',
+  'housing:precision-attached',
+  'housing:precision-detached',
+  'housing:owner-attached',
+  'housing:owner-updated',
+  'housing:owner-detached',
+  'housing:perimeter-attached',
+  'housing:perimeter-detached',
+  'housing:group-attached',
+  'housing:group-detached',
+  'housing:group-removed',
+  'housing:campaign-attached',
+  'housing:campaign-detached',
+  'housing:campaign-removed',
+  'housing:document-attached',
+  'housing:document-detached',
+  'housing:document-removed',
+  'document:created',
+  'document:updated',
+  'document:removed',
+  'campaign:document-attached',
+  'campaign:document-detached',
+  'campaign:document-removed',
+  'owner:updated',
+  'campaign:updated'
+] as const satisfies ReadonlyArray<EventType>;
+```
+
+Modify `packages/models/src/EventPayloads.ts` — add the 3 new payload shapes right after the `'housing:document-removed'` entry (around line 137):
+
+```ts
+  // Campaign-document association events
+  'campaign:document-attached': CreationEventChange<{
+    filename: string;
+  }>;
+
+  'campaign:document-detached': RemoveEventChange<{
+    filename: string;
+  }>;
+
+  'campaign:document-removed': RemoveEventChange<{
+    filename: string;
+  }>;
+```
+
+- [ ] **Step 6: Typecheck**
+
+Run: `yarn nx run-many -t typecheck`
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/models/src/CampaignDocumentDTO.ts packages/models/src/index.ts packages/models/src/EventType.ts packages/models/src/EventPayloads.ts packages/schemas/src/campaign-document-payload.ts packages/schemas/src/test/campaign-document-payload.test.ts packages/schemas/src/index.ts
+git commit -m "feat: add CampaignDocumentDTO, campaign-document event types, and payload schema"
+```
+
+---
+
+### Task 3: Migrations + `CampaignDocumentApi` + `campaignDocumentRepository`
+
+**Files:**
+
+- Create: `server/src/infra/database/migrations/20260720100000_documents-campaigns.ts`
+- Create: `server/src/infra/database/migrations/20260720100001_campaign-document-events.ts`
+- Create: `server/src/models/CampaignDocumentApi.ts`
+- Modify: `server/src/test/testFixtures.ts`
+- Create: `server/src/repositories/test/campaignDocumentRepository.test.ts`
+- Create: `server/src/repositories/campaignDocumentRepository.ts`
+
+**Interfaces:**
+
+- Consumes: `CampaignDocumentDTO` (Task 2), `DocumentApi`/`toDocumentDTO`/`documentRepository` internals (existing).
+- Produces: `campaignDocumentRepository.{link, linkMany, unlink, unlinkMany, find, get, remove}`, `CampaignDocumentApi { ...DocumentApi, campaignId: string }`, `toCampaignDocumentDTO`, `genCampaignDocumentApi()` fixture — all consumed by Task 4.
+
+- [ ] **Step 1: Create the migrations**
+
+Create `server/src/infra/database/migrations/20260720100000_documents-campaigns.ts`:
+
+```ts
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.createTable('documents_campaigns', (table) => {
+    table.uuid('document_id').notNullable();
+    table.uuid('campaign_id').notNullable();
+
+    table.primary(['document_id', 'campaign_id']);
+    table
+      .foreign('document_id')
+      .references('id')
+      .inTable('documents')
+      .onUpdate('CASCADE')
+      .onDelete('CASCADE');
+    table
+      .foreign('campaign_id')
+      .references('id')
+      .inTable('campaigns')
+      .onUpdate('CASCADE')
+      .onDelete('CASCADE');
+    table.index('campaign_id');
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTable('documents_campaigns');
+}
+```
+
+Create `server/src/infra/database/migrations/20260720100001_campaign-document-events.ts`:
+
+```ts
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.createTable('campaign_document_events', (table) => {
+    table
+      .uuid('event_id')
+      .primary()
+      .references('id')
+      .inTable('events')
+      .onDelete('CASCADE');
+    table
+      .uuid('document_id')
+      .notNullable()
+      .references('id')
+      .inTable('documents')
+      .onDelete('CASCADE');
+    table
+      .uuid('campaign_id')
+      .notNullable()
+      .references('id')
+      .inTable('campaigns')
+      .onDelete('CASCADE');
+
+    table.index('document_id');
+    table.index('campaign_id');
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTable('campaign_document_events');
+}
+```
+
+Run the migrations against the local/test databases:
+
+```bash
+export DEV_DB=postgres://postgres:postgres@localhost/dev
+export TEST_DB=postgres://postgres:postgres@localhost/test
+yarn workspace @zerologementvacant/server migrate
+```
+
+- [ ] **Step 2: Add the `CampaignDocumentApi` model**
+
+Create `server/src/models/CampaignDocumentApi.ts`:
+
+```ts
+import { CampaignDocumentDTO } from '@zerologementvacant/models';
+
+import {
+  DocumentApi,
+  toDocumentDTO,
+  type FetchDocumentURLOptions
+} from './DocumentApi';
+
+export interface CampaignDocumentApi extends DocumentApi {
+  campaignId: string;
+}
+
+export async function toCampaignDocumentDTO(
+  document: CampaignDocumentApi,
+  options: FetchDocumentURLOptions
+): Promise<CampaignDocumentDTO> {
+  return toDocumentDTO(document, options);
+}
+```
+
+- [ ] **Step 3: Add the `genCampaignDocumentApi` fixture**
+
+Modify `server/src/test/testFixtures.ts` — add this function right after `genHousingDocumentApi` (around line 583), and add `import { CampaignDocumentApi } from '~/models/CampaignDocumentApi';` near the other model imports at the top of the file:
+
+```ts
+export function genCampaignDocumentApi(
+  overrides?: Partial<CampaignDocumentApi>
+): CampaignDocumentApi {
+  const baseDocument = genDocumentApi(overrides);
+
+  return {
+    ...baseDocument,
+    campaignId: overrides?.campaignId ?? faker.string.uuid()
+  };
+}
+```
+
+- [ ] **Step 4: Write the failing repository test**
+
+Create `server/src/repositories/test/campaignDocumentRepository.test.ts`:
+
+```ts
+import { faker } from '@faker-js/faker/locale/fr';
+
+import { CampaignApi } from '~/models/CampaignApi';
+import { CampaignDocumentApi } from '~/models/CampaignDocumentApi';
+import campaignDocumentRepository, {
+  CampaignDocuments,
+  toCampaignDocumentDBO,
+  type CampaignDocumentDBO
+} from '~/repositories/campaignDocumentRepository';
+import { Documents, toDocumentDBO } from '~/repositories/documentRepository';
+import {
+  Establishments,
+  formatEstablishmentApi
+} from '~/repositories/establishmentRepository';
+import { toUserDBO, Users } from '~/repositories/userRepository';
+import { factories } from '~/test/factories';
+import {
+  genCampaignDocumentApi,
+  genEstablishmentApi,
+  genUserApi
+} from '~/test/testFixtures';
+
+describe('Campaign document repository', () => {
+  const establishment = genEstablishmentApi();
+  const user = genUserApi(establishment.id);
+
+  beforeAll(async () => {
+    await Establishments().insert(formatEstablishmentApi(establishment));
+    await Users().insert(toUserDBO(user));
+  });
+
+  describe('link', () => {
+    it('should create document-campaign link', async () => {
+      const campaign = await factories
+        .campaign(establishment)
+        .create({}, { associations: { createdBy: user } });
+
+      const campaignDocument = genCampaignDocumentApi({
+        createdBy: user.id,
+        creator: user,
+        campaignId: campaign.id
+      });
+      await Documents().insert(toDocumentDBO(campaignDocument));
+
+      await campaignDocumentRepository.link(campaignDocument);
+
+      const actual = await CampaignDocuments()
+        .where('document_id', campaignDocument.id)
+        .first();
+
+      expect(actual).toMatchObject({
+        document_id: campaignDocument.id,
+        campaign_id: campaign.id
+      });
+    });
+
+    it('should be idempotent (ignore duplicate links)', async () => {
+      const campaign = await factories
+        .campaign(establishment)
+        .create({}, { associations: { createdBy: user } });
+
+      const campaignDocument = genCampaignDocumentApi({
+        createdBy: user.id,
+        creator: user,
+        campaignId: campaign.id
+      });
+      await Documents().insert(toDocumentDBO(campaignDocument));
+
+      await campaignDocumentRepository.link(campaignDocument);
+      await campaignDocumentRepository.link(campaignDocument);
+
+      const actual = await CampaignDocuments().where(
+        'document_id',
+        campaignDocument.id
+      );
+      expect(actual).toHaveLength(1);
+    });
+  });
+
+  describe('linkMany', () => {
+    it('should create multiple document-campaign links (cartesian product)', async () => {
+      const campaigns = await factories
+        .campaign(establishment)
+        .createList(2, {}, { associations: { createdBy: user } });
+
+      const campaignDocuments = [
+        genCampaignDocumentApi({ createdBy: user.id, creator: user }),
+        genCampaignDocumentApi({ createdBy: user.id, creator: user })
+      ];
+      await Documents().insert(campaignDocuments.map(toDocumentDBO));
+
+      const links = campaignDocuments.flatMap((d) =>
+        campaigns.map((c) => ({
+          document_id: d.id,
+          campaign_id: c.id
+        }))
+      );
+      await campaignDocumentRepository.linkMany(links);
+
+      const allLinks = await CampaignDocuments().whereIn(
+        'document_id',
+        campaignDocuments.map((d) => d.id)
+      );
+
+      expect(allLinks).toHaveLength(4);
+    });
+
+    it('should handle empty arrays', async () => {
+      await expect(
+        campaignDocumentRepository.linkMany([])
+      ).resolves.not.toThrow();
+    });
+  });
+
+  describe('unlink', () => {
+    it('should remove document-campaign link', async () => {
+      const campaign = await factories
+        .campaign(establishment)
+        .create({}, { associations: { createdBy: user } });
+
+      const campaignDocument = genCampaignDocumentApi({
+        createdBy: user.id,
+        creator: user,
+        campaignId: campaign.id
+      });
+      await Documents().insert(toDocumentDBO(campaignDocument));
+
+      const linkDBO: CampaignDocumentDBO = {
+        document_id: campaignDocument.id,
+        campaign_id: campaign.id
+      };
+      await CampaignDocuments().insert(linkDBO);
+
+      await campaignDocumentRepository.unlink({
+        documentId: campaignDocument.id,
+        campaignId: campaign.id
+      });
+
+      const actual = await CampaignDocuments().where(
+        'document_id',
+        campaignDocument.id
+      );
+      expect(actual).toHaveLength(0);
+    });
+  });
+
+  describe('get', () => {
+    let campaign: CampaignApi;
+    let document: CampaignDocumentApi;
+
+    beforeAll(async () => {
+      campaign = await factories
+        .campaign(establishment)
+        .create({}, { associations: { createdBy: user } });
+      document = genCampaignDocumentApi({
+        createdBy: user.id,
+        creator: user,
+        campaignId: campaign.id
+      });
+      await Documents().insert(toDocumentDBO(document));
+      await CampaignDocuments().insert(toCampaignDocumentDBO(document));
+    });
+
+    it('should return null if the document is missing', async () => {
+      const actual = await campaignDocumentRepository.get(faker.string.uuid());
+
+      expect(actual).toBeNull();
+    });
+
+    it('should return the document if it exists', async () => {
+      const actual = await campaignDocumentRepository.get(document.id);
+
+      expect(actual).toBeDefined();
+      expect(actual).toMatchObject<Partial<CampaignDocumentApi>>({
+        id: document.id,
+        filename: document.filename,
+        s3Key: document.s3Key,
+        contentType: document.contentType,
+        sizeBytes: document.sizeBytes,
+        campaignId: campaign.id,
+        createdBy: user.id
+      });
+    });
+
+    it('should include creator information', async () => {
+      const actual = await campaignDocumentRepository.get(document.id);
+
+      expect(actual).toBeDefined();
+      expect(actual!.creator).toBeDefined();
+      expect(actual!.creator.id).toBe(user.id);
+      expect(actual!.creator.email).toBe(user.email);
+    });
+
+    it('should return null when campaign does not match', async () => {
+      const differentCampaign = await factories
+        .campaign(establishment)
+        .create({}, { associations: { createdBy: user } });
+
+      const actual = await campaignDocumentRepository.get(document.id, {
+        campaign: [differentCampaign.id]
+      });
+
+      expect(actual).toBeNull();
+    });
+  });
+
+  describe('remove', () => {
+    it('should soft-delete the document', async () => {
+      const campaign = await factories
+        .campaign(establishment)
+        .create({}, { associations: { createdBy: user } });
+      const document = genCampaignDocumentApi({
+        createdBy: user.id,
+        creator: user,
+        campaignId: campaign.id
+      });
+      await Documents().insert(toDocumentDBO(document));
+      await CampaignDocuments().insert(toCampaignDocumentDBO(document));
+
+      await campaignDocumentRepository.remove(document);
+
+      const actualDocument = await Documents()
+        .where({ id: document.id })
+        .first();
+
+      expect(actualDocument).toBeDefined();
+      expect(actualDocument!.deleted_at).not.toBeNull();
+
+      const actualLink = await CampaignDocuments()
+        .where({ document_id: document.id, campaign_id: campaign.id })
+        .first();
+
+      expect(actualLink).toBeDefined();
+    });
+  });
+
+  describe('unlinkMany', () => {
+    it('should unlink multiple documents from all campaigns', async () => {
+      const campaigns = await factories
+        .campaign(establishment)
+        .createList(2, {}, { associations: { createdBy: user } });
+      const campaignDocuments = [
+        genCampaignDocumentApi({ createdBy: user.id, creator: user }),
+        genCampaignDocumentApi({ createdBy: user.id, creator: user })
+      ];
+
+      await Documents().insert(campaignDocuments.map(toDocumentDBO));
+
+      const links = campaignDocuments.flatMap((doc) =>
+        campaigns.map((c) => ({
+          document_id: doc.id,
+          campaign_id: c.id
+        }))
+      );
+      await campaignDocumentRepository.linkMany(links);
+
+      const linksBefore = await CampaignDocuments().whereIn(
+        'document_id',
+        campaignDocuments.map((doc) => doc.id)
+      );
+      expect(linksBefore).toHaveLength(4);
+
+      await campaignDocumentRepository.unlinkMany({
+        documentIds: campaignDocuments.map((doc) => doc.id)
+      });
+
+      const linksAfter = await CampaignDocuments().whereIn(
+        'document_id',
+        campaignDocuments.map((doc) => doc.id)
+      );
+      expect(linksAfter).toBeEmpty();
+    });
+
+    it('should handle empty array', async () => {
+      await expect(
+        campaignDocumentRepository.unlinkMany({ documentIds: [] })
+      ).resolves.not.toThrow();
+    });
+
+    it('should only unlink specified documents', async () => {
+      const campaign = await factories
+        .campaign(establishment)
+        .create({}, { associations: { createdBy: user } });
+      const documents = [
+        genCampaignDocumentApi({
+          createdBy: user.id,
+          creator: user,
+          campaignId: campaign.id
+        }),
+        genCampaignDocumentApi({
+          createdBy: user.id,
+          creator: user,
+          campaignId: campaign.id
+        })
+      ];
+
+      await Documents().insert(documents.map(toDocumentDBO));
+
+      const links = documents.map((doc) => ({
+        document_id: doc.id,
+        campaign_id: campaign.id
+      }));
+      await campaignDocumentRepository.linkMany(links);
+
+      await campaignDocumentRepository.unlinkMany({
+        documentIds: [documents[0].id]
+      });
+
+      const remainingLinks = await CampaignDocuments().where({
+        campaign_id: campaign.id
+      });
+      expect(remainingLinks).toHaveLength(1);
+      expect(remainingLinks[0].document_id).toBe(documents[1].id);
+    });
+  });
+});
+```
+
+**Note on factories**: `campaign` is created via `factories.campaign(establishment).create(...)`/`.createList(...)` from `~/test/factories` (the server-side fishery factory, already used this way in `campaignRepository.test.ts`) rather than `genCampaignApi` + a manual `Campaigns().insert(...)` — the factory does both in one call. `establishment`/`user` stay on `genEstablishmentApi()`/`genUserApi()` + manual insert, matching the actual convention in every migrated file today (no test in this codebase calls `factories.establishment`/`factories.user` yet — only the entity under test gets the factory treatment). `genCampaignDocumentApi` also stays as-is: no `document`/`campaignDocument` factory exists anywhere in this codebase, and the factories migration's own design docs explicitly list documents as out of scope.
+
+- [ ] **Step 5: Run the test to verify it fails**
+
+Run: `yarn nx test server -- campaignDocumentRepository.test.ts`
+Expected: FAIL — cannot find module `~/repositories/campaignDocumentRepository`.
+
+- [ ] **Step 6: Implement `campaignDocumentRepository.ts`**
+
+Create `server/src/repositories/campaignDocumentRepository.ts`:
+
+```ts
+import type { Knex } from 'knex';
+
+import db from '~/infra/database';
+import { withinTransaction } from '~/infra/database/transaction';
+import { createLogger } from '~/infra/logger';
+import { CampaignApi } from '~/models/CampaignApi';
+import { CampaignDocumentApi } from '~/models/CampaignDocumentApi';
+import { UserDBO, USERS_TABLE } from '~/repositories/userRepository';
+
+import {
+  Documents,
+  DOCUMENTS_TABLE,
+  fromDocumentDBO,
+  type DocumentDBO
+} from './documentRepository';
+
+const logger = createLogger('campaignDocumentRepository');
+
+export const CAMPAIGN_DOCUMENT_TABLE = 'documents_campaigns';
+
+export const CampaignDocuments = (
+  transaction: Knex<CampaignDocumentDBO> = db
+) => transaction<CampaignDocumentDBO>(CAMPAIGN_DOCUMENT_TABLE);
+
+export interface CampaignDocumentDBO {
+  document_id: string;
+  campaign_id: string;
+}
+
+type CampaignDocumentWithCreatorDBO = DocumentDBO &
+  CampaignDocumentDBO & {
+    creator: UserDBO;
+  };
+
+async function link(document: CampaignDocumentApi): Promise<void> {
+  logger.debug('Creating document-campaign link', {
+    documentId: document.id,
+    campaignId: document.campaignId
+  });
+
+  await withinTransaction(async (transaction) => {
+    await CampaignDocuments(transaction)
+      .insert(toCampaignDocumentDBO(document))
+      .onConflict(['document_id', 'campaign_id'])
+      .ignore();
+  });
+}
+
+async function linkMany(
+  campaignDocuments: ReadonlyArray<CampaignDocumentDBO>
+): Promise<void> {
+  if (campaignDocuments.length === 0) {
+    logger.debug('No campaign documents to link. Skipping...');
+    return;
+  }
+
+  logger.debug('Linking documents to campaigns...', { campaignDocuments });
+
+  await withinTransaction(async (transaction) => {
+    await CampaignDocuments(transaction)
+      .insert(campaignDocuments)
+      .onConflict(['document_id', 'campaign_id'])
+      .ignore();
+  });
+}
+
+async function unlink(link: {
+  documentId: string;
+  campaignId: string;
+}): Promise<void> {
+  logger.debug('Unlinking document from campaign...', link);
+
+  await CampaignDocuments()
+    .where({
+      document_id: link.documentId,
+      campaign_id: link.campaignId
+    })
+    .delete();
+}
+
+async function unlinkMany(params: { documentIds: string[] }): Promise<void> {
+  if (!params.documentIds.length) {
+    logger.debug('No documents to unlink. Skipping...');
+    return;
+  }
+
+  logger.debug('Unlinking documents from campaigns...', {
+    documents: params.documentIds.length
+  });
+
+  await withinTransaction(async (transaction) => {
+    await CampaignDocuments(transaction)
+      .whereIn('document_id', params.documentIds)
+      .delete();
+  });
+
+  logger.debug('Documents unlinked from campaigns', {
+    documents: params.documentIds.length
+  });
+}
+
+interface FindOptions {
+  filters?: {
+    documentIds?: string[];
+    campaignIds?: Array<CampaignApi['id']>;
+    deleted?: boolean;
+  };
+}
+
+async function find(
+  options?: FindOptions
+): Promise<ReadonlyArray<CampaignDocumentApi>> {
+  logger.debug('Finding document-campaign links...', options);
+
+  const documents = await listQuery()
+    .modify((query) => {
+      if (options?.filters?.documentIds?.length) {
+        query.whereIn(
+          `${CAMPAIGN_DOCUMENT_TABLE}.document_id`,
+          options.filters.documentIds
+        );
+      }
+
+      if (options?.filters?.campaignIds?.length) {
+        query.whereIn(
+          `${CAMPAIGN_DOCUMENT_TABLE}.campaign_id`,
+          options.filters.campaignIds
+        );
+      }
+
+      if (options?.filters?.deleted === true) {
+        query.whereNotNull(`${DOCUMENTS_TABLE}.deleted_at`);
+      } else if (options?.filters?.deleted === false) {
+        query.whereNull(`${DOCUMENTS_TABLE}.deleted_at`);
+      }
+    })
+    .orderBy(`${DOCUMENTS_TABLE}.created_at`, 'desc');
+
+  return documents.map(fromCampaignDocumentDBO);
+}
+
+interface GetOptions {
+  campaign?: Array<CampaignApi['id']>;
+}
+
+async function get(
+  id: string,
+  options?: GetOptions
+): Promise<CampaignDocumentApi | null> {
+  logger.debug('Getting campaign document...', { id });
+  const document = await listQuery()
+    .where(`${CAMPAIGN_DOCUMENT_TABLE}.document_id`, id)
+    .modify((query) => {
+      if (options?.campaign?.length) {
+        query.whereIn(
+          `${CAMPAIGN_DOCUMENT_TABLE}.campaign_id`,
+          options.campaign
+        );
+      }
+    })
+    .first();
+
+  return document ? fromCampaignDocumentDBO(document) : null;
+}
+
+async function remove(document: CampaignDocumentApi): Promise<void> {
+  logger.debug('Soft-deleting campaign document...', document);
+  await Documents().where('id', document.id).update({ deleted_at: new Date() });
+}
+
+function listQuery() {
+  return Documents()
+    .select(
+      `${DOCUMENTS_TABLE}.*`,
+      `${CAMPAIGN_DOCUMENT_TABLE}.campaign_id`,
+      db.raw(`json_build_object(
+        'id', ${USERS_TABLE}.id,
+        'email', ${USERS_TABLE}.email,
+        'first_name', ${USERS_TABLE}.first_name,
+        'last_name', ${USERS_TABLE}.last_name,
+        'role', ${USERS_TABLE}.role,
+        'establishment_id', ${USERS_TABLE}.establishment_id,
+        'time_per_week', ${USERS_TABLE}.time_per_week,
+        'phone', ${USERS_TABLE}.phone,
+        'position', ${USERS_TABLE}.position,
+        'updated_at', ${USERS_TABLE}.updated_at
+      ) as creator`)
+    )
+    .join(
+      CAMPAIGN_DOCUMENT_TABLE,
+      `${CAMPAIGN_DOCUMENT_TABLE}.document_id`,
+      `${DOCUMENTS_TABLE}.id`
+    )
+    .join(USERS_TABLE, `${USERS_TABLE}.id`, `${DOCUMENTS_TABLE}.created_by`);
+}
+
+export function toCampaignDocumentDBO(
+  document: CampaignDocumentApi
+): CampaignDocumentDBO {
+  return {
+    document_id: document.id,
+    campaign_id: document.campaignId
+  };
+}
+
+export function fromCampaignDocumentDBO(
+  dbo: CampaignDocumentWithCreatorDBO
+): CampaignDocumentApi {
+  if (!dbo.creator) {
+    throw new Error('Creator not fetched');
+  }
+
+  return {
+    ...fromDocumentDBO(dbo),
+    campaignId: dbo.campaign_id
+  };
+}
+
+const campaignDocumentRepository = {
+  link,
+  linkMany,
+  unlink,
+  unlinkMany,
+  find,
+  get,
+  remove
+};
+
+export default campaignDocumentRepository;
+```
+
+- [ ] **Step 7: Run the test to verify it passes**
+
+Run: `yarn nx test server -- campaignDocumentRepository.test.ts`
+Expected: PASS (all describe blocks).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add server/src/infra/database/migrations/20260720100000_documents-campaigns.ts server/src/infra/database/migrations/20260720100001_campaign-document-events.ts server/src/models/CampaignDocumentApi.ts server/src/test/testFixtures.ts server/src/repositories/campaignDocumentRepository.ts server/src/repositories/test/campaignDocumentRepository.test.ts
+git commit -m "feat: add documents_campaigns junction table and campaignDocumentRepository"
+```
+
+---
+
+### Task 4: Events plumbing + controller + router
+
+**Files:**
+
+- Modify: `server/src/models/EventApi.ts`
+- Modify: `server/src/repositories/eventRepository.ts`
+- Modify: `server/src/controllers/test/document-api.test.ts`
+- Modify: `server/src/controllers/documentController.ts`
+- Modify: `server/src/routers/protected.ts`
+
+**Interfaces:**
+
+- Consumes: `campaignDocumentRepository` (Task 3), `campaignDocumentPayload` schema (Task 2), `campaignRepository.findOne({id, establishmentId})` (existing), `CampaignMissingError` (existing).
+- Produces: `documentController.{linkToCampaign, listByCampaign, removeByCampaign}`, routes `GET/POST /campaigns/:id/documents`, `DELETE /campaigns/:id/documents/:documentId` — consumed by Task 5 (frontend).
+
+- [ ] **Step 1: Add `CampaignDocumentEventApi` and the eventRepository plumbing**
+
+Modify `server/src/models/EventApi.ts` — add this type right after `HousingDocumentEventApi` (around line 120):
+
+```ts
+// Campaign-document association events
+export type CampaignDocumentEventApi = EventUnion<
+  | 'campaign:document-attached'
+  | 'campaign:document-detached'
+  | 'campaign:document-removed'
+> & {
+  campaignId: string;
+  documentId: string;
+};
+```
+
+Modify `server/src/repositories/eventRepository.ts`:
+
+Add to the import from `~/models/EventApi` (alphabetically, after `CampaignHousingEventApi`):
+
+```ts
+import {
+  CampaignDocumentEventApi,
+  CampaignEventApi,
+  CampaignHousingEventApi,
+  DocumentEventApi,
+  EventApi,
+  EventUnion,
+  GroupHousingEventApi,
+  HousingDocumentEventApi,
+  HousingEventApi,
+  HousingOwnerEventApi,
+  OwnerEventApi,
+  PerimeterHousingEventApi,
+  PrecisionHousingEventApi
+} from '~/models/EventApi';
+```
+
+Add the table constant and accessor, near the other document ones (after `HOUSING_DOCUMENT_EVENTS_TABLE`/`HousingDocumentEvents`):
+
+```ts
+export const CAMPAIGN_DOCUMENT_EVENTS_TABLE = 'campaign_document_events';
+
+export const CampaignDocumentEvents = (transaction = db) =>
+  transaction<CampaignDocumentEventDBO>(CAMPAIGN_DOCUMENT_EVENTS_TABLE);
+```
+
+Add the insert function, right after `insertManyHousingDocumentEvents`:
+
+```ts
+async function insertManyCampaignDocumentEvents(
+  events: ReadonlyArray<CampaignDocumentEventApi>
+): Promise<void> {
+  if (!events.length) {
+    return;
+  }
+
+  logger.debug('Inserting campaign document events...', {
+    events: events.length
+  });
+  await withinTransaction(async (transaction) => {
+    await transaction.batchInsert(EVENTS_TABLE, events.map(formatEventApi));
+    await transaction.batchInsert(
+      CAMPAIGN_DOCUMENT_EVENTS_TABLE,
+      events.map(formatCampaignDocumentEventApi)
+    );
+  });
+}
+```
+
+Add the DBO type and formatter, right after `formatHousingDocumentEventApi`:
+
+```ts
+export interface CampaignDocumentEventDBO {
+  event_id: string;
+  campaign_id: string;
+  document_id: string;
+}
+
+export function formatCampaignDocumentEventApi(
+  event: CampaignDocumentEventApi
+): CampaignDocumentEventDBO {
+  return {
+    event_id: event.id,
+    campaign_id: event.campaignId,
+    document_id: event.documentId
+  };
+}
+```
+
+Register the new function in the default export:
+
+```ts
+export default {
+  insertManyCampaignEvents,
+  insertManyCampaignHousingEvents,
+  insertManyCampaignDocumentEvents,
+  insertManyHousingEvents,
+  insertManyHousingOwnerEvents,
+  insertManyGroupHousingEvents,
+  insertManyOwnerEvents,
+  insertManyPrecisionHousingEvents,
+  insertManyDocumentEvents,
+  insertManyHousingDocumentEvents,
+  find,
+  removeCampaignEvents
+};
+```
+
+- [ ] **Step 2: Write the failing controller tests**
+
+Modify `server/src/controllers/test/document-api.test.ts`. Add one new import, and replace the existing `eventRepository`/`testFixtures` import lines with their merged versions below (don't leave the old, narrower versions of those two lines in place — and drop `genCampaignApi`, it's no longer needed once campaigns are created via the factory):
+
+```ts
+import { CampaignDocuments } from '~/repositories/campaignDocumentRepository';
+import {
+  CAMPAIGN_DOCUMENT_EVENTS_TABLE,
+  DOCUMENT_EVENTS_TABLE,
+  Events,
+  EVENTS_TABLE,
+  HOUSING_DOCUMENT_EVENTS_TABLE,
+  type EventDBO
+} from '~/repositories/eventRepository';
+```
+
+This replaces the file's existing `eventRepository` import line. Also add `import { factories } from '~/test/factories';` and replace the existing `testFixtures` import line with:
+
+```ts
+import {
+  genDocumentApi,
+  genEstablishmentApi,
+  genHousingApi,
+  genUserApi
+} from '~/test/testFixtures';
+```
+
+Add these `describe` blocks at the end of the file, right before the final closing `});` of `describe('Document API', ...)`:
+
+```ts
+describe('POST /campaigns/:id/documents', () => {
+  const testRoute = (id: string) => `/campaigns/${id}/documents`;
+
+  it('should link documents to campaign', async () => {
+    const campaign = await factories
+      .campaign(establishment)
+      .create({}, { associations: { createdBy: user } });
+    const document = genDocumentApi({
+      createdBy: user.id,
+      creator: user,
+      establishmentId: establishment.id
+    });
+    await Documents().insert(toDocumentDBO(document));
+
+    const { status, body } = await request(url)
+      .post(testRoute(campaign.id))
+      .use(tokenProvider(user))
+      .send({ documentIds: [document.id] });
+
+    expect(status).toBe(constants.HTTP_STATUS_CREATED);
+    expect(body).toHaveLength(1);
+    expect(body[0]).toMatchObject({ id: document.id });
+  });
+
+  it('should create an event "campaign:document-attached"', async () => {
+    const campaign = await factories
+      .campaign(establishment)
+      .create({}, { associations: { createdBy: user } });
+    const document = genDocumentApi({
+      createdBy: user.id,
+      creator: user,
+      establishmentId: establishment.id
+    });
+    await Documents().insert(toDocumentDBO(document));
+
+    const { status } = await request(url)
+      .post(testRoute(campaign.id))
+      .use(tokenProvider(user))
+      .send({ documentIds: [document.id] });
+
+    expect(status).toBe(constants.HTTP_STATUS_CREATED);
+    const event = await Events()
+      .where({ type: 'campaign:document-attached' })
+      .join(
+        CAMPAIGN_DOCUMENT_EVENTS_TABLE,
+        `${CAMPAIGN_DOCUMENT_EVENTS_TABLE}.event_id`,
+        `${EVENTS_TABLE}.id`
+      )
+      .where(`${CAMPAIGN_DOCUMENT_EVENTS_TABLE}.document_id`, document.id)
+      .first();
+    expect(event).toMatchObject<
+      Partial<EventDBO<'campaign:document-attached'>>
+    >({
+      type: 'campaign:document-attached',
+      next_old: null,
+      next_new: { filename: document.filename },
+      created_by: user.id
+    });
+  });
+
+  it('should return 404 if campaign not found', async () => {
+    const { status } = await request(url)
+      .post(testRoute(faker.string.uuid()))
+      .use(tokenProvider(user))
+      .send({ documentIds: [faker.string.uuid()] });
+
+    expect(status).toBe(constants.HTTP_STATUS_NOT_FOUND);
+  });
+
+  it('should return 404 if campaign belongs to another establishment', async () => {
+    const campaign = await factories
+      .campaign(anotherEstablishment)
+      .create(
+        {},
+        { associations: { createdBy: userFromAnotherEstablishment } }
+      );
+    const document = genDocumentApi({
+      createdBy: userFromAnotherEstablishment.id,
+      creator: userFromAnotherEstablishment,
+      establishmentId: anotherEstablishment.id
+    });
+    await Documents().insert(toDocumentDBO(document));
+
+    const { status } = await request(url)
+      .post(testRoute(campaign.id))
+      .use(tokenProvider(user))
+      .send({ documentIds: [document.id] });
+
+    expect(status).toBe(constants.HTTP_STATUS_NOT_FOUND);
+  });
+
+  it('should return 403 for a visitor', async () => {
+    const campaign = await factories
+      .campaign(establishment)
+      .create({}, { associations: { createdBy: user } });
+    const document = genDocumentApi({
+      createdBy: user.id,
+      creator: user,
+      establishmentId: establishment.id
+    });
+    await Documents().insert(toDocumentDBO(document));
+
+    const { status } = await request(url)
+      .post(testRoute(campaign.id))
+      .use(tokenProvider(visitor))
+      .send({ documentIds: [document.id] });
+
+    expect(status).toBe(constants.HTTP_STATUS_FORBIDDEN);
+  });
+});
+
+describe('GET /campaigns/:id/documents', () => {
+  const testRoute = (id: string) => `/campaigns/${id}/documents`;
+
+  it('should return 200 OK with documents list', async () => {
+    const campaign = await factories
+      .campaign(establishment)
+      .create({}, { associations: { createdBy: user } });
+    const document = genDocumentApi({
+      createdBy: user.id,
+      creator: user,
+      establishmentId: establishment.id
+    });
+    await Documents().insert(toDocumentDBO(document));
+    await CampaignDocuments().insert({
+      document_id: document.id,
+      campaign_id: campaign.id
+    });
+
+    const { status, body } = await request(url)
+      .get(testRoute(campaign.id))
+      .use(tokenProvider(user));
+
+    expect(status).toBe(constants.HTTP_STATUS_OK);
+    expect(body).toBeArrayOfSize(1);
+    expect(body[0]).toMatchObject({
+      id: document.id,
+      url: expect.stringContaining('http')
+    });
+  });
+
+  it('should return 404 if campaign belongs to another establishment', async () => {
+    const campaign = await factories
+      .campaign(anotherEstablishment)
+      .create(
+        {},
+        { associations: { createdBy: userFromAnotherEstablishment } }
+      );
+
+    const { status } = await request(url)
+      .get(testRoute(campaign.id))
+      .use(tokenProvider(user));
+
+    expect(status).toBe(constants.HTTP_STATUS_NOT_FOUND);
+  });
+});
+
+describe('DELETE /campaigns/:id/documents/:documentId', () => {
+  const testRoute = (id: string, documentId: string) =>
+    `/campaigns/${id}/documents/${documentId}`;
+
+  it('should remove association only (keep document)', async () => {
+    const campaign = await factories
+      .campaign(establishment)
+      .create({}, { associations: { createdBy: user } });
+    const document = genDocumentApi({
+      createdBy: user.id,
+      creator: user,
+      establishmentId: establishment.id
+    });
+    await Documents().insert(toDocumentDBO(document));
+    await CampaignDocuments().insert({
+      document_id: document.id,
+      campaign_id: campaign.id
+    });
+
+    const { status } = await request(url)
+      .delete(testRoute(campaign.id, document.id))
+      .use(tokenProvider(user));
+
+    expect(status).toBe(constants.HTTP_STATUS_NO_CONTENT);
+
+    const links = await CampaignDocuments()
+      .where({ document_id: document.id, campaign_id: campaign.id })
+      .select('*');
+    expect(links).toHaveLength(0);
+
+    const [doc] = await Documents().where({ id: document.id }).select('*');
+    expect(doc).toBeDefined();
+    expect(doc.deleted_at).toBeNull();
+  });
+
+  it('should create an event "campaign:document-detached"', async () => {
+    const campaign = await factories
+      .campaign(establishment)
+      .create({}, { associations: { createdBy: user } });
+    const document = genDocumentApi({
+      createdBy: user.id,
+      creator: user,
+      establishmentId: establishment.id
+    });
+    await Documents().insert(toDocumentDBO(document));
+    await CampaignDocuments().insert({
+      document_id: document.id,
+      campaign_id: campaign.id
+    });
+
+    const { status } = await request(url)
+      .delete(testRoute(campaign.id, document.id))
+      .use(tokenProvider(user));
+
+    expect(status).toBe(constants.HTTP_STATUS_NO_CONTENT);
+    const event = await Events()
+      .where({ type: 'campaign:document-detached' })
+      .join(
+        CAMPAIGN_DOCUMENT_EVENTS_TABLE,
+        `${CAMPAIGN_DOCUMENT_EVENTS_TABLE}.event_id`,
+        `${EVENTS_TABLE}.id`
+      )
+      .where(`${CAMPAIGN_DOCUMENT_EVENTS_TABLE}.document_id`, document.id)
+      .first();
+    expect(event).toMatchObject<
+      Partial<EventDBO<'campaign:document-detached'>>
+    >({
+      type: 'campaign:document-detached',
+      next_old: { filename: document.filename },
+      next_new: null,
+      created_by: user.id
+    });
+  });
+
+  it('should return 404 if association not found', async () => {
+    const campaign = await factories
+      .campaign(establishment)
+      .create({}, { associations: { createdBy: user } });
+
+    const { status } = await request(url)
+      .delete(testRoute(campaign.id, faker.string.uuid()))
+      .use(tokenProvider(user));
+
+    expect(status).toBe(constants.HTTP_STATUS_NOT_FOUND);
+  });
+
+  it('should return 404 if campaign belongs to another establishment', async () => {
+    const campaign = await factories
+      .campaign(anotherEstablishment)
+      .create(
+        {},
+        { associations: { createdBy: userFromAnotherEstablishment } }
+      );
+    const document = genDocumentApi({
+      createdBy: userFromAnotherEstablishment.id,
+      creator: userFromAnotherEstablishment,
+      establishmentId: anotherEstablishment.id
+    });
+    await Documents().insert(toDocumentDBO(document));
+    await CampaignDocuments().insert({
+      document_id: document.id,
+      campaign_id: campaign.id
+    });
+
+    const { status } = await request(url)
+      .delete(testRoute(campaign.id, document.id))
+      .use(tokenProvider(user));
+
+    expect(status).toBe(constants.HTTP_STATUS_NOT_FOUND);
+  });
+});
+
+describe('DELETE /documents/:id (campaign cascade)', () => {
+  it('should create an event "campaign:document-removed" for each campaign the document was attached to', async () => {
+    const document = genDocumentApi({
+      createdBy: user.id,
+      creator: user,
+      establishmentId: establishment.id
+    });
+    await Documents().insert(toDocumentDBO(document));
+    const campaign = await factories
+      .campaign(establishment)
+      .create({}, { associations: { createdBy: user } });
+    await CampaignDocuments().insert({
+      document_id: document.id,
+      campaign_id: campaign.id
+    });
+
+    const { status } = await request(url)
+      .delete(`/documents/${document.id}`)
+      .use(tokenProvider(user));
+
+    expect(status).toBe(constants.HTTP_STATUS_NO_CONTENT);
+    const event = await Events()
+      .where({ type: 'campaign:document-removed' })
+      .join(
+        CAMPAIGN_DOCUMENT_EVENTS_TABLE,
+        `${CAMPAIGN_DOCUMENT_EVENTS_TABLE}.event_id`,
+        `${EVENTS_TABLE}.id`
+      )
+      .where(`${CAMPAIGN_DOCUMENT_EVENTS_TABLE}.document_id`, document.id)
+      .first();
+    expect(event).toMatchObject<Partial<EventDBO<'campaign:document-removed'>>>(
+      {
+        type: 'campaign:document-removed',
+        next_old: { filename: document.filename },
+        next_new: null,
+        created_by: user.id
+      }
+    );
+  });
+});
+```
+
+**Note on factories**: same rationale as Task 3 — `campaign` goes through `factories.campaign(establishment).create(...)` (server-side, from `~/test/factories`), `establishment`/`user`/`document` stay on `gen*Api()`, matching the codebase's actual, practiced convention. `Campaigns`/`formatCampaignApi` are no longer imported in this file since nothing calls them directly anymore.
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `yarn nx test server -- document-api.test.ts`
+Expected: FAIL — `documentController.linkToCampaign`/`listByCampaign`/`removeByCampaign` don't exist, and the routes 404.
+
+- [ ] **Step 4: Implement the controller methods**
+
+Modify `server/src/controllers/documentController.ts`. Replace the `@zerologementvacant/models` import (already touched in Task 1, Step 5) with this merged version that adds `type CampaignDTO`:
+
+```ts
+import {
+  ACCEPTED_DOCUMENT_EXTENSIONS,
+  HousingDocumentDTO,
+  MAX_DOCUMENT_SIZE_IN_MiB,
+  type CampaignDTO,
+  type DocumentDTO,
+  type DocumentPayload,
+  type HousingDTO
+} from '@zerologementvacant/models';
+```
+
+Replace the existing `import { type HousingDocumentPayload } from '@zerologementvacant/schemas';` line with this merged version that adds `type CampaignDocumentPayload`:
+
+```ts
+import {
+  type CampaignDocumentPayload,
+  type HousingDocumentPayload
+} from '@zerologementvacant/schemas';
+```
+
+Add these new imports:
+
+```ts
+import CampaignMissingError from '~/errors/campaignMissingError';
+import {
+  CampaignDocumentApi,
+  toCampaignDocumentDTO
+} from '~/models/CampaignDocumentApi';
+import { CampaignDocumentEventApi } from '~/models/EventApi';
+import campaignDocumentRepository from '~/repositories/campaignDocumentRepository';
+import campaignRepository from '~/repositories/campaignRepository';
+```
+
+Extend the `remove` function's cascade logic — replace the body between finding `housingDocuments` and the `startTransaction` call with:
+
+```ts
+// Find all housings linked to this document
+const housingDocuments = await housingDocumentRepository.find({
+  filters: { documentIds: [params.id] }
+});
+const removeEvents = housingDocuments.map<HousingDocumentEventApi>(
+  (housingDocument) => ({
+    id: uuidv4(),
+    type: 'housing:document-removed',
+    nextOld: { filename: document.filename },
+    nextNew: null,
+    createdAt: new Date().toJSON(),
+    createdBy: user.id,
+    documentId: params.id,
+    housingGeoCode: housingDocument.housingGeoCode,
+    housingId: housingDocument.housingId
+  })
+);
+
+// Find all campaigns linked to this document
+const campaignDocuments = await campaignDocumentRepository.find({
+  filters: { documentIds: [params.id] }
+});
+const campaignRemoveEvents = campaignDocuments.map<CampaignDocumentEventApi>(
+  (campaignDocument) => ({
+    id: uuidv4(),
+    type: 'campaign:document-removed',
+    nextOld: { filename: document.filename },
+    nextNew: null,
+    createdAt: new Date().toJSON(),
+    createdBy: user.id,
+    documentId: params.id,
+    campaignId: campaignDocument.campaignId
+  })
+);
+
+const documentRemoveEvent: DocumentEventApi = {
+  id: uuidv4(),
+  type: 'document:removed',
+  nextOld: { filename: document.filename },
+  nextNew: null,
+  createdAt: new Date().toJSON(),
+  createdBy: request.user!.id,
+  documentId: params.id
+};
+const deleteCommand = new DeleteObjectCommand({
+  Bucket: config.s3.bucket,
+  Key: document.s3Key
+});
+
+await startTransaction(async () => {
+  await Promise.all([
+    eventRepository.insertManyHousingDocumentEvents(removeEvents),
+    eventRepository.insertManyCampaignDocumentEvents(campaignRemoveEvents),
+    eventRepository.insertManyDocumentEvents([documentRemoveEvent]),
+    housingDocumentRepository.unlinkMany({ documentIds: [params.id] }),
+    campaignDocumentRepository.unlinkMany({ documentIds: [params.id] }),
+    documentRepository.remove(params.id)
+  ]);
+  await s3.send(deleteCommand);
+});
+```
+
+Add the three new handlers, right after `removeByHousing` and before the `documentController` export object:
+
+```ts
+const linkToCampaign: RequestHandler<
+  { id: CampaignDTO['id'] },
+  ReadonlyArray<DocumentDTO>,
+  CampaignDocumentPayload,
+  never
+> = async (request, response) => {
+  const { establishment, params, body, user } = request as AuthenticatedRequest<
+    { id: CampaignDTO['id'] },
+    ReadonlyArray<DocumentDTO>,
+    CampaignDocumentPayload,
+    never
+  >;
+
+  logger.info('Linking documents to campaign', {
+    campaign: params.id,
+    documentCount: body.documentIds.length
+  });
+
+  const campaign = await campaignRepository.findOne({
+    id: params.id,
+    establishmentId: establishment.id
+  });
+  if (!campaign) {
+    throw new CampaignMissingError(params.id);
+  }
+
+  const documents = await documentRepository.find({
+    filters: {
+      ids: body.documentIds,
+      establishmentIds: [establishment.id],
+      deleted: false
+    }
+  });
+
+  if (documents.length !== body.documentIds.length) {
+    const foundIds = documents.map((document) => document.id);
+    const missingIds = body.documentIds.filter((id) => !foundIds.includes(id));
+    throw new DocumentMissingError(...missingIds);
+  }
+
+  const links = body.documentIds.map((documentId) => ({
+    document_id: documentId,
+    campaign_id: campaign.id
+  }));
+  const attachEvents = documents.map<CampaignDocumentEventApi>((document) => ({
+    id: uuidv4(),
+    type: 'campaign:document-attached',
+    nextOld: null,
+    nextNew: { filename: document.filename },
+    createdAt: new Date().toJSON(),
+    createdBy: user.id,
+    documentId: document.id,
+    campaignId: campaign.id
+  }));
+
+  await startTransaction(async () => {
+    await Promise.all([
+      campaignDocumentRepository.linkMany(links),
+      eventRepository.insertManyCampaignDocumentEvents(attachEvents)
+    ]);
+  });
+
+  const documentsWithURLs = await async.map(
+    documents,
+    async (document: DocumentApi) =>
+      toDocumentDTO(document, { s3, bucket: config.s3.bucket })
+  );
+
+  response.status(constants.HTTP_STATUS_CREATED).json(documentsWithURLs);
+};
+
+const listByCampaign: RequestHandler<
+  { id: CampaignDTO['id'] },
+  DocumentDTO[],
+  never,
+  never
+> = async (request, response): Promise<void> => {
+  const { establishment, params } = request as AuthenticatedRequest<
+    { id: CampaignDTO['id'] },
+    DocumentDTO[],
+    never,
+    never
+  >;
+
+  logger.debug('Finding documents by campaign...', { campaign: params.id });
+  const campaign = await campaignRepository.findOne({
+    id: params.id,
+    establishmentId: establishment.id
+  });
+  if (!campaign) {
+    throw new CampaignMissingError(params.id);
+  }
+
+  const documents = await campaignDocumentRepository.find({
+    filters: { campaignIds: [campaign.id], deleted: false }
+  });
+
+  const documentsWithURLs = await async.map(
+    [...documents],
+    async (document: CampaignDocumentApi) =>
+      toCampaignDocumentDTO(document, { s3, bucket: config.s3.bucket })
+  );
+
+  response.status(constants.HTTP_STATUS_OK).json(documentsWithURLs);
+};
+
+const removeByCampaign: RequestHandler<
+  { id: CampaignDTO['id']; documentId: DocumentDTO['id'] },
+  void,
+  never,
+  never
+> = async (request, response) => {
+  const { establishment, params, user } = request as AuthenticatedRequest<
+    { id: CampaignDTO['id']; documentId: DocumentDTO['id'] },
+    void,
+    never,
+    never
+  >;
+
+  logger.info('Removing document-campaign association', {
+    campaign: params.id,
+    document: params.documentId
+  });
+
+  const campaign = await campaignRepository.findOne({
+    id: params.id,
+    establishmentId: establishment.id
+  });
+  if (!campaign) {
+    throw new CampaignMissingError(params.id);
+  }
+
+  const links = await campaignDocumentRepository.find({
+    filters: { campaignIds: [campaign.id] }
+  });
+  const document = links.find((link) => link.id === params.documentId);
+  if (!document) {
+    throw new DocumentMissingError(params.documentId);
+  }
+
+  const detachEvent: CampaignDocumentEventApi = {
+    id: uuidv4(),
+    type: 'campaign:document-detached',
+    nextOld: { filename: document.filename },
+    nextNew: null,
+    createdAt: new Date().toJSON(),
+    createdBy: user.id,
+    documentId: params.documentId,
+    campaignId: campaign.id
+  };
+
+  await startTransaction(async () => {
+    await Promise.all([
+      eventRepository.insertManyCampaignDocumentEvents([detachEvent]),
+      campaignDocumentRepository.unlink({
+        documentId: params.documentId,
+        campaignId: campaign.id
+      })
+    ]);
+  });
+
+  response.status(constants.HTTP_STATUS_NO_CONTENT).send();
+};
+```
+
+Update the exported object:
+
+```ts
+const documentController = {
+  create,
+  get,
+  update,
+  remove,
+  linkToHousing,
+  listByHousing,
+  removeByHousing,
+  linkToCampaign,
+  listByCampaign,
+  removeByCampaign
+};
+```
+
+- [ ] **Step 5: Wire the routes**
+
+Modify `server/src/routers/protected.ts` — add these routes right after the existing `router.delete('/campaigns/:id/housings', ...)` block (around line 329), before `router.get('/drafts', ...)`:
+
+```ts
+router.get(
+  '/campaigns/:id/documents',
+  validator.validate({
+    params: object({ id: schemas.id })
+  }),
+  documentController.listByCampaign
+);
+router.post(
+  '/campaigns/:id/documents',
+  hasRole([UserRole.USUAL, UserRole.ADMIN]),
+  validator.validate({
+    params: object({ id: schemas.id }),
+    body: schemas.campaignDocumentPayload
+  }),
+  documentController.linkToCampaign
+);
+router.delete(
+  '/campaigns/:id/documents/:documentId',
+  hasRole([UserRole.USUAL, UserRole.ADMIN]),
+  validator.validate({
+    params: object({ id: schemas.id, documentId: schemas.id })
+  }),
+  documentController.removeByCampaign
+);
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `yarn nx test server -- document-api.test.ts`
+Expected: PASS (all describe blocks, including the pre-existing housing ones — confirms no regression).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/src/models/EventApi.ts server/src/repositories/eventRepository.ts server/src/controllers/test/document-api.test.ts server/src/controllers/documentController.ts server/src/routers/protected.ts
+git commit -m "feat: add campaign document link/list/remove endpoints"
+```
+
+---
+
+### Task 5: Frontend RTK Query endpoints + MSW mocks
+
+**Files:**
+
+- Modify: `frontend/src/mocks/handlers/data.ts`
+- Modify: `frontend/src/mocks/handlers/document-handlers.ts`
+- Modify: `frontend/src/services/document.service.ts`
+
+**Interfaces:**
+
+- Consumes: `GET/POST /campaigns/:id/documents`, `DELETE /campaigns/:id/documents/:documentId` (Task 4, real backend); MSW mocks below simulate these for frontend tests.
+- Produces: `useFindCampaignDocumentsQuery(campaignId)`, `useLinkDocumentsToCampaignMutation()`, `useUnlinkCampaignDocumentMutation()` — consumed by Task 6, 7, 8.
+
+- [ ] **Step 1: Add the `campaignDocuments` map to the mock data store**
+
+Modify `frontend/src/mocks/handlers/data.ts` — add the map near the other `campaign*` declarations (after `campaignHousings`):
+
+```ts
+const campaignDocuments = new Map<
+  CampaignDTO['id'],
+  ReadonlyArray<Pick<DocumentDTO, 'id'>>
+>();
+```
+
+Add `campaignDocuments` to the default export object (insert the one new line after `campaigns`, keep every other line exactly as it already is):
+
+```ts
+export default {
+  buildings,
+  campaigns,
+  campaignDocuments,
+  campaignDrafts,
+  campaignHousings,
+  datafoncierHousings,
+  documents,
+  drafts,
+  draftCampaigns,
+  establishments,
+  files,
+  groups,
+  groupHousings,
+  housings,
+  housingCampaigns,
+  housingDocuments,
+  housingEvents,
+  housingFiles,
+  housingNotes,
+  housingOwners,
+  housingPrecisions,
+  localities,
+  notes,
+  owners,
+  precisions,
+  prospects,
+  signupLinks,
+  users,
+
+  reset
+};
+```
+
+(Note: `documents` and `housingDocuments` are not cleared in `reset()` either — `campaignDocuments` is intentionally left out of `reset()` too, for consistency with that existing behavior. The `reset()` function itself is unchanged.)
+
+- [ ] **Step 2: Add the MSW handlers**
+
+Modify `frontend/src/mocks/handlers/document-handlers.ts` — add `type CampaignDTO` to the existing type import from `@zerologementvacant/models`:
+
+```ts
+import type {
+  CampaignDTO,
+  DocumentDTO,
+  DocumentPayload,
+  HousingDTO
+} from '@zerologementvacant/models';
+```
+
+Add these three handlers, right after `findByHousing`:
+
+```ts
+const findByCampaign = http.get<{ id: string }, never, DocumentDTO[]>(
+  `${config.apiEndpoint}/campaigns/:id/documents`,
+  async ({ params }) => {
+    const documents = (data.campaignDocuments.get(params.id) ?? [])
+      .map((ref) => data.documents.get(ref.id))
+      .filter(Predicate.isNotUndefined);
+
+    return HttpResponse.json(documents, {
+      status: constants.HTTP_STATUS_OK
+    });
+  }
+);
+
+const linkToCampaign = http.post<
+  { id: CampaignDTO['id'] },
+  { documentIds: DocumentDTO['id'][] },
+  DocumentDTO[] | Error
+>(
+  `${config.apiEndpoint}/campaigns/:id/documents`,
+  async ({ params, request }) => {
+    const { documentIds } = await request.json();
+
+    const campaign = data.campaigns.find(
+      (campaign) => campaign.id === params.id
+    );
+    if (!campaign) {
+      return HttpResponse.json(
+        {
+          name: 'CampaignMissingError',
+          message: `Campaign ${params.id} missing`
+        },
+        { status: constants.HTTP_STATUS_NOT_FOUND }
+      );
+    }
+
+    const documents = documentIds
+      .map((id) => data.documents.get(id))
+      .filter(Predicate.isNotUndefined);
+
+    if (documents.length !== documentIds.length) {
+      return HttpResponse.json(
+        { name: 'DocumentMissingError', message: 'Some documents not found' },
+        { status: constants.HTTP_STATUS_BAD_REQUEST }
+      );
+    }
+
+    const existingDocuments = data.campaignDocuments.get(params.id) ?? [];
+    const newRefs = documentIds.map((id) => ({ id }));
+    data.campaignDocuments.set(params.id, [...existingDocuments, ...newRefs]);
+
+    return HttpResponse.json(documents, {
+      status: constants.HTTP_STATUS_CREATED
+    });
+  }
+);
+
+const unlinkFromCampaign = http.delete<
+  { id: CampaignDTO['id']; documentId: DocumentDTO['id'] },
+  never,
+  null | Error
+>(
+  `${config.apiEndpoint}/campaigns/:id/documents/:documentId`,
+  async ({ params }) => {
+    const exists = data.campaignDocuments
+      .get(params.id)
+      ?.map((document) => document.id)
+      ?.includes(params.documentId);
+    if (!exists) {
+      return HttpResponse.json(
+        {
+          name: 'DocumentMissingError',
+          message: `Document ${params.documentId} not linked to campaign`
+        },
+        { status: constants.HTTP_STATUS_NOT_FOUND }
+      );
+    }
+
+    data.campaignDocuments.set(
+      params.id,
+      (data.campaignDocuments.get(params.id) ?? []).filter(
+        (document) => document.id !== params.documentId
+      )
+    );
+
+    return HttpResponse.json(null, {
+      status: constants.HTTP_STATUS_NO_CONTENT
+    });
+  }
+);
+```
+
+Register them in the exported array:
+
+```ts
+export const documentHandlers: RequestHandler[] = [
+  upload,
+  update,
+  remove,
+  findByHousing,
+  linkToHousing,
+  unlinkFromHousing,
+  findByCampaign,
+  linkToCampaign,
+  unlinkFromCampaign
+];
+```
+
+- [ ] **Step 3: Add the RTK Query endpoints**
+
+Modify `frontend/src/services/document.service.ts` — add `CampaignDTO` to the type import:
+
+```ts
+import type {
+  CampaignDTO,
+  DocumentDTO,
+  DocumentPayload,
+  HousingDocumentDTO,
+  HousingDTO
+} from '@zerologementvacant/models';
+```
+
+Add these three endpoints inside `documentApi.injectEndpoints`'s `endpoints` builder object, right after `linkDocumentsToHousing`:
+
+```ts
+    findCampaignDocuments: builder.query<DocumentDTO[], CampaignDTO['id']>({
+      query: (campaignId) => `campaigns/${campaignId}/documents`,
+      providesTags: (documents, _error, campaignId) =>
+        documents
+          ? [
+              ...documents.map((document) => ({
+                type: 'Document' as const,
+                id: document.id
+              })),
+              { type: 'Document', id: `LIST-${campaignId}` }
+            ]
+          : [{ type: 'Document', id: `LIST-${campaignId}` }]
+    }),
+
+    linkDocumentsToCampaign: builder.mutation<
+      DocumentDTO[],
+      { campaignId: CampaignDTO['id']; documentIds: DocumentDTO['id'][] }
+    >({
+      query: ({ campaignId, documentIds }) => ({
+        url: `campaigns/${campaignId}/documents`,
+        method: 'POST',
+        body: { documentIds }
+      }),
+      invalidatesTags: (_result, _error, { campaignId }) => [
+        { type: 'Document', id: `LIST-${campaignId}` }
+      ]
+    }),
+
+    unlinkCampaignDocument: builder.mutation<
+      void,
+      { campaignId: CampaignDTO['id']; documentId: DocumentDTO['id'] }
+    >({
+      query: ({ campaignId, documentId }) => ({
+        url: `campaigns/${campaignId}/documents/${documentId}`,
+        method: 'DELETE'
+      }),
+      async onQueryStarted(
+        { campaignId, documentId },
+        { dispatch, queryFulfilled }
+      ) {
+        const patchResult = dispatch(
+          documentApi.util.updateQueryData(
+            'findCampaignDocuments',
+            campaignId,
+            (documents) => {
+              const index = documents.findIndex(
+                (draft) => draft.id === documentId
+              );
+              if (index !== -1) {
+                documents.splice(index, 1);
+              }
+            }
+          )
+        );
+
+        queryFulfilled.catch(patchResult.undo);
+      }
+    }),
+```
+
+Add the three hooks to the exported destructure:
+
+```ts
+export const {
+  useFindHousingDocumentsQuery,
+  useUploadDocumentsMutation,
+  useLinkDocumentsToHousingMutation,
+  useUpdateDocumentMutation,
+  useUnlinkDocumentMutation,
+  useDeleteDocumentMutation,
+  useGetDocumentQuery,
+  useFindCampaignDocumentsQuery,
+  useLinkDocumentsToCampaignMutation,
+  useUnlinkCampaignDocumentMutation
+} = documentApi;
+```
+
+- [ ] **Step 4: Typecheck**
+
+Run: `yarn nx run-many -t typecheck`
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/mocks/handlers/data.ts frontend/src/mocks/handlers/document-handlers.ts frontend/src/services/document.service.ts
+git commit -m "feat: add campaign document RTK Query endpoints and MSW mocks"
+```
+
+---
+
+### Task 6: `CampaignDocumentUpload` component
+
+**Files:**
+
+- Create: `frontend/src/components/FileUpload/CampaignDocumentUpload.tsx`
+- Create: `frontend/src/components/FileUpload/test/CampaignDocumentUpload.test.tsx`
+
+**Interfaces:**
+
+- Consumes: `DocumentUpload`, `useDocumentUpload` (existing, unchanged), `ACCEPTED_DOCUMENT_EXTENSIONS`/`MAX_DOCUMENT_SIZE_IN_MiB` (Task 1).
+- Produces: `<CampaignDocumentUpload onUpload={(documents: DocumentDTO[]) => void} label?={string} />` — consumed by Task 7.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/src/components/FileUpload/test/CampaignDocumentUpload.test.tsx`:
+
+```tsx
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { UserRole } from '@zerologementvacant/models';
+import {
+  genEstablishmentDTO,
+  genUserDTO
+} from '@zerologementvacant/models/fixtures';
+import { Provider } from 'react-redux';
+import { vi } from 'vitest';
+
+import { fromEstablishmentDTO } from '~/models/Establishment';
+import { fromUserDTO } from '~/models/User';
+import { genAuthUser } from '~/test/fixtures';
+import configureTestStore from '~/utils/storeUtils';
+
+import CampaignDocumentUpload from '../CampaignDocumentUpload';
+
+describe('CampaignDocumentUpload', () => {
+  const user = userEvent.setup();
+
+  function setup() {
+    const establishment = genEstablishmentDTO();
+    const auth = genUserDTO(UserRole.USUAL, establishment);
+    const store = configureTestStore({
+      auth: genAuthUser(fromUserDTO(auth), fromEstablishmentDTO(establishment))
+    });
+    const onUpload = vi.fn();
+
+    render(
+      <Provider store={store}>
+        <CampaignDocumentUpload onUpload={onUpload} />
+      </Provider>
+    );
+
+    return { onUpload };
+  }
+
+  it('renders the campaign-specific upload label', () => {
+    setup();
+
+    expect(
+      screen.getByText('Associez un ou plusieurs documents à cette campagne')
+    ).toBeInTheDocument();
+  });
+
+  it('accepts the generic document file types', () => {
+    setup();
+
+    const input = document.querySelector('input[type="file"]');
+    expect(input).toHaveAttribute('accept');
+    expect(input?.getAttribute('accept')).toContain('application/pdf');
+  });
+
+  it('calls onUpload with the created documents after a successful upload', async () => {
+    const { onUpload } = setup();
+    const file = new File(['content'], 'campagne.pdf', {
+      type: 'application/pdf'
+    });
+    const input = document.querySelector(
+      'input[type="file"]'
+    ) as HTMLInputElement;
+
+    await user.upload(input, file);
+
+    await waitFor(() => {
+      expect(onUpload).toHaveBeenCalledWith([
+        expect.objectContaining({ filename: 'campagne.pdf' })
+      ]);
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `yarn nx test frontend -- CampaignDocumentUpload.test.tsx`
+Expected: FAIL — cannot find module `../CampaignDocumentUpload`.
+
+- [ ] **Step 3: Implement the component**
+
+Create `frontend/src/components/FileUpload/CampaignDocumentUpload.tsx`:
+
+```tsx
+import {
+  ACCEPTED_DOCUMENT_EXTENSIONS,
+  MAX_DOCUMENT_SIZE_IN_MiB,
+  type DocumentDTO
+} from '@zerologementvacant/models';
+
+import DocumentUpload, {
+  type DocumentUploadProps
+} from '~/components/FileUpload/DocumentUpload';
+import { useDocumentUpload } from '~/components/FileUpload/useDocumentUpload';
+
+export type CampaignDocumentUploadProps = Pick<DocumentUploadProps, 'label'> & {
+  /**
+   * Called every time documents are successfully uploaded.
+   * @param documents
+   */
+  onUpload(documents: ReadonlyArray<DocumentDTO>): void;
+};
+
+function CampaignDocumentUpload(props: Readonly<CampaignDocumentUploadProps>) {
+  const { error, isError, isLoading, isSuccess, upload } = useDocumentUpload({
+    onUpload: props.onUpload
+  });
+
+  return (
+    <DocumentUpload
+      id="campaign-document-upload"
+      accept={ACCEPTED_DOCUMENT_EXTENSIONS as string[]}
+      error={error}
+      hint={
+        <div>
+          Taille maximale par fichier : 25Mo. Formats supportés : images (png,
+          jpg, heic, webp, etc.) et documents (docx, xlsx, ppt, etc.). Le nom du
+          fichier doit faire moins de 255 caractères. Plusieurs fichiers
+          possibles. Veillez à ne pas partager de{' '}
+          <a
+            href="https://cnil.fr/fr/definition/donnee-sensible#:~:text=Ce%20sont%20des%20informations%20qui,physique%20de%20mani%C3%A8re%20unique%2C%20des."
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            données sensibles
+          </a>
+          .
+        </div>
+      }
+      isError={isError}
+      isLoading={isLoading}
+      isSuccess={isSuccess}
+      label={
+        props.label ?? 'Associez un ou plusieurs documents à cette campagne'
+      }
+      maxSize={MAX_DOCUMENT_SIZE_IN_MiB}
+      multiple
+      onUpload={upload}
+    />
+  );
+}
+
+export default CampaignDocumentUpload;
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `yarn nx test frontend -- CampaignDocumentUpload.test.tsx`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: RGAA self-check**
+
+This component only composes the already-accessible DSFR `Upload` (via `DocumentUpload`) with new label/hint copy — no new interactive pattern. Thématique 11 (formulaire) is satisfied by the reused DSFR component; the hint text's CNIL link has an explicit accessible name via its visible text. No new violation introduced.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/components/FileUpload/CampaignDocumentUpload.tsx frontend/src/components/FileUpload/test/CampaignDocumentUpload.test.tsx
+git commit -m "feat: add CampaignDocumentUpload component"
+```
+
+---
+
+### Task 7: `CampaignDocumentsTab` component
+
+**Files:**
+
+- Create: `frontend/src/components/Campaign/CampaignDocumentsTab.tsx`
+- Create: `frontend/src/components/Campaign/test/CampaignDocumentsTab.test.tsx`
+
+**Interfaces:**
+
+- Consumes: `CampaignDocumentUpload` (Task 6), `useFindCampaignDocumentsQuery`/`useLinkDocumentsToCampaignMutation`/`useUnlinkCampaignDocumentMutation` (Task 5), `useUpdateDocumentMutation` (existing), `DocumentCard`, `DocumentFullscreenPreview`, `createDocumentDeleteModal`, `createDocumentRenameModal` (existing, unchanged).
+- Produces: `<CampaignDocumentsTab campaign={CampaignDTO} />` — consumed by Task 8.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/src/components/Campaign/test/CampaignDocumentsTab.test.tsx`:
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import { UserRole } from '@zerologementvacant/models';
+import {
+  genDocumentDTO,
+  genEstablishmentDTO,
+  genUserDTO
+} from '@zerologementvacant/models/fixtures';
+import { Provider } from 'react-redux';
+
+import data from '~/mocks/handlers/data';
+import { fromEstablishmentDTO } from '~/models/Establishment';
+import { fromUserDTO } from '~/models/User';
+import { factories } from '~/test/factories';
+import { genAuthUser } from '~/test/fixtures';
+import configureTestStore from '~/utils/storeUtils';
+
+import CampaignDocumentsTab from '../CampaignDocumentsTab';
+
+describe('CampaignDocumentsTab', () => {
+  function renderTab(role: UserRole) {
+    const establishment = genEstablishmentDTO();
+    const auth = genUserDTO(role, establishment);
+    const campaign = factories
+      .campaign(establishment)
+      .build({}, { associations: { createdBy: auth } });
+    data.campaigns.push(campaign);
+    const store = configureTestStore({
+      auth: genAuthUser(fromUserDTO(auth), fromEstablishmentDTO(establishment))
+    });
+
+    render(
+      <Provider store={store}>
+        <CampaignDocumentsTab campaign={campaign} />
+      </Provider>
+    );
+
+    return { campaign, establishment, auth };
+  }
+
+  it('shows an empty state message when there are no documents', async () => {
+    renderTab(UserRole.USUAL);
+
+    expect(
+      await screen.findByText(
+        /Il n’y a pas de document associé à cette campagne/i
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('displays existing documents', async () => {
+    const establishment = genEstablishmentDTO();
+    const auth = genUserDTO(UserRole.USUAL, establishment);
+    const campaign = factories
+      .campaign(establishment)
+      .build({}, { associations: { createdBy: auth } });
+    const document = genDocumentDTO(auth, establishment);
+    data.campaigns.push(campaign);
+    data.documents.set(document.id, document);
+    data.campaignDocuments.set(campaign.id, [document]);
+    const store = configureTestStore({
+      auth: genAuthUser(fromUserDTO(auth), fromEstablishmentDTO(establishment))
+    });
+
+    render(
+      <Provider store={store}>
+        <CampaignDocumentsTab campaign={campaign} />
+      </Provider>
+    );
+
+    expect(
+      await screen.findByText(new RegExp(document.filename, 'i'))
+    ).toBeInTheDocument();
+  });
+
+  it('shows the upload zone for a usual user', async () => {
+    renderTab(UserRole.USUAL);
+
+    expect(
+      await screen.findByText(
+        'Associez un ou plusieurs documents à cette campagne'
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('hides the upload zone for a visitor', async () => {
+    renderTab(UserRole.VISITOR);
+
+    await screen.findByText(/Il n’y a pas de document associé/i);
+    expect(
+      screen.queryByText('Associez un ou plusieurs documents à cette campagne')
+    ).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `yarn nx test frontend -- CampaignDocumentsTab.test.tsx`
+Expected: FAIL — cannot find module `../CampaignDocumentsTab`.
+
+- [ ] **Step 3: Implement the component**
+
+Create `frontend/src/components/Campaign/CampaignDocumentsTab.tsx`:
+
+```tsx
+import Pictures from '@codegouvfr/react-dsfr/picto/Pictures';
+import Grid from '@mui/material/Grid';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import type { CampaignDTO, DocumentDTO } from '@zerologementvacant/models';
+import type { ReactNode } from 'react';
+import { useId, useMemo, useState } from 'react';
+import { match, Pattern } from 'ts-pattern';
+
+import CampaignDocumentUpload from '~/components/FileUpload/CampaignDocumentUpload';
+import DocumentFullscreenPreview from '~/components/FileUpload/DocumentFullscreenPreview';
+import DocumentCard, {
+  type DocumentCardProps
+} from '~/components/HousingDetails/DocumentCard';
+import { createDocumentDeleteModal } from '~/components/HousingDetails/DocumentDeleteModal';
+import { createDocumentRenameModal } from '~/components/HousingDetails/DocumentRenameModal';
+import { useNotification } from '~/hooks/useNotification';
+import { useUser } from '~/hooks/useUser';
+import {
+  useFindCampaignDocumentsQuery,
+  useLinkDocumentsToCampaignMutation,
+  useUnlinkCampaignDocumentMutation,
+  useUpdateDocumentMutation
+} from '~/services/document.service';
+
+export interface CampaignDocumentsTabProps {
+  campaign: CampaignDTO;
+}
+
+function CampaignDocumentsTab(props: Readonly<CampaignDocumentsTabProps>) {
+  const { campaign } = props;
+
+  const {
+    data: documents,
+    isLoading,
+    isSuccess
+  } = useFindCampaignDocumentsQuery(campaign.id);
+
+  const [linkDocuments] = useLinkDocumentsToCampaignMutation();
+  function onUpload(uploaded: ReadonlyArray<DocumentDTO>): void {
+    linkDocuments({
+      campaignId: campaign.id,
+      documentIds: uploaded.map((document) => document.id)
+    });
+  }
+
+  const [updateDocument, updateDocumentMutation] = useUpdateDocumentMutation();
+  useNotification({
+    toastId: 'document-update',
+    isError: updateDocumentMutation.isError,
+    isLoading: updateDocumentMutation.isLoading,
+    isSuccess: updateDocumentMutation.isSuccess,
+    message: {
+      error: 'Erreur lors du renommage du document.',
+      loading: 'Renommage du document...',
+      success: 'Document renommé !'
+    }
+  });
+  function onRename(document: DocumentDTO): void {
+    updateDocument({ id: document.id, filename: document.filename });
+  }
+
+  const [unlinkDocument, unlinkDocumentMutation] =
+    useUnlinkCampaignDocumentMutation();
+  useNotification({
+    toastId: 'document-delete',
+    isError: unlinkDocumentMutation.isError,
+    isLoading: unlinkDocumentMutation.isLoading,
+    isSuccess: unlinkDocumentMutation.isSuccess,
+    message: {
+      error: 'Erreur lors de la suppression du document',
+      loading: 'Suppression du document...',
+      success: 'Document supprimé !'
+    }
+  });
+  const onDelete: DocumentCardProps['onDelete'] = (document) => {
+    unlinkDocument({ campaignId: campaign.id, documentId: document.id });
+  };
+
+  const documentRenameModalId = useId();
+  const documentRenameModal = useMemo(
+    () => createDocumentRenameModal(documentRenameModalId),
+    [documentRenameModalId]
+  );
+  const documentDeleteModalId = useId();
+  const documentDeleteModal = useMemo(
+    () => createDocumentDeleteModal(documentDeleteModalId),
+    [documentDeleteModalId]
+  );
+
+  const { isUsual, isAdmin } = useUser();
+  const canUpload = isAdmin || isUsual;
+
+  const [selectedDocument, setSelectedDocument] = useState<DocumentDTO | null>(
+    null
+  );
+  const [documentToDelete, setDocumentToDelete] = useState<DocumentDTO | null>(
+    null
+  );
+  const [fullscreenPreviewIndex, setFullscreenPreviewIndex] = useState<
+    number | null
+  >(null);
+
+  function confirmRename(document: DocumentDTO): void {
+    setSelectedDocument(document);
+    documentRenameModal.open();
+  }
+
+  function cancelRename(): void {
+    documentRenameModal.close();
+    setSelectedDocument(null);
+  }
+
+  function renameDocument(filename: string): void {
+    if (!selectedDocument) {
+      return;
+    }
+    onRename({ ...selectedDocument, filename });
+    documentRenameModal.close();
+    setSelectedDocument(null);
+  }
+
+  function onVisualize(index: number): void {
+    setFullscreenPreviewIndex(index);
+  }
+
+  function confirmDeletion(document: DocumentDTO): void {
+    setDocumentToDelete(document);
+    documentDeleteModal.open();
+  }
+
+  function cancelDeletion(): void {
+    setDocumentToDelete(null);
+    documentDeleteModal.close();
+  }
+
+  function deleteDocument(): void {
+    if (!documentToDelete) {
+      return;
+    }
+    onDelete(documentToDelete);
+    documentDeleteModal.close();
+    setDocumentToDelete(null);
+  }
+
+  async function onDownload(document: DocumentDTO): Promise<void> {
+    try {
+      const response = await fetch(document.url);
+      const blob = await response.blob();
+      const url = globalThis.URL.createObjectURL(blob);
+      const link = globalThis.document.createElement('a');
+      link.href = url;
+      link.download = document.filename;
+      globalThis.document.body.appendChild(link);
+      link.click();
+      link.remove();
+      globalThis.URL.revokeObjectURL(url);
+    } catch (error) {
+      console.error('Failed to download document', error);
+    }
+  }
+
+  const documentList = documents ?? [];
+
+  return (
+    <>
+      <documentRenameModal.Component
+        document={selectedDocument}
+        onCancel={cancelRename}
+        onSubmit={renameDocument}
+        onDownload={() => {
+          if (selectedDocument) {
+            onDownload(selectedDocument);
+          }
+        }}
+      />
+      <documentDeleteModal.Component
+        onCancel={cancelDeletion}
+        onSubmit={deleteDocument}
+      />
+
+      {fullscreenPreviewIndex !== null && (
+        <DocumentFullscreenPreview
+          documents={documentList}
+          index={fullscreenPreviewIndex}
+          onIndexChange={setFullscreenPreviewIndex}
+          open={fullscreenPreviewIndex !== null}
+          onClose={() => {
+            setFullscreenPreviewIndex(null);
+          }}
+          onDownload={onDownload}
+        />
+      )}
+
+      <Stack component="section" spacing="2rem" useFlexGap>
+        {canUpload ? (
+          <Stack component="header">
+            <CampaignDocumentUpload onUpload={onUpload} />
+          </Stack>
+        ) : null}
+
+        {match({ documents: documentList, isLoading, isSuccess })
+          .returnType<ReactNode>()
+          .with({ isSuccess: true, documents: [] }, () => (
+            <Stack
+              component="section"
+              spacing="0.75rem"
+              useFlexGap
+              sx={{ alignItems: 'center', textAlign: 'center' }}
+            >
+              <Pictures width="7.5rem" height="7.5rem" />
+              <Typography
+                component="p"
+                variant="subtitle2"
+                sx={{ fontWeight: 500, width: '17rem' }}
+              >
+                Il n’y a pas de document associé à cette campagne
+              </Typography>
+            </Stack>
+          ))
+          .with(
+            {
+              isSuccess: true,
+              documents: [Pattern.any, ...Pattern.array(Pattern.any)]
+            },
+            ({ documents }) => (
+              <Stack spacing="1rem" useFlexGap>
+                <Typography component="h2" variant="h6">
+                  Documents ({documents.length})
+                </Typography>
+
+                <Grid container spacing="1rem">
+                  {documents.map((document, index) => (
+                    <Grid key={document.id} size={{ xs: 12, md: 6, xl: 4 }}>
+                      <DocumentCard
+                        document={document}
+                        index={index}
+                        onDelete={confirmDeletion}
+                        onDownload={onDownload}
+                        onRename={confirmRename}
+                        onVisualize={onVisualize}
+                      />
+                    </Grid>
+                  ))}
+                </Grid>
+              </Stack>
+            )
+          )
+          .otherwise(() => null)}
+      </Stack>
+    </>
+  );
+}
+
+export default CampaignDocumentsTab;
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `yarn nx test frontend -- CampaignDocumentsTab.test.tsx`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: RGAA self-check**
+
+This component reuses `DocumentCard` (Dropdown menu, thématique 7 — already accessible, unchanged), `DocumentFullscreenPreview` (modal lightbox, thématique 7), and the delete/rename modals (thématique 11 for the rename form) exactly as they exist for housing today. No new interactive pattern is introduced. No regression.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/components/Campaign/CampaignDocumentsTab.tsx frontend/src/components/Campaign/test/CampaignDocumentsTab.test.tsx
+git commit -m "feat: add CampaignDocumentsTab component"
+```
+
+---
+
+### Task 8: Wire into `CampaignView.tsx` + full integration tests
+
+**Files:**
+
+- Modify: `frontend/src/views/Campaign/CampaignView.tsx`
+- Modify: `frontend/src/views/Campaign/test/CampaignView.test.tsx`
+
+**Interfaces:**
+
+- Consumes: `CampaignDocumentsTab` (Task 7).
+- Produces: the finished "Documents" tab on the campaign detail page.
+
+- [ ] **Step 1: Write the failing integration tests**
+
+Modify `frontend/src/views/Campaign/test/CampaignView.test.tsx`. Update the imports at the top of the file:
+
+```tsx
+import { faker } from '@faker-js/faker/locale/fr';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {
+  UserRole,
+  type CampaignDTO,
+  type DocumentDTO,
+  type EstablishmentDTO,
+  type HousingDTO,
+  type UserDTO
+} from '@zerologementvacant/models';
+import {
+  genDocumentDTO,
+  genDraftDTO,
+  genEstablishmentDTO,
+  genHousingDTO,
+  genSenderDTO,
+  genUserDTO
+} from '@zerologementvacant/models/fixtures';
+import { Provider } from 'react-redux';
+import { createMemoryRouter, RouterProvider } from 'react-router';
+import { describe, expect, it } from 'vitest';
+
+import { HousingFiltersProvider } from '~/hooks/HousingFiltersContext';
+import data from '~/mocks/handlers/data';
+import { fromEstablishmentDTO } from '~/models/Establishment';
+import { fromUserDTO } from '~/models/User';
+import { factories } from '~/test/factories';
+import { genAuthUser } from '~/test/fixtures';
+import configureTestStore from '~/utils/storeUtils';
+import HousingListView from '~/views/HousingList/HousingListView';
+
+import CampaignView from '../CampaignView';
+```
+
+Update the `renderView` helper to seed an authenticated user and accept document/auth overrides:
+
+```tsx
+interface RenderViewOptions {
+  housings?: HousingDTO[];
+  documents?: DocumentDTO[];
+  auth?: UserDTO;
+  establishment?: EstablishmentDTO;
+}
+
+function renderView(campaign: CampaignDTO, options?: RenderViewOptions) {
+  data.campaigns.push(campaign);
+  if (options?.housings?.length) {
+    data.housings.push(...options.housings);
+    data.campaignHousings.set(
+      campaign.id,
+      options.housings.map((h) => ({ id: h.id }))
+    );
+    options.housings.forEach((housing) => {
+      data.housingCampaigns.set(housing.id, [{ id: campaign.id }]);
+    });
+  }
+  if (options?.documents?.length) {
+    options.documents.forEach((document) => {
+      data.documents.set(document.id, document);
+    });
+    data.campaignDocuments.set(campaign.id, options.documents);
+  }
+
+  const renderAuth = options?.auth ?? auth;
+  const renderEstablishment = options?.establishment ?? establishment;
+
+  const router = createMemoryRouter(
+    [
+      { path: '/campagnes', element: <div>Campagnes</div> },
+      { path: '/campagnes/:id', element: <CampaignView /> },
+      { path: '/parc-de-logements', element: <HousingListView /> }
+    ],
+    { initialEntries: [`/campagnes/${campaign.id}`] }
+  );
+
+  render(
+    <Provider
+      store={configureTestStore({
+        auth: genAuthUser(
+          fromUserDTO(renderAuth),
+          fromEstablishmentDTO(renderEstablishment)
+        )
+      })}
+    >
+      <HousingFiltersProvider>
+        <RouterProvider router={router} />
+      </HousingFiltersProvider>
+    </Provider>
+  );
+
+  return { router };
+}
+```
+
+Add a new `describe('Documents tab', ...)` block at the end of the file, right before the final closing `});` of `describe('CampaignView', ...)`:
+
+```tsx
+describe('Documents tab', () => {
+  it('shows an empty state message when there are no documents', async () => {
+    const campaign = factories
+      .campaign(establishment)
+      .build(
+        { sentAt: null, returnCount: null },
+        { associations: { createdBy: auth } }
+      );
+
+    renderView(campaign, { documents: [] });
+
+    await screen.findByRole('heading', { level: 1 });
+    const tab = await screen.findByRole('tab', { name: 'Documents' });
+    await user.click(tab);
+    const tabpanel = await screen.findByRole('tabpanel', {
+      name: 'Documents'
+    });
+    expect(
+      await within(tabpanel).findByText(
+        /Il n’y a pas de document associé à cette campagne/i
+      )
+    ).toBeVisible();
+  });
+
+  it('displays existing documents', async () => {
+    const campaign = factories
+      .campaign(establishment)
+      .build(
+        { sentAt: null, returnCount: null },
+        { associations: { createdBy: auth } }
+      );
+    const document = genDocumentDTO(auth, establishment);
+
+    renderView(campaign, { documents: [document] });
+
+    const tab = await screen.findByRole('tab', { name: 'Documents' });
+    await user.click(tab);
+    const tabpanel = await screen.findByRole('tabpanel', {
+      name: 'Documents'
+    });
+    expect(
+      await within(tabpanel).findByText(new RegExp(document.filename, 'i'))
+    ).toBeVisible();
+  });
+
+  it('renames a document', async () => {
+    const campaign = factories
+      .campaign(establishment)
+      .build(
+        { sentAt: null, returnCount: null },
+        { associations: { createdBy: auth } }
+      );
+    const document = genDocumentDTO(auth, establishment);
+
+    renderView(campaign, { documents: [document] });
+
+    const tab = await screen.findByRole('tab', { name: 'Documents' });
+    await user.click(tab);
+    const tabpanel = await screen.findByRole('tabpanel', {
+      name: 'Documents'
+    });
+    const dropdown = await within(tabpanel).findByRole('button', {
+      name: 'Options'
+    });
+    await user.click(dropdown);
+    const renameButton = await screen.findByRole('button', {
+      name: 'Renommer'
+    });
+    await user.click(renameButton);
+    const modal = await screen.findByRole('dialog', {
+      name: 'Renommer le document'
+    });
+    const input = await within(modal).findByRole('textbox', {
+      name: /^Nouveau nom du document/
+    });
+    await user.clear(input);
+    await user.type(input, 'nouveau-nom-campagne.pdf');
+    const save = await within(modal).findByRole('button', {
+      name: 'Confirmer'
+    });
+    await user.click(save);
+
+    expect(
+      await within(tabpanel).findByText('nouveau-nom-campagne.pdf')
+    ).toBeVisible();
+  });
+
+  it('deletes a document', async () => {
+    const campaign = factories
+      .campaign(establishment)
+      .build(
+        { sentAt: null, returnCount: null },
+        { associations: { createdBy: auth } }
+      );
+    const document = genDocumentDTO(auth, establishment);
+
+    renderView(campaign, { documents: [document] });
+
+    const tab = await screen.findByRole('tab', { name: 'Documents' });
+    await user.click(tab);
+    const tabpanel = await screen.findByRole('tabpanel', {
+      name: 'Documents'
+    });
+    const dropdown = await within(tabpanel).findByRole('button', {
+      name: 'Options'
+    });
+    await user.click(dropdown);
+    const deleteButton = await screen.findByRole('button', {
+      name: 'Supprimer'
+    });
+    await user.click(deleteButton);
+    const modal = await screen.findByRole('dialog', {
+      name: 'Suppression du document'
+    });
+    const confirm = await within(modal).findByRole('button', {
+      name: 'Confirmer'
+    });
+    await user.click(confirm);
+
+    expect(
+      within(tabpanel).queryByText(new RegExp(document.filename, 'i'))
+    ).not.toBeInTheDocument();
+  });
+
+  it('hides rename and delete for a visitor', async () => {
+    const campaign = factories
+      .campaign(establishment)
+      .build(
+        { sentAt: null, returnCount: null },
+        { associations: { createdBy: auth } }
+      );
+    const document = genDocumentDTO(auth, establishment);
+    const visitor = genUserDTO(UserRole.VISITOR, establishment);
+
+    renderView(campaign, { documents: [document], auth: visitor });
+
+    const tab = await screen.findByRole('tab', { name: 'Documents' });
+    await user.click(tab);
+    const tabpanel = await screen.findByRole('tabpanel', {
+      name: 'Documents'
+    });
+    const dropdown = await within(tabpanel).findByRole('button', {
+      name: 'Options'
+    });
+    await user.click(dropdown);
+
+    expect(
+      screen.queryByRole('button', { name: 'Renommer' })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Supprimer' })
+    ).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `yarn nx test frontend -- CampaignView.test.tsx`
+Expected: FAIL on the new "Documents tab" tests — no "Documents" tab exists yet in `CampaignView.tsx`.
+
+- [ ] **Step 3: Wire the tab into `CampaignView.tsx`**
+
+Modify `frontend/src/views/Campaign/CampaignView.tsx` — add the lazy import near the existing ones (after `DraftForm`):
+
+```tsx
+const CampaignRecipientsNext = lazy(
+  () => import('~/components/Campaign/CampaignRecipients')
+);
+const DraftForm = lazy(() => import('~/components/Draft/DraftForm'));
+const CampaignDocumentsTabLazy = lazy(
+  () => import('~/components/Campaign/CampaignDocumentsTab')
+);
+```
+
+Add the third tab entry to the `Tabs` `tabs` array:
+
+```tsx
+<Suspense>
+  <Tabs
+    tabs={[
+      {
+        label: 'Destinataires',
+        content: <CampaignRecipientsNext campaign={campaign} />
+      },
+      {
+        label: 'Courrier',
+        content:
+          getCampaignDraftQuery.isSuccess && getCampaignDraftQuery.data ? (
+            <DraftForm campaign={campaign} draft={getCampaignDraftQuery.data} />
+          ) : null
+      },
+      {
+        label: 'Documents',
+        content: <CampaignDocumentsTabLazy campaign={campaign} />
+      }
+    ]}
+  />
+</Suspense>
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `yarn nx test frontend -- CampaignView.test.tsx`
+Expected: PASS — all pre-existing tests (title, breadcrumb, sentAt modal, delete modal, "Voir les logements", Courrier tab) plus the new "Documents tab" describe block.
+
+- [ ] **Step 5: Regression-verify the shared permission helper and full suite**
+
+Run: `yarn nx test frontend -- HousingView.test.tsx` (expected: PASS — confirms `canWriteDocument` still gates housing documents correctly)
+Run: `yarn nx test frontend -- CampaignDocumentUpload.test.tsx CampaignDocumentsTab.test.tsx CampaignView.test.tsx` (expected: PASS)
+Run: `yarn nx test server -- document-api.test.ts campaignDocumentRepository.test.ts` (expected: PASS)
+Run: `yarn nx run-many -t typecheck` (expected: no errors)
+Run: `yarn nx run-many -t lint` (expected: no errors — this also confirms the previously-unused `visitor` fixture in `document-api.test.ts` is now used)
+
+- [ ] **Step 6: Manual verification against the Figma design**
+
+Start the dev servers (`yarn workspace @zerologementvacant/server dev` and `yarn workspace @zerologementvacant/front dev`), open a campaign detail page, click the "Documents" tab, and confirm:
+
+- Tab order matches the Figma design (Destinataires, Courrier, Documents).
+- Upload zone copy and layout match the Figma screenshot (`node 16628:13904`).
+- Uploading a file shows it immediately in the "Documents (N)" grid.
+- Options menu (Visualiser/Renommer/Télécharger/Supprimer) works per document.
+- A `VISITOR`-role user sees the documents but not the upload zone or the Renommer/Supprimer actions.
+
+- [ ] **Step 7: RGAA final self-check**
+
+Confirm via manual keyboard navigation: Tab into the new "Documents" tab (DSFR `Tabs`, thématique 7/12.8 — arrow-key navigation between tabs, visible focus per 10.7), Tab into the upload zone (native `<input type="file">`, thématique 11), Tab into a document card's "Options" dropdown and operate it fully via keyboard (Enter to open, arrow keys/Tab through items, Escape to close — thématique 7). No new component was built from scratch, so no new violation is expected; report the result.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add frontend/src/views/Campaign/CampaignView.tsx frontend/src/views/Campaign/test/CampaignView.test.tsx
+git commit -m "feat: wire Documents tab into CampaignView"
+```
+
+---
+
+## Post-plan: PR
+
+Per `.claude/rules` and root `CLAUDE.md`: push the branch, open a PR with a summary (link the design spec and this plan), then add labels and assign via `gh pr edit <number> --add-label "<labels>" --add-assignee "@me"`. Do this only when explicitly requested — not automatically at the end of this plan.

--- a/docs/superpowers/specs/2026-07-20-campaign-documents-design.md
+++ b/docs/superpowers/specs/2026-07-20-campaign-documents-design.md
@@ -1,0 +1,329 @@
+# Campaign Documents — Design
+
+Notion ticket: GEN-1428 — [Campagnes] Ajouter l'onglet Documents
+Figma: node 16628:13904 ("Campagne - Importer ses courriers")
+
+## Problem
+
+Campaigns have no way to attach supporting documents (courrier templates,
+formulaires, fiches de renseignement, flyers, fiches RGPD, etc.). The Notion
+ticket asks for a "Documents" tab on the campaign detail page, matching how
+documents already display on a housing's detail page: upload one or more
+files, see them immediately attached, and browse them as a grid of cards.
+
+The housing-documents feature (generic `documents` table + S3 storage +
+`documents_housings` junction + full frontend upload/list/rename/delete UI)
+already exists end-to-end in production. This feature extends that same
+generic infrastructure to campaigns rather than building anything new from
+scratch.
+
+## Goals
+
+- Add a "Documents" tab to the campaign detail page (`CampaignView.tsx`),
+  positioned after "Destinataires" and "Courrier", matching the Figma order.
+- Let a user upload one or more documents to a campaign; they are created and
+  attached immediately (single user action), matching the ticket's spec.
+- Display attached documents the same way housing documents are displayed:
+  thumbnail/preview, filename, type + size, an Options menu
+  (Visualiser/Renommer/Télécharger/Supprimer).
+- Reuse the existing generic document infrastructure (S3 storage, upload
+  validation, DTOs, frontend components) rather than duplicating it.
+- Centralize the one meaningful piece of duplicated permission logic
+  (`DocumentCard`'s inline write-check) into a single shared function.
+
+## Non-goals
+
+- Pagination of the campaign document list — housing documents don't
+  paginate either; out of scope until a real need appears.
+- A visible audit/history UI for campaign document events — the event
+  tables are added for traceability parity with housing, but no timeline
+  component is wired up for campaigns today (none exists for campaigns at
+  all yet).
+- Changing who can access campaigns overall, or introducing a per-document
+  ownership/ACL model — the existing flat, establishment-scoped + role-based
+  permission model is preserved as-is, just applied to campaigns too.
+- URL-based deep-linking to a specific tab — the existing `Tabs` usage on
+  this page is uncontrolled (no tab is reflected in the URL today); this
+  feature doesn't change that.
+
+## Approach
+
+Many-to-many junction table (`documents_campaigns`), mirroring the existing
+`documents_housings` pattern 1:1, per the codebase's own extension guide
+(`docs/guides/document-upload-architecture.md`, "Extending to Other Domains
+→ Adding Campaign Documents"). The generic `documents` table remains
+entity-agnostic; campaigns get their own junction + event tables, repository,
+controller methods, and routes, all copy-adapted from the housing
+equivalents.
+
+### Alternatives considered
+
+- **Direct FK `documents.campaign_id`** (mirrors `senders.signatory_one_document_id`):
+  less code short-term, but makes `documents` entity-aware, breaks symmetry
+  with housing's many-to-many model (two different linking mechanics to
+  remember per entity), and forecloses documents ever being shared across
+  campaigns without a migration. Rejected.
+- **Denormalized document-ID array on `campaigns`**: no new table, but no FK
+  integrity, no cascade delete, no reverse lookup, and a total break from
+  every existing linking pattern in the codebase. Rejected outright.
+
+## Architecture
+
+### Data model
+
+Two new migrations (timestamped per existing convention), both mirroring
+the housing-document migrations:
+
+**`documents_campaigns`** (junction table):
+
+```sql
+CREATE TABLE documents_campaigns (
+  document_id UUID NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
+  campaign_id UUID NOT NULL REFERENCES campaigns(id) ON DELETE CASCADE,
+  PRIMARY KEY (document_id, campaign_id)
+);
+CREATE INDEX ON documents_campaigns (campaign_id);
+```
+
+**`campaign_document_events`** (audit trail, mirrors `housing_document_events`):
+
+```sql
+CREATE TABLE campaign_document_events (
+  event_id UUID PRIMARY KEY REFERENCES events(id),
+  document_id UUID NOT NULL REFERENCES documents(id),
+  campaign_id UUID NOT NULL REFERENCES campaigns(id)
+);
+```
+
+**Constant rename** (`packages/models`): `ACCEPTED_HOUSING_DOCUMENT_EXTENSIONS`
+and `MAX_HOUSING_DOCUMENT_SIZE_IN_MiB` move out of `HousingDocumentDTO.ts`
+into `DocumentDTO.ts` as entity-agnostic `ACCEPTED_DOCUMENT_EXTENSIONS` /
+`MAX_DOCUMENT_SIZE_IN_MiB` (values unchanged: 25 MiB, same format list).
+`HousingDocumentDTO.ts` keeps only its `HousingDocumentDTO` type alias. Every
+existing usage is updated to the renamed import — this is a mechanical
+rename, not a behavior change, and the Figma spec for campaign uploads uses
+identical limits so no divergent campaign-specific constants are needed.
+
+**New DTOs / models**:
+
+- `packages/models/src/CampaignDocumentDTO.ts` — `export type CampaignDocumentDTO = DocumentDTO;`
+  (mirrors `HousingDocumentDTO.ts`).
+- `server/src/models/CampaignDocumentApi.ts` — `CampaignDocumentApi extends DocumentApi { campaignId }`,
+  `toCampaignDocumentDTO()` (mirrors `HousingDocumentApi.ts`).
+- `server/src/models/EventApi.ts` — add `CampaignDocumentEventApi` union member
+  (`campaign:document-attached | campaign:document-detached | campaign:document-removed`),
+  mirroring `HousingDocumentEventApi`.
+
+**Schema**: `packages/schemas/src/campaign-document-payload.ts` —
+`{ documentIds: string[] }` (mirrors `housing-document-payload.ts`), exported
+as `schemas.campaignDocumentPayload`, with the same `@fast-check/vitest`
+property-based test coverage.
+
+### Shared permission helper
+
+The generic role check (`isAdmin`/`isUsual`) is already centralized in the
+`useUser()` hook; the only place a compound rule is written inline today is
+`DocumentCard.tsx:70` — `isAdmin || (isUsual && sameEstablishment)`. Since
+`DocumentCard` is reused verbatim for campaign documents (no new frontend
+call site), this is extracted once:
+
+```ts
+// packages/models/src/DocumentDTO.ts (or an adjacent file)
+export function canWriteDocument(
+  role: UserRole,
+  sameEstablishment: boolean
+): boolean {
+  return (
+    role === UserRole.ADMIN || (role === UserRole.USUAL && sameEstablishment)
+  );
+}
+```
+
+`DocumentCard.tsx` calls this in place of its inline expression. The backend
+`hasRole([UserRole.USUAL, UserRole.ADMIN])` middleware is a different shape
+(Express middleware vs. pure predicate) and establishment-scoping there is
+already enforced structurally via repository query filters — full
+unification isn't practical, so the backend keeps its existing mechanism.
+This is a residual, accepted duplication, called out explicitly rather than
+hidden: if the role rule ever changes, both `canWriteDocument` and the
+`hasRole([...])` call sites need updating together.
+
+### Backend chain
+
+**Repository** — `server/src/repositories/campaignDocumentRepository.ts`,
+mirrors `housingDocumentRepository.ts` with a simpler 2-column composite key
+(no geo-code): `link`, `linkMany` (idempotent, `ON CONFLICT DO NOTHING`),
+`unlink`, `unlinkMany`, `find`, `get`, `remove`.
+
+**Controller** — extend `server/src/controllers/documentController.ts` with
+three new handlers, mirroring `linkToHousing` / `listByHousing` /
+`removeByHousing` line-for-line:
+
+- `linkToCampaign` — validates the campaign exists and belongs to the
+  establishment (`campaignRepository.findOne({ id, filters: { establishmentId } })`),
+  validates the referenced documents exist and belong to the establishment,
+  inserts junction rows via `campaignDocumentRepository.linkMany`, emits
+  `campaign:document-attached` events.
+- `listByCampaign` — validates the campaign, returns all linked documents
+  with fresh pre-signed URLs.
+- `removeByCampaign` — unlinks only (keeps the underlying document, matching
+  `removeByHousing`), emits `campaign:document-detached`.
+
+`create` / `update` / `remove` (the entity-agnostic document CRUD) are
+untouched — campaign uploads hit the same `POST /documents` endpoint housing
+uploads already use, just now configured with the renamed generic constants.
+`remove`'s existing cascade-cleanup logic (S3 delete, unlink from all
+parents, `document:removed` event) is extended to also unlink and emit
+`campaign:document-removed` for any linked campaigns, mirroring what it
+already does for linked housings.
+
+**Router** (`server/src/routers/protected.ts`), same shape as the housing
+routes:
+
+```ts
+router.get(
+  '/campaigns/:id/documents',
+  validator.validate({ params: object({ id: schemas.id }) }),
+  documentController.listByCampaign
+);
+
+router.post(
+  '/campaigns/:id/documents',
+  hasRole([UserRole.USUAL, UserRole.ADMIN]),
+  validator.validate({
+    params: object({ id: schemas.id }),
+    body: schemas.campaignDocumentPayload
+  }),
+  documentController.linkToCampaign
+);
+
+router.delete(
+  '/campaigns/:id/documents/:documentId',
+  hasRole([UserRole.USUAL, UserRole.ADMIN]),
+  validator.validate({
+    params: object({ id: schemas.id, documentId: schemas.id })
+  }),
+  documentController.removeByCampaign
+);
+```
+
+### Frontend
+
+**New components**:
+
+- `frontend/src/components/FileUpload/CampaignDocumentUpload.tsx` — mirrors
+  `HousingDocumentUpload.tsx`: campaign-specific label ("Associez un ou
+  plusieurs documents à cette campagne") + hint text over the shared
+  `DocumentUpload` + `useDocumentUpload` primitives, using the renamed
+  generic constants.
+- `frontend/src/components/Campaign/CampaignDocumentsTab.tsx` — mirrors
+  `HousingDetails/DocumentsTab.tsx`: upload header (gated by
+  `isAdmin || isUsual`), empty state ("Il n'y a pas de document associé à
+  cette campagne"), grid of `DocumentCard`s under a "Documents (N)" heading,
+  wires up `DocumentDeleteModal` / `DocumentRenameModal` /
+  `DocumentFullscreenPreview`. No pagination.
+- `DocumentCard.tsx` — one-line change: inline `canWrite` expression becomes
+  a call to `canWriteDocument(role, sameEstablishment)`. Otherwise unchanged,
+  reused as-is for both housing and campaign documents.
+
+**RTK Query** (`frontend/src/services/document.service.ts`, extending the
+existing `documentApi`):
+
+- `useFindCampaignDocumentsQuery(campaignId)` → `GET /campaigns/:id/documents`
+- `useLinkDocumentsToCampaignMutation()` → `POST /campaigns/:id/documents { documentIds }`
+- `useUnlinkCampaignDocumentMutation()` → `DELETE /campaigns/:id/documents/:documentId`,
+  same optimistic cache-patch pattern as `useUnlinkDocumentMutation`.
+- `useUploadDocumentsMutation` / `useUpdateDocumentMutation` /
+  `useDeleteDocumentMutation` reused unchanged (already entity-agnostic).
+
+**Wiring into `CampaignView.tsx`**: add a third, lazy-loaded tab after
+Destinataires and Courrier:
+
+```tsx
+const CampaignDocumentsTabLazy = lazy(() => import('~/components/Campaign/CampaignDocumentsTab'));
+// ...
+tabs={[
+  { label: 'Destinataires', content: <CampaignRecipientsNext campaign={campaign} /> },
+  { label: 'Courrier', content: /* existing DraftForm branch */ },
+  { label: 'Documents', content: <CampaignDocumentsTabLazy campaign={campaign} /> }
+]}
+```
+
+No URL sync — matches the existing uncontrolled `Tabs` usage on this page.
+
+**MSW mocks**: extend `frontend/src/mocks/handlers/document-handlers.ts`
+with campaign-scoped handlers against a new `data.campaignDocuments` map,
+alongside the existing `data.housingDocuments`.
+
+## Testing strategy (TDD, mandatory)
+
+Backend order per `.claude/rules/backend-conventions.md`: Router → Controller
+test → Controller → Repository test → Repository.
+
+- `packages/schemas/src/test/campaign-document-payload.test.ts` — property-based,
+  mirrors `housing-document-payload.test.ts`.
+- `packages/models/src/test/*.test.ts` — unit test for `canWriteDocument`:
+  ADMIN (any establishment) → true; USUAL + same establishment → true;
+  USUAL + different establishment → false; VISITOR → false.
+- `server/src/models/test/CampaignDocumentApi.test.ts` — mirrors
+  `DocumentApi.test.ts` (DTO conversion, pre-signed URL generation).
+- `server/src/repositories/test/campaignDocumentRepository.test.ts` —
+  mirrors `housingDocumentRepository.test.ts`: link / idempotent linkMany /
+  unlink / unlinkMany / find / get / remove, asserted via primitive table
+  accessors.
+- `server/src/controllers/test/campaign-document-api.test.ts` (supertest) —
+  `GET/POST /campaigns/:id/documents`, `DELETE /campaigns/:id/documents/:documentId`:
+  success paths, campaign/document not-found or wrong-establishment (404),
+  role gate (403 for `VISITOR`), event rows asserted via primitive accessors.
+- `frontend/src/components/FileUpload/test/CampaignDocumentUpload.test.tsx`
+  and `frontend/src/components/Campaign/test/CampaignDocumentsTab.test.tsx` —
+  loading/empty/populated states, upload/rename/delete flows, permission
+  gating across `USUAL`/`ADMIN`/`VISITOR` and cross-establishment, via MSW
+  (never `vi.mock` for network data).
+- Extend `frontend/src/views/Campaign/test/CampaignView.test.tsx` with a
+  view-level integration test for the full Documents tab flow (click tab →
+  upload zone + existing docs visible → upload → appears in list → rename →
+  delete), following the `GroupViewNext.test.tsx` pattern.
+- `DocumentCard.test.tsx` — quick regression pass since `canWrite` now
+  delegates to the shared helper; same behavior expected.
+
+### RGAA note
+
+This feature reuses `DocumentCard`, `DocumentsTab`'s structure,
+`DocumentUpload`, and the DSFR `Tabs`/`Dropdown` components as-is (already
+accessible in production for housing) — no new interactive pattern is
+introduced. The new campaign-specific files are thin wiring/label wrappers.
+Thématiques 7 (Dropdown/focus handling) and 11 (upload zone as a form
+control) will be re-verified against the reused components once wired into
+the campaign context; anything unexpected will be flagged explicitly.
+
+## Risks & trade-offs
+
+- **Cross-cutting rename** — renaming `ACCEPTED_HOUSING_DOCUMENT_EXTENSIONS`/
+  `MAX_HOUSING_DOCUMENT_SIZE_IN_MiB` touches existing housing-document call
+  sites (controller, router, `HousingDocumentUpload.tsx`, tests). Mechanical
+  and low-risk (same values, just renamed), but every call site must be
+  updated in the same change to avoid a broken import.
+- **Residual permission duplication** — the backend's `hasRole([...])` gate
+  and the new `canWriteDocument` frontend helper encode the same rule via
+  different mechanisms and aren't automatically kept in sync. Accepted and
+  documented rather than solved, since the two systems (Express middleware
+  vs. pure predicate) aren't practically unifiable here.
+- **No campaign event history UI yet** — `campaign_document_events` rows are
+  written for traceability but have no visible timeline consumer today,
+  matching the current state of campaign events generally.
+
+## Implementation order (TDD)
+
+1. `packages/models`: rename constants to generic names, add `CampaignDocumentDTO`,
+   add `canWriteDocument`. Add/update unit tests first.
+2. `packages/schemas`: add `campaignDocumentPayload` + property-based tests.
+3. Migrations: `documents_campaigns`, `campaign_document_events`.
+4. Backend: repository test → `campaignDocumentRepository.ts`; controller
+   test → `documentController.ts` additions; router wiring in `protected.ts`.
+5. Frontend: `document.service.ts` endpoints + MSW handlers →
+   `CampaignDocumentUpload.tsx` → `CampaignDocumentsTab.tsx` (tests first for
+   each) → wire into `CampaignView.tsx`.
+6. Verify: manual pass against the Figma screenshot (upload, list, rename,
+   delete, permission gating) + full test suite + RGAA re-check on reused
+   interactive components.

--- a/frontend/src/components/Campaign/CampaignDocumentsTab.tsx
+++ b/frontend/src/components/Campaign/CampaignDocumentsTab.tsx
@@ -1,0 +1,255 @@
+import Pictures from '@codegouvfr/react-dsfr/picto/Pictures';
+import Grid from '@mui/material/Grid';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import type { CampaignDTO, DocumentDTO } from '@zerologementvacant/models';
+import type { ReactNode } from 'react';
+import { useId, useMemo, useState } from 'react';
+import { match, Pattern } from 'ts-pattern';
+
+import CampaignDocumentUpload from '~/components/FileUpload/CampaignDocumentUpload';
+import DocumentFullscreenPreview from '~/components/FileUpload/DocumentFullscreenPreview';
+import DocumentCard, {
+  type DocumentCardProps
+} from '~/components/HousingDetails/DocumentCard';
+import { createDocumentDeleteModal } from '~/components/HousingDetails/DocumentDeleteModal';
+import { createDocumentRenameModal } from '~/components/HousingDetails/DocumentRenameModal';
+import { useNotification } from '~/hooks/useNotification';
+import { useUser } from '~/hooks/useUser';
+import {
+  useFindCampaignDocumentsQuery,
+  useLinkDocumentsToCampaignMutation,
+  useUnlinkCampaignDocumentMutation,
+  useUpdateDocumentMutation
+} from '~/services/document.service';
+
+export interface CampaignDocumentsTabProps {
+  campaign: CampaignDTO;
+}
+
+function CampaignDocumentsTab(props: Readonly<CampaignDocumentsTabProps>) {
+  const { campaign } = props;
+
+  const {
+    data: documents,
+    isLoading,
+    isSuccess
+  } = useFindCampaignDocumentsQuery(campaign.id);
+
+  const [linkDocuments] = useLinkDocumentsToCampaignMutation();
+  function onUpload(uploaded: ReadonlyArray<DocumentDTO>): void {
+    linkDocuments({
+      campaignId: campaign.id,
+      documentIds: uploaded.map((document) => document.id)
+    });
+  }
+
+  const [updateDocument, updateDocumentMutation] = useUpdateDocumentMutation();
+  useNotification({
+    toastId: 'document-update',
+    isError: updateDocumentMutation.isError,
+    isLoading: updateDocumentMutation.isLoading,
+    isSuccess: updateDocumentMutation.isSuccess,
+    message: {
+      error: 'Erreur lors du renommage du document.',
+      loading: 'Renommage du document...',
+      success: 'Document renommé !'
+    }
+  });
+  function onRename(document: DocumentDTO): void {
+    updateDocument({ id: document.id, filename: document.filename });
+  }
+
+  const [unlinkDocument, unlinkDocumentMutation] =
+    useUnlinkCampaignDocumentMutation();
+  useNotification({
+    toastId: 'document-delete',
+    isError: unlinkDocumentMutation.isError,
+    isLoading: unlinkDocumentMutation.isLoading,
+    isSuccess: unlinkDocumentMutation.isSuccess,
+    message: {
+      error: 'Erreur lors de la suppression du document',
+      loading: 'Suppression du document...',
+      success: 'Document supprimé !'
+    }
+  });
+  const onDelete: DocumentCardProps['onDelete'] = (document) => {
+    unlinkDocument({ campaignId: campaign.id, documentId: document.id });
+  };
+
+  const documentRenameModalId = useId();
+  const documentRenameModal = useMemo(
+    () => createDocumentRenameModal(documentRenameModalId),
+    [documentRenameModalId]
+  );
+  const documentDeleteModalId = useId();
+  const documentDeleteModal = useMemo(
+    () => createDocumentDeleteModal(documentDeleteModalId),
+    [documentDeleteModalId]
+  );
+
+  const { isUsual, isAdmin } = useUser();
+  const canUpload = isAdmin || isUsual;
+
+  const [selectedDocument, setSelectedDocument] = useState<DocumentDTO | null>(
+    null
+  );
+  const [documentToDelete, setDocumentToDelete] = useState<DocumentDTO | null>(
+    null
+  );
+  const [fullscreenPreviewIndex, setFullscreenPreviewIndex] = useState<
+    number | null
+  >(null);
+
+  function confirmRename(document: DocumentDTO): void {
+    setSelectedDocument(document);
+    documentRenameModal.open();
+  }
+
+  function cancelRename(): void {
+    documentRenameModal.close();
+    setSelectedDocument(null);
+  }
+
+  function renameDocument(filename: string): void {
+    if (!selectedDocument) {
+      return;
+    }
+    onRename({ ...selectedDocument, filename });
+    documentRenameModal.close();
+    setSelectedDocument(null);
+  }
+
+  function onVisualize(index: number): void {
+    setFullscreenPreviewIndex(index);
+  }
+
+  function confirmDeletion(document: DocumentDTO): void {
+    setDocumentToDelete(document);
+    documentDeleteModal.open();
+  }
+
+  function cancelDeletion(): void {
+    setDocumentToDelete(null);
+    documentDeleteModal.close();
+  }
+
+  function deleteDocument(): void {
+    if (!documentToDelete) {
+      return;
+    }
+    onDelete(documentToDelete);
+    documentDeleteModal.close();
+    setDocumentToDelete(null);
+  }
+
+  async function onDownload(document: DocumentDTO): Promise<void> {
+    try {
+      const response = await fetch(document.url);
+      const blob = await response.blob();
+      const url = globalThis.URL.createObjectURL(blob);
+      const link = globalThis.document.createElement('a');
+      link.href = url;
+      link.download = document.filename;
+      globalThis.document.body.appendChild(link);
+      link.click();
+      link.remove();
+      globalThis.URL.revokeObjectURL(url);
+    } catch (error) {
+      console.error('Failed to download document', error);
+    }
+  }
+
+  const documentList = documents ?? [];
+
+  return (
+    <>
+      <documentRenameModal.Component
+        document={selectedDocument}
+        onCancel={cancelRename}
+        onSubmit={renameDocument}
+        onDownload={() => {
+          if (selectedDocument) {
+            onDownload(selectedDocument);
+          }
+        }}
+      />
+      <documentDeleteModal.Component
+        onCancel={cancelDeletion}
+        onSubmit={deleteDocument}
+      />
+
+      {fullscreenPreviewIndex !== null && (
+        <DocumentFullscreenPreview
+          documents={documentList}
+          index={fullscreenPreviewIndex}
+          onIndexChange={setFullscreenPreviewIndex}
+          open={fullscreenPreviewIndex !== null}
+          onClose={() => {
+            setFullscreenPreviewIndex(null);
+          }}
+          onDownload={onDownload}
+        />
+      )}
+
+      <Stack component="section" spacing="2rem" useFlexGap>
+        {canUpload ? (
+          <Stack component="header">
+            <CampaignDocumentUpload onUpload={onUpload} />
+          </Stack>
+        ) : null}
+
+        {match({ documents: documentList, isLoading, isSuccess })
+          .returnType<ReactNode>()
+          .with({ isSuccess: true, documents: [] }, () => (
+            <Stack
+              component="section"
+              spacing="0.75rem"
+              useFlexGap
+              sx={{ alignItems: 'center', textAlign: 'center' }}
+            >
+              <Pictures width="7.5rem" height="7.5rem" />
+              <Typography
+                component="p"
+                variant="subtitle2"
+                sx={{ fontWeight: 500, width: '17rem' }}
+              >
+                Il n’y a pas de document associé à cette campagne
+              </Typography>
+            </Stack>
+          ))
+          .with(
+            {
+              isSuccess: true,
+              documents: [Pattern.any, ...Pattern.array(Pattern.any)]
+            },
+            ({ documents }) => (
+              <Stack spacing="1rem" useFlexGap>
+                <Typography component="h2" variant="h6">
+                  Documents ({documents.length})
+                </Typography>
+
+                <Grid container spacing="1rem">
+                  {documents.map((document, index) => (
+                    <Grid key={document.id} size={{ xs: 12, md: 6, xl: 4 }}>
+                      <DocumentCard
+                        document={document}
+                        index={index}
+                        onDelete={confirmDeletion}
+                        onDownload={onDownload}
+                        onRename={confirmRename}
+                        onVisualize={onVisualize}
+                      />
+                    </Grid>
+                  ))}
+                </Grid>
+              </Stack>
+            )
+          )
+          .otherwise(() => null)}
+      </Stack>
+    </>
+  );
+}
+
+export default CampaignDocumentsTab;

--- a/frontend/src/components/Campaign/CampaignDocumentsTab.tsx
+++ b/frontend/src/components/Campaign/CampaignDocumentsTab.tsx
@@ -1,21 +1,9 @@
-import Pictures from '@codegouvfr/react-dsfr/picto/Pictures';
-import Grid from '@mui/material/Grid';
-import Stack from '@mui/material/Stack';
-import Typography from '@mui/material/Typography';
 import type { CampaignDTO, DocumentDTO } from '@zerologementvacant/models';
-import type { ReactNode } from 'react';
-import { useId, useMemo, useState } from 'react';
-import { match, Pattern } from 'ts-pattern';
 
 import CampaignDocumentUpload from '~/components/FileUpload/CampaignDocumentUpload';
-import DocumentFullscreenPreview from '~/components/FileUpload/DocumentFullscreenPreview';
-import DocumentCard, {
-  type DocumentCardProps
-} from '~/components/HousingDetails/DocumentCard';
-import { createDocumentDeleteModal } from '~/components/HousingDetails/DocumentDeleteModal';
-import { createDocumentRenameModal } from '~/components/HousingDetails/DocumentRenameModal';
+import type { DocumentCardProps } from '~/components/HousingDetails/DocumentCard';
+import DocumentsTab from '~/components/HousingDetails/DocumentsTab';
 import { useNotification } from '~/hooks/useNotification';
-import { useUser } from '~/hooks/useUser';
 import {
   useFindCampaignDocumentsQuery,
   useLinkDocumentsToCampaignMutation,
@@ -77,178 +65,16 @@ function CampaignDocumentsTab(props: Readonly<CampaignDocumentsTabProps>) {
     unlinkDocument({ campaignId: campaign.id, documentId: document.id });
   };
 
-  const documentRenameModalId = useId();
-  const documentRenameModal = useMemo(
-    () => createDocumentRenameModal(documentRenameModalId),
-    [documentRenameModalId]
-  );
-  const documentDeleteModalId = useId();
-  const documentDeleteModal = useMemo(
-    () => createDocumentDeleteModal(documentDeleteModalId),
-    [documentDeleteModalId]
-  );
-
-  const { isUsual, isAdmin } = useUser();
-  const canUpload = isAdmin || isUsual;
-
-  const [selectedDocument, setSelectedDocument] = useState<DocumentDTO | null>(
-    null
-  );
-  const [documentToDelete, setDocumentToDelete] = useState<DocumentDTO | null>(
-    null
-  );
-  const [fullscreenPreviewIndex, setFullscreenPreviewIndex] = useState<
-    number | null
-  >(null);
-
-  function confirmRename(document: DocumentDTO): void {
-    setSelectedDocument(document);
-    documentRenameModal.open();
-  }
-
-  function cancelRename(): void {
-    documentRenameModal.close();
-    setSelectedDocument(null);
-  }
-
-  function renameDocument(filename: string): void {
-    if (!selectedDocument) {
-      return;
-    }
-    onRename({ ...selectedDocument, filename });
-    documentRenameModal.close();
-    setSelectedDocument(null);
-  }
-
-  function onVisualize(index: number): void {
-    setFullscreenPreviewIndex(index);
-  }
-
-  function confirmDeletion(document: DocumentDTO): void {
-    setDocumentToDelete(document);
-    documentDeleteModal.open();
-  }
-
-  function cancelDeletion(): void {
-    setDocumentToDelete(null);
-    documentDeleteModal.close();
-  }
-
-  function deleteDocument(): void {
-    if (!documentToDelete) {
-      return;
-    }
-    onDelete(documentToDelete);
-    documentDeleteModal.close();
-    setDocumentToDelete(null);
-  }
-
-  async function onDownload(document: DocumentDTO): Promise<void> {
-    try {
-      const response = await fetch(document.url);
-      const blob = await response.blob();
-      const url = globalThis.URL.createObjectURL(blob);
-      const link = globalThis.document.createElement('a');
-      link.href = url;
-      link.download = document.filename;
-      globalThis.document.body.appendChild(link);
-      link.click();
-      link.remove();
-      globalThis.URL.revokeObjectURL(url);
-    } catch (error) {
-      console.error('Failed to download document', error);
-    }
-  }
-
-  const documentList = documents ?? [];
-
   return (
-    <>
-      <documentRenameModal.Component
-        document={selectedDocument}
-        onCancel={cancelRename}
-        onSubmit={renameDocument}
-        onDownload={() => {
-          if (selectedDocument) {
-            onDownload(selectedDocument);
-          }
-        }}
-      />
-      <documentDeleteModal.Component
-        onCancel={cancelDeletion}
-        onSubmit={deleteDocument}
-      />
-
-      {fullscreenPreviewIndex !== null && (
-        <DocumentFullscreenPreview
-          documents={documentList}
-          index={fullscreenPreviewIndex}
-          onIndexChange={setFullscreenPreviewIndex}
-          open={fullscreenPreviewIndex !== null}
-          onClose={() => {
-            setFullscreenPreviewIndex(null);
-          }}
-          onDownload={onDownload}
-        />
-      )}
-
-      <Stack component="section" spacing="2rem" useFlexGap>
-        {canUpload ? (
-          <Stack component="header">
-            <CampaignDocumentUpload onUpload={onUpload} />
-          </Stack>
-        ) : null}
-
-        {match({ documents: documentList, isLoading, isSuccess })
-          .returnType<ReactNode>()
-          .with({ isSuccess: true, documents: [] }, () => (
-            <Stack
-              component="section"
-              spacing="0.75rem"
-              useFlexGap
-              sx={{ alignItems: 'center', textAlign: 'center' }}
-            >
-              <Pictures width="7.5rem" height="7.5rem" />
-              <Typography
-                component="p"
-                variant="subtitle2"
-                sx={{ fontWeight: 500, width: '17rem' }}
-              >
-                Il n’y a pas de document associé à cette campagne
-              </Typography>
-            </Stack>
-          ))
-          .with(
-            {
-              isSuccess: true,
-              documents: [Pattern.any, ...Pattern.array(Pattern.any)]
-            },
-            ({ documents }) => (
-              <Stack spacing="1rem" useFlexGap>
-                <Typography component="h2" variant="h6">
-                  Documents ({documents.length})
-                </Typography>
-
-                <Grid container spacing="1rem">
-                  {documents.map((document, index) => (
-                    <Grid key={document.id} size={{ xs: 12, md: 6, xl: 4 }}>
-                      <DocumentCard
-                        document={document}
-                        index={index}
-                        onDelete={confirmDeletion}
-                        onDownload={onDownload}
-                        onRename={confirmRename}
-                        onVisualize={onVisualize}
-                      />
-                    </Grid>
-                  ))}
-                </Grid>
-              </Stack>
-            )
-          )
-          .otherwise(() => null)}
-      </Stack>
-    </>
+    <DocumentsTab
+      documents={documents ?? []}
+      isLoading={isLoading}
+      isSuccess={isSuccess}
+      onRename={onRename}
+      onDelete={onDelete}
+      emptyStateMessage="Il n’y a pas de document associé à cette campagne"
+      uploadSlot={<CampaignDocumentUpload onUpload={onUpload} />}
+    />
   );
 }
 

--- a/frontend/src/components/Campaign/CampaignDocumentsTab.tsx
+++ b/frontend/src/components/Campaign/CampaignDocumentsTab.tsx
@@ -21,10 +21,28 @@ function CampaignDocumentsTab(props: Readonly<CampaignDocumentsTabProps>) {
   const {
     data: documents,
     isLoading,
-    isSuccess
+    isSuccess,
+    isError,
+    refetch
   } = useFindCampaignDocumentsQuery(campaign.id);
 
-  const [linkDocuments] = useLinkDocumentsToCampaignMutation();
+  const [linkDocuments, linkDocumentsMutation] =
+    useLinkDocumentsToCampaignMutation();
+  // The upload zone reports success once files are stored, under the same
+  // "file-upload" toast. Reuse it so the final state reflects the attach step:
+  // if linking fails, the document exists but is not associated to the campaign.
+  useNotification({
+    toastId: 'file-upload',
+    isError: linkDocumentsMutation.isError,
+    isLoading: linkDocumentsMutation.isLoading,
+    isSuccess: linkDocumentsMutation.isSuccess,
+    message: {
+      error:
+        'Le document a été importé mais n’a pas pu être associé à la campagne. Veuillez réessayer.',
+      loading: 'Association du document à la campagne...',
+      success: 'Document associé à la campagne !'
+    }
+  });
   function onUpload(uploaded: ReadonlyArray<DocumentDTO>): void {
     linkDocuments({
       campaignId: campaign.id,
@@ -70,6 +88,8 @@ function CampaignDocumentsTab(props: Readonly<CampaignDocumentsTabProps>) {
       documents={documents ?? []}
       isLoading={isLoading}
       isSuccess={isSuccess}
+      isError={isError}
+      onRetry={refetch}
       onRename={onRename}
       onDelete={onDelete}
       emptyStateMessage="Il n’y a pas de document associé à cette campagne"

--- a/frontend/src/components/Campaign/test/CampaignDocumentsTab.test.tsx
+++ b/frontend/src/components/Campaign/test/CampaignDocumentsTab.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen } from '@testing-library/react';
+import { UserRole } from '@zerologementvacant/models';
+import {
+  genDocumentDTO,
+  genEstablishmentDTO,
+  genUserDTO
+} from '@zerologementvacant/models/fixtures';
+import { Provider } from 'react-redux';
+
+import data from '~/mocks/handlers/data';
+import { fromEstablishmentDTO } from '~/models/Establishment';
+import { fromUserDTO } from '~/models/User';
+import { factories } from '~/test/factories';
+import { genAuthUser } from '~/test/fixtures';
+import configureTestStore from '~/utils/storeUtils';
+
+import CampaignDocumentsTab from '../CampaignDocumentsTab';
+
+describe('CampaignDocumentsTab', () => {
+  function renderTab(role: UserRole) {
+    const establishment = genEstablishmentDTO();
+    const auth = genUserDTO(role, establishment);
+    const campaign = factories
+      .campaign(establishment)
+      .build({}, { associations: { createdBy: auth } });
+    data.campaigns.push(campaign);
+    const store = configureTestStore({
+      auth: genAuthUser(fromUserDTO(auth), fromEstablishmentDTO(establishment))
+    });
+
+    render(
+      <Provider store={store}>
+        <CampaignDocumentsTab campaign={campaign} />
+      </Provider>
+    );
+
+    return { campaign, establishment, auth };
+  }
+
+  it('shows an empty state message when there are no documents', async () => {
+    renderTab(UserRole.USUAL);
+
+    expect(
+      await screen.findByText(
+        /Il n’y a pas de document associé à cette campagne/i
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('displays existing documents', async () => {
+    const establishment = genEstablishmentDTO();
+    const auth = genUserDTO(UserRole.USUAL, establishment);
+    const campaign = factories
+      .campaign(establishment)
+      .build({}, { associations: { createdBy: auth } });
+    const document = genDocumentDTO(auth, establishment);
+    data.campaigns.push(campaign);
+    data.documents.set(document.id, document);
+    data.campaignDocuments.set(campaign.id, [document]);
+    const store = configureTestStore({
+      auth: genAuthUser(fromUserDTO(auth), fromEstablishmentDTO(establishment))
+    });
+
+    render(
+      <Provider store={store}>
+        <CampaignDocumentsTab campaign={campaign} />
+      </Provider>
+    );
+
+    expect(
+      await screen.findByText(new RegExp(document.filename, 'i'))
+    ).toBeInTheDocument();
+  });
+
+  it('shows the upload zone for a usual user', async () => {
+    renderTab(UserRole.USUAL);
+
+    expect(
+      await screen.findByText(
+        'Associez un ou plusieurs documents à cette campagne'
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('hides the upload zone for a visitor', async () => {
+    renderTab(UserRole.VISITOR);
+
+    await screen.findByText(/Il n’y a pas de document associé/i);
+    expect(
+      screen.queryByText('Associez un ou plusieurs documents à cette campagne')
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/Campaign/test/CampaignDocumentsTab.test.tsx
+++ b/frontend/src/components/Campaign/test/CampaignDocumentsTab.test.tsx
@@ -8,10 +8,8 @@ import {
 import { Provider } from 'react-redux';
 
 import data from '~/mocks/handlers/data';
-import { fromEstablishmentDTO } from '~/models/Establishment';
-import { fromUserDTO } from '~/models/User';
+import { MockAuthProvider } from '~/test/auth';
 import { factories } from '~/test/factories';
-import { genAuthUser } from '~/test/fixtures';
 import configureTestStore from '~/utils/storeUtils';
 
 import CampaignDocumentsTab from '../CampaignDocumentsTab';
@@ -24,13 +22,15 @@ describe('CampaignDocumentsTab', () => {
       .campaign(establishment)
       .build({}, { associations: { createdBy: auth } });
     data.campaigns.push(campaign);
-    const store = configureTestStore({
-      auth: genAuthUser(fromUserDTO(auth), fromEstablishmentDTO(establishment))
-    });
+    data.users.push(auth);
+    data.establishments.push(establishment);
+    const store = configureTestStore();
 
     render(
       <Provider store={store}>
-        <CampaignDocumentsTab campaign={campaign} />
+        <MockAuthProvider options={{ user: auth, establishment }}>
+          <CampaignDocumentsTab campaign={campaign} />
+        </MockAuthProvider>
       </Provider>
     );
 
@@ -57,13 +57,15 @@ describe('CampaignDocumentsTab', () => {
     data.campaigns.push(campaign);
     data.documents.set(document.id, document);
     data.campaignDocuments.set(campaign.id, [document]);
-    const store = configureTestStore({
-      auth: genAuthUser(fromUserDTO(auth), fromEstablishmentDTO(establishment))
-    });
+    data.users.push(auth);
+    data.establishments.push(establishment);
+    const store = configureTestStore();
 
     render(
       <Provider store={store}>
-        <CampaignDocumentsTab campaign={campaign} />
+        <MockAuthProvider options={{ user: auth, establishment }}>
+          <CampaignDocumentsTab campaign={campaign} />
+        </MockAuthProvider>
       </Provider>
     );
 

--- a/frontend/src/components/Campaign/test/CampaignDocumentsTab.test.tsx
+++ b/frontend/src/components/Campaign/test/CampaignDocumentsTab.test.tsx
@@ -1,15 +1,20 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { UserRole } from '@zerologementvacant/models';
 import {
   genDocumentDTO,
   genEstablishmentDTO,
   genUserDTO
 } from '@zerologementvacant/models/fixtures';
+import { http, HttpResponse } from 'msw';
 import { Provider } from 'react-redux';
 
+import Notification from '~/components/Notification/Notification';
 import data from '~/mocks/handlers/data';
+import { mockAPI } from '~/mocks/mock-api';
 import { MockAuthProvider } from '~/test/auth';
 import { factories } from '~/test/factories';
+import config from '~/utils/config';
 import configureTestStore from '~/utils/storeUtils';
 
 import CampaignDocumentsTab from '../CampaignDocumentsTab';
@@ -71,6 +76,113 @@ describe('CampaignDocumentsTab', () => {
 
     expect(
       await screen.findByText(new RegExp(document.filename, 'i'))
+    ).toBeInTheDocument();
+  });
+
+  it('renders the documents as an accessible list', async () => {
+    const establishment = genEstablishmentDTO();
+    const auth = genUserDTO(UserRole.USUAL, establishment);
+    const campaign = factories
+      .campaign(establishment)
+      .build({}, { associations: { createdBy: auth } });
+    const document = genDocumentDTO(auth, establishment);
+    data.campaigns.push(campaign);
+    data.documents.set(document.id, document);
+    data.campaignDocuments.set(campaign.id, [document]);
+    data.users.push(auth);
+    data.establishments.push(establishment);
+    const store = configureTestStore();
+
+    render(
+      <Provider store={store}>
+        <MockAuthProvider options={{ user: auth, establishment }}>
+          <CampaignDocumentsTab campaign={campaign} />
+        </MockAuthProvider>
+      </Provider>
+    );
+
+    await screen.findByText(new RegExp(document.filename, 'i'));
+
+    expect(screen.getByRole('list')).toBeInTheDocument();
+    expect(screen.getAllByRole('listitem')).toHaveLength(1);
+  });
+
+  it('shows an error alert with a retry action when loading fails', async () => {
+    const establishment = genEstablishmentDTO();
+    const auth = genUserDTO(UserRole.USUAL, establishment);
+    const campaign = factories
+      .campaign(establishment)
+      .build({}, { associations: { createdBy: auth } });
+    data.campaigns.push(campaign);
+    data.users.push(auth);
+    data.establishments.push(establishment);
+    mockAPI.use(
+      http.get(`${config.apiEndpoint}/campaigns/:id/documents`, () =>
+        HttpResponse.json(
+          { name: 'ServerError', message: 'boom' },
+          { status: 500 }
+        )
+      )
+    );
+    const store = configureTestStore();
+
+    render(
+      <Provider store={store}>
+        <MockAuthProvider options={{ user: auth, establishment }}>
+          <CampaignDocumentsTab campaign={campaign} />
+        </MockAuthProvider>
+      </Provider>
+    );
+
+    expect(
+      await screen.findByText(/Le chargement des documents a échoué/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Réessayer/i })
+    ).toBeInTheDocument();
+  });
+
+  it('warns when a document was uploaded but could not be attached to the campaign', async () => {
+    const user = userEvent.setup();
+    const establishment = genEstablishmentDTO();
+    const auth = genUserDTO(UserRole.USUAL, establishment);
+    const campaign = factories
+      .campaign(establishment)
+      .build({}, { associations: { createdBy: auth } });
+    data.campaigns.push(campaign);
+    data.users.push(auth);
+    data.establishments.push(establishment);
+    data.authSession.userId = auth.id;
+    data.authSession.establishmentId = establishment.id;
+    mockAPI.use(
+      http.post(`${config.apiEndpoint}/campaigns/:id/documents`, () =>
+        HttpResponse.json(
+          { name: 'ServerError', message: 'boom' },
+          { status: 500 }
+        )
+      )
+    );
+    const store = configureTestStore();
+
+    render(
+      <Provider store={store}>
+        <MockAuthProvider options={{ user: auth, establishment }}>
+          <CampaignDocumentsTab campaign={campaign} />
+          <Notification />
+        </MockAuthProvider>
+      </Provider>
+    );
+
+    const input = await screen.findByLabelText(
+      /Associez un ou plusieurs documents/i
+    );
+    const file = new File(['content'], 'contrat.pdf', {
+      type: 'application/pdf'
+    });
+    await user.upload(input, file);
+
+    expect(
+      await screen.findByText(/pas pu être associé à la campagne/i)
     ).toBeInTheDocument();
   });
 

--- a/frontend/src/components/EventsHistory/AggregatedEventCard.tsx
+++ b/frontend/src/components/EventsHistory/AggregatedEventCard.tsx
@@ -150,6 +150,9 @@ function AggregatedEventCard(props: AggregatedEventCardProps) {
           {
             type: Pattern.union(
               'campaign:updated',
+              'campaign:document-attached',
+              'campaign:document-detached',
+              'campaign:document-removed',
               'document:created',
               'document:updated',
               'document:removed',

--- a/frontend/src/components/EventsHistory/IndividualEventCard.tsx
+++ b/frontend/src/components/EventsHistory/IndividualEventCard.tsx
@@ -130,6 +130,9 @@ function IndividualEventCard(props: IndividualEventCardProps) {
           type: Pattern.union(
             'owner:created',
             'campaign:updated',
+            'campaign:document-attached',
+            'campaign:document-detached',
+            'campaign:document-removed',
             'document:created',
             'document:updated',
             'document:removed',

--- a/frontend/src/components/FileUpload/CampaignDocumentUpload.tsx
+++ b/frontend/src/components/FileUpload/CampaignDocumentUpload.tsx
@@ -7,6 +7,7 @@ import {
 import DocumentUpload, {
   type DocumentUploadProps
 } from '~/components/FileUpload/DocumentUpload';
+import DocumentUploadHint from '~/components/FileUpload/DocumentUploadHint';
 import { useDocumentUpload } from '~/components/FileUpload/useDocumentUpload';
 
 export type CampaignDocumentUploadProps = Pick<DocumentUploadProps, 'label'> & {
@@ -27,23 +28,7 @@ function CampaignDocumentUpload(props: Readonly<CampaignDocumentUploadProps>) {
       id="campaign-document-upload"
       accept={ACCEPTED_DOCUMENT_EXTENSIONS as string[]}
       error={error}
-      hint={
-        <div>
-          Taille maximale par fichier : 25Mo. Formats supportés : images (png,
-          jpg, heic, webp, etc.) et documents (docx, xlsx, ppt, etc.). Le nom du
-          fichier doit faire moins de 255 caractères. Plusieurs fichiers
-          possibles. Veillez à ne pas partager de{' '}
-          <a
-            href="https://cnil.fr/fr/definition/donnee-sensible#:~:text=Ce%20sont%20des%20informations%20qui,physique%20de%20mani%C3%A8re%20unique%2C%20des."
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            données sensibles
-            <span className="fr-sr-only"> (nouvelle fenêtre)</span>
-          </a>
-          .
-        </div>
-      }
+      hint={<DocumentUploadHint />}
       isError={isError}
       isLoading={isLoading}
       isSuccess={isSuccess}

--- a/frontend/src/components/FileUpload/CampaignDocumentUpload.tsx
+++ b/frontend/src/components/FileUpload/CampaignDocumentUpload.tsx
@@ -39,6 +39,7 @@ function CampaignDocumentUpload(props: Readonly<CampaignDocumentUploadProps>) {
             rel="noopener noreferrer"
           >
             données sensibles
+            <span className="fr-sr-only"> (nouvelle fenêtre)</span>
           </a>
           .
         </div>

--- a/frontend/src/components/FileUpload/CampaignDocumentUpload.tsx
+++ b/frontend/src/components/FileUpload/CampaignDocumentUpload.tsx
@@ -1,0 +1,59 @@
+import {
+  ACCEPTED_DOCUMENT_EXTENSIONS,
+  MAX_DOCUMENT_SIZE_IN_MiB,
+  type DocumentDTO
+} from '@zerologementvacant/models';
+
+import DocumentUpload, {
+  type DocumentUploadProps
+} from '~/components/FileUpload/DocumentUpload';
+import { useDocumentUpload } from '~/components/FileUpload/useDocumentUpload';
+
+export type CampaignDocumentUploadProps = Pick<DocumentUploadProps, 'label'> & {
+  /**
+   * Called every time documents are successfully uploaded.
+   * @param documents
+   */
+  onUpload(documents: ReadonlyArray<DocumentDTO>): void;
+};
+
+function CampaignDocumentUpload(props: Readonly<CampaignDocumentUploadProps>) {
+  const { error, isError, isLoading, isSuccess, upload } = useDocumentUpload({
+    onUpload: props.onUpload
+  });
+
+  return (
+    <DocumentUpload
+      id="campaign-document-upload"
+      accept={ACCEPTED_DOCUMENT_EXTENSIONS as string[]}
+      error={error}
+      hint={
+        <div>
+          Taille maximale par fichier : 25Mo. Formats supportés : images (png,
+          jpg, heic, webp, etc.) et documents (docx, xlsx, ppt, etc.). Le nom du
+          fichier doit faire moins de 255 caractères. Plusieurs fichiers
+          possibles. Veillez à ne pas partager de{' '}
+          <a
+            href="https://cnil.fr/fr/definition/donnee-sensible#:~:text=Ce%20sont%20des%20informations%20qui,physique%20de%20mani%C3%A8re%20unique%2C%20des."
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            données sensibles
+          </a>
+          .
+        </div>
+      }
+      isError={isError}
+      isLoading={isLoading}
+      isSuccess={isSuccess}
+      label={
+        props.label ?? 'Associez un ou plusieurs documents à cette campagne'
+      }
+      maxSize={MAX_DOCUMENT_SIZE_IN_MiB}
+      multiple
+      onUpload={upload}
+    />
+  );
+}
+
+export default CampaignDocumentUpload;

--- a/frontend/src/components/FileUpload/DocumentFullscreenPreview.tsx
+++ b/frontend/src/components/FileUpload/DocumentFullscreenPreview.tsx
@@ -52,7 +52,13 @@ function DocumentFullscreenPreview(
   }
 
   return (
-    <Modal {...modalProps} {...rest} role="dialog">
+    <Modal
+      {...modalProps}
+      {...rest}
+      role="dialog"
+      aria-modal
+      aria-label={`Aperçu du document : ${currentDocument.filename}`}
+    >
       <Container
         maxWidth="xl"
         sx={{ padding: '1.5rem', pb: '3rem', height: '100vh' }}

--- a/frontend/src/components/FileUpload/DocumentUploadHint.tsx
+++ b/frontend/src/components/FileUpload/DocumentUploadHint.tsx
@@ -1,0 +1,21 @@
+function DocumentUploadHint() {
+  return (
+    <div>
+      Taille maximale par fichier : 25Mo. Formats supportés : images (png, jpg,
+      heic, webp) et documents (pdf, doc, docx, xls, xlsx, ppt, pptx). Le nom du
+      fichier doit faire moins de 255 caractères. Plusieurs fichiers possibles.
+      Veillez à ne pas partager de{' '}
+      <a
+        href="https://cnil.fr/fr/definition/donnee-sensible#:~:text=Ce%20sont%20des%20informations%20qui,physique%20de%20mani%C3%A8re%20unique%2C%20des."
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        données sensibles
+        <span className="fr-sr-only"> (nouvelle fenêtre)</span>
+      </a>
+      .
+    </div>
+  );
+}
+
+export default DocumentUploadHint;

--- a/frontend/src/components/FileUpload/DocumentUploadHint.tsx
+++ b/frontend/src/components/FileUpload/DocumentUploadHint.tsx
@@ -1,6 +1,8 @@
 function DocumentUploadHint() {
+  // Rendered inside DSFR's `<span class="fr-hint-text">`, so the content must
+  // stay inline: a block element here would produce invalid `<span><div>` markup.
   return (
-    <div>
+    <>
       Taille maximale par fichier : 25Mo. Formats supportés : images (png, jpg,
       heic, webp) et documents (pdf, doc, docx, xls, xlsx, ppt, pptx). Le nom du
       fichier doit faire moins de 255 caractères. Plusieurs fichiers possibles.
@@ -14,7 +16,7 @@ function DocumentUploadHint() {
         <span className="fr-sr-only"> (nouvelle fenêtre)</span>
       </a>
       .
-    </div>
+    </>
   );
 }
 

--- a/frontend/src/components/FileUpload/HousingDocumentUpload.tsx
+++ b/frontend/src/components/FileUpload/HousingDocumentUpload.tsx
@@ -1,11 +1,13 @@
 import {
   ACCEPTED_DOCUMENT_EXTENSIONS,
+  MAX_DOCUMENT_SIZE_IN_MiB,
   type DocumentDTO
 } from '@zerologementvacant/models';
 
 import DocumentUpload, {
   type DocumentUploadProps
 } from '~/components/FileUpload/DocumentUpload';
+import DocumentUploadHint from '~/components/FileUpload/DocumentUploadHint';
 import { useDocumentUpload } from '~/components/FileUpload/useDocumentUpload';
 
 export type HousingDocumentUploadProps = Pick<DocumentUploadProps, 'label'> & {
@@ -26,28 +28,12 @@ function HousingDocumentUpload(props: Readonly<HousingDocumentUploadProps>) {
       id="housing-document-upload"
       accept={ACCEPTED_DOCUMENT_EXTENSIONS as string[]}
       error={error}
-      hint={
-        <div>
-          Taille maximale par fichier : 25Mo. Formats supportés : images (png,
-          jpg, heic, webp) et documents (pdf, doc, docx, xls, xlsx, ppt, pptx).
-          Le nom du fichier doit faire moins de 255 caractères. Plusieurs
-          fichiers possibles. Veillez à ne pas partager de{' '}
-          <a
-            href="https://cnil.fr/fr/definition/donnee-sensible#:~:text=Ce%20sont%20des%20informations%20qui,physique%20de%20mani%C3%A8re%20unique%2C%20des."
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            données sensibles
-            <span className="fr-sr-only"> (nouvelle fenêtre)</span>
-          </a>
-          .
-        </div>
-      }
+      hint={<DocumentUploadHint />}
       isError={isError}
       isLoading={isLoading}
       isSuccess={isSuccess}
       label={props.label ?? 'Associez un ou plusieurs documents à ce logement'}
-      maxSize={25}
+      maxSize={MAX_DOCUMENT_SIZE_IN_MiB}
       multiple
       onUpload={upload}
     />

--- a/frontend/src/components/FileUpload/HousingDocumentUpload.tsx
+++ b/frontend/src/components/FileUpload/HousingDocumentUpload.tsx
@@ -1,5 +1,5 @@
 import {
-  ACCEPTED_HOUSING_DOCUMENT_EXTENSIONS,
+  ACCEPTED_DOCUMENT_EXTENSIONS,
   type DocumentDTO
 } from '@zerologementvacant/models';
 
@@ -24,7 +24,7 @@ function HousingDocumentUpload(props: Readonly<HousingDocumentUploadProps>) {
   return (
     <DocumentUpload
       id="housing-document-upload"
-      accept={ACCEPTED_HOUSING_DOCUMENT_EXTENSIONS as string[]}
+      accept={ACCEPTED_DOCUMENT_EXTENSIONS as string[]}
       error={error}
       hint={
         <div>

--- a/frontend/src/components/FileUpload/HousingDocumentUpload.tsx
+++ b/frontend/src/components/FileUpload/HousingDocumentUpload.tsx
@@ -38,6 +38,7 @@ function HousingDocumentUpload(props: Readonly<HousingDocumentUploadProps>) {
             rel="noopener noreferrer"
           >
             données sensibles
+            <span className="fr-sr-only"> (nouvelle fenêtre)</span>
           </a>
           .
         </div>

--- a/frontend/src/components/FileUpload/test/CampaignDocumentUpload.test.tsx
+++ b/frontend/src/components/FileUpload/test/CampaignDocumentUpload.test.tsx
@@ -9,9 +9,7 @@ import { Provider } from 'react-redux';
 import { vi } from 'vitest';
 
 import data from '~/mocks/handlers/data';
-import { fromEstablishmentDTO } from '~/models/Establishment';
-import { fromUserDTO } from '~/models/User';
-import { genAuthUser } from '~/test/fixtures';
+import { MockAuthProvider } from '~/test/auth';
 import configureTestStore from '~/utils/storeUtils';
 
 import CampaignDocumentUpload from '../CampaignDocumentUpload';
@@ -25,14 +23,14 @@ describe('CampaignDocumentUpload', () => {
     data.users.push(auth);
     data.establishments.push(establishment);
 
-    const store = configureTestStore({
-      auth: genAuthUser(fromUserDTO(auth), fromEstablishmentDTO(establishment))
-    });
+    const store = configureTestStore();
     const onUpload = vi.fn();
 
     render(
       <Provider store={store}>
-        <CampaignDocumentUpload onUpload={onUpload} />
+        <MockAuthProvider options={{ user: auth, establishment }}>
+          <CampaignDocumentUpload onUpload={onUpload} />
+        </MockAuthProvider>
       </Provider>
     );
 

--- a/frontend/src/components/FileUpload/test/CampaignDocumentUpload.test.tsx
+++ b/frontend/src/components/FileUpload/test/CampaignDocumentUpload.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { UserRole } from '@zerologementvacant/models';
+import {
+  genEstablishmentDTO,
+  genUserDTO
+} from '@zerologementvacant/models/fixtures';
+import { Provider } from 'react-redux';
+import { vi } from 'vitest';
+
+import data from '~/mocks/handlers/data';
+import { fromEstablishmentDTO } from '~/models/Establishment';
+import { fromUserDTO } from '~/models/User';
+import { genAuthUser } from '~/test/fixtures';
+import configureTestStore from '~/utils/storeUtils';
+
+import CampaignDocumentUpload from '../CampaignDocumentUpload';
+
+describe('CampaignDocumentUpload', () => {
+  const user = userEvent.setup();
+
+  function setup() {
+    const establishment = genEstablishmentDTO();
+    const auth = genUserDTO(UserRole.USUAL, establishment);
+    data.users.push(auth);
+    data.establishments.push(establishment);
+
+    const store = configureTestStore({
+      auth: genAuthUser(fromUserDTO(auth), fromEstablishmentDTO(establishment))
+    });
+    const onUpload = vi.fn();
+
+    render(
+      <Provider store={store}>
+        <CampaignDocumentUpload onUpload={onUpload} />
+      </Provider>
+    );
+
+    return { onUpload };
+  }
+
+  it('renders the campaign-specific upload label', () => {
+    setup();
+
+    expect(
+      screen.getByText('Associez un ou plusieurs documents à cette campagne')
+    ).toBeInTheDocument();
+  });
+
+  it('accepts the generic document file types', () => {
+    setup();
+
+    const input = document.querySelector('input[type="file"]');
+    expect(input).toHaveAttribute('accept');
+    expect(input?.getAttribute('accept')).toContain('application/pdf');
+  });
+
+  it('calls onUpload with the created documents after a successful upload', async () => {
+    const { onUpload } = setup();
+    const file = new File(['content'], 'campagne.pdf', {
+      type: 'application/pdf'
+    });
+    const input = document.querySelector(
+      'input[type="file"]'
+    ) as HTMLInputElement;
+
+    await user.upload(input, file);
+
+    await waitFor(() => {
+      expect(onUpload).toHaveBeenCalledWith([
+        expect.objectContaining({ filename: 'campagne.pdf' })
+      ]);
+    });
+  });
+});

--- a/frontend/src/components/FileUpload/test/DocumentFullscreenPreview.test.tsx
+++ b/frontend/src/components/FileUpload/test/DocumentFullscreenPreview.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+import { UserRole } from '@zerologementvacant/models';
+import {
+  genDocumentDTO,
+  genEstablishmentDTO,
+  genUserDTO
+} from '@zerologementvacant/models/fixtures';
+import { describe, expect, it } from 'vitest';
+
+import DocumentFullscreenPreview from '../DocumentFullscreenPreview';
+
+describe('DocumentFullscreenPreview', () => {
+  it('exposes an accessible dialog name based on the current document', () => {
+    const establishment = genEstablishmentDTO();
+    const author = genUserDTO(UserRole.USUAL, establishment);
+    const document = genDocumentDTO(author, establishment);
+
+    render(
+      <DocumentFullscreenPreview
+        documents={[document]}
+        index={0}
+        open
+        onClose={() => {}}
+        onIndexChange={() => {}}
+      />
+    );
+
+    const dialog = screen.getByRole('dialog', {
+      name: (accessibleName) => accessibleName.includes(document.filename)
+    });
+    expect(dialog).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/HousingDetails/DocumentCard.tsx
+++ b/frontend/src/components/HousingDetails/DocumentCard.tsx
@@ -4,7 +4,11 @@ import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import { styled } from '@mui/material/styles';
 import Typography from '@mui/material/Typography';
-import type { DocumentDTO } from '@zerologementvacant/models';
+import {
+  canWriteDocument,
+  UserRole,
+  type DocumentDTO
+} from '@zerologementvacant/models';
 import mime from 'mime';
 import prettyBytes from 'pretty-bytes';
 import { useState } from 'react';
@@ -64,10 +68,13 @@ function DocumentCard(props: Readonly<DocumentCardProps>) {
     .getExtension(props.document.contentType)
     ?.toUpperCase();
 
-  const { isUsual, isAdmin, establishment } = useUser();
+  const { user, establishment } = useUser();
   const sameEstablishment: boolean =
     establishment?.id === props.document.establishmentId;
-  const canWrite: boolean = isAdmin || (isUsual && sameEstablishment);
+  const canWrite: boolean = canWriteDocument(
+    user?.role ?? UserRole.VISITOR,
+    sameEstablishment
+  );
 
   const [dropdownOpen, setDropdownOpen] = useState(false);
 

--- a/frontend/src/components/HousingDetails/DocumentsTab.tsx
+++ b/frontend/src/components/HousingDetails/DocumentsTab.tsx
@@ -8,9 +8,6 @@ import { useId, useMemo, useState } from 'react';
 import { match, Pattern } from 'ts-pattern';
 
 import DocumentFullscreenPreview from '~/components/FileUpload/DocumentFullscreenPreview';
-import HousingDocumentUpload, {
-  type HousingDocumentUploadProps
-} from '~/components/FileUpload/HousingDocumentUpload';
 import DocumentCard, {
   type DocumentCardProps
 } from '~/components/HousingDetails/DocumentCard';
@@ -23,7 +20,15 @@ export interface DocumentsTabProps {
   isLoading?: boolean;
   isSuccess?: boolean;
   documentCardProps?: Pick<DocumentCardProps, 'actions'>;
-  onUpload: HousingDocumentUploadProps['onUpload'];
+  /**
+   * The upload zone to render in the header, when the current user has write access.
+   * Rendered only if `canUpload` is true, so the caller does not need to gate it.
+   */
+  uploadSlot?: ReactNode;
+  /**
+   * @default 'Il n’y a pas de document associé à ce logement'
+   */
+  emptyStateMessage?: string;
   onRename(document: DocumentDTO): void;
   onDelete: DocumentCardProps['onDelete'];
 }
@@ -148,10 +153,8 @@ function DocumentsTab(props: Readonly<DocumentsTabProps>) {
       )}
 
       <Stack component="section" spacing="2rem" useFlexGap>
-        {canUpload ? (
-          <Stack component="header">
-            <HousingDocumentUpload onUpload={props.onUpload} />
-          </Stack>
+        {canUpload && props.uploadSlot ? (
+          <Stack component="header">{props.uploadSlot}</Stack>
         ) : null}
 
         {match({
@@ -173,7 +176,8 @@ function DocumentsTab(props: Readonly<DocumentsTabProps>) {
                 variant="subtitle2"
                 sx={{ fontWeight: 500, width: '17rem' }}
               >
-                Il n’y a pas de document associé à ce logement
+                {props.emptyStateMessage ??
+                  'Il n’y a pas de document associé à ce logement'}
               </Typography>
             </Stack>
           ))

--- a/frontend/src/components/HousingDetails/DocumentsTab.tsx
+++ b/frontend/src/components/HousingDetails/DocumentsTab.tsx
@@ -1,3 +1,5 @@
+import { Alert } from '@codegouvfr/react-dsfr/Alert';
+import { Button } from '@codegouvfr/react-dsfr/Button';
 import Pictures from '@codegouvfr/react-dsfr/picto/Pictures';
 import Grid from '@mui/material/Grid';
 import Stack from '@mui/material/Stack';
@@ -19,6 +21,12 @@ export interface DocumentsTabProps {
   documents: ReadonlyArray<DocumentDTO>;
   isLoading?: boolean;
   isSuccess?: boolean;
+  isError?: boolean;
+  /**
+   * Called when the user retries after a loading error. When provided, a retry
+   * button is shown alongside the error alert.
+   */
+  onRetry?: () => void;
   documentCardProps?: Pick<DocumentCardProps, 'actions'>;
   /**
    * The upload zone to render in the header, when the current user has write access.
@@ -160,9 +168,29 @@ function DocumentsTab(props: Readonly<DocumentsTabProps>) {
         {match({
           documents,
           isLoading: props.isLoading,
-          isSuccess: props.isSuccess
+          isSuccess: props.isSuccess,
+          isError: props.isError
         })
           .returnType<ReactNode>()
+          .with({ isError: true }, () => (
+            <Stack
+              component="section"
+              spacing="1rem"
+              useFlexGap
+              sx={{ alignItems: 'flex-start' }}
+            >
+              <Alert
+                severity="error"
+                title="Le chargement des documents a échoué"
+                description="Une erreur est survenue. Veuillez réessayer."
+              />
+              {props.onRetry ? (
+                <Button priority="secondary" onClick={props.onRetry}>
+                  Réessayer
+                </Button>
+              ) : null}
+            </Stack>
+          ))
           .with({ isSuccess: true, documents: [] }, () => (
             <Stack
               component="section"
@@ -192,9 +220,13 @@ function DocumentsTab(props: Readonly<DocumentsTabProps>) {
                   Documents ({documents.length})
                 </Typography>
 
-                <Grid container spacing="1rem">
+                <Grid container spacing="1rem" role="list">
                   {documents.map((document, index) => (
-                    <Grid key={document.id} size={{ xs: 12, md: 6, xl: 4 }}>
+                    <Grid
+                      key={document.id}
+                      size={{ xs: 12, md: 6, xl: 4 }}
+                      role="listitem"
+                    >
                       <DocumentCard
                         {...props.documentCardProps}
                         document={document}

--- a/frontend/src/components/HousingDetails/HousingDetailsCard.tsx
+++ b/frontend/src/components/HousingDetails/HousingDetailsCard.tsx
@@ -3,7 +3,9 @@ import Skeleton from '@mui/material/Skeleton';
 import { skipToken } from '@reduxjs/toolkit/query';
 import type { DocumentDTO } from '@zerologementvacant/models';
 
-import type { HousingDocumentUploadProps } from '~/components/FileUpload/HousingDocumentUpload';
+import HousingDocumentUpload, {
+  type HousingDocumentUploadProps
+} from '~/components/FileUpload/HousingDocumentUpload';
 import { useHousing } from '~/hooks/useHousing';
 import { useNotification } from '~/hooks/useNotification';
 import {
@@ -108,7 +110,7 @@ function HousingDetailsCard() {
               documents={housingDocuments ?? []}
               isLoading={isDocumentLoading}
               isSuccess={isDocumentSuccess}
-              onUpload={link}
+              uploadSlot={<HousingDocumentUpload onUpload={link} />}
               onRename={rename}
               onDelete={remove}
             />

--- a/frontend/src/components/HousingEdition/HousingEditionSideMenu.tsx
+++ b/frontend/src/components/HousingEdition/HousingEditionSideMenu.tsx
@@ -40,6 +40,9 @@ import {
 import type { Housing, HousingUpdate } from '../../models/Housing';
 import AppLink from '../_app/AppLink/AppLink';
 import Aside from '../Aside/Aside';
+import HousingDocumentUpload, {
+  type HousingDocumentUploadProps
+} from '../FileUpload/HousingDocumentUpload';
 import DocumentsTab, {
   type DocumentsTabProps
 } from '../HousingDetails/DocumentsTab';
@@ -246,7 +249,7 @@ function HousingEditionSideMenu(props: HousingEditionSideMenuProps) {
     resetRemoving();
   };
 
-  const onUpload: DocumentsTabProps['onUpload'] = (documents) => {
+  const onUpload: HousingDocumentUploadProps['onUpload'] = (documents) => {
     const currentDocuments = form.getValues('documents');
     form.setValue('documents', [...currentDocuments, ...documents]);
   };
@@ -283,7 +286,7 @@ function HousingEditionSideMenu(props: HousingEditionSideMenuProps) {
             documentCardProps={{ actions: 'remove-only' }}
             isLoading={false}
             isSuccess={true}
-            onUpload={onUpload}
+            uploadSlot={<HousingDocumentUpload onUpload={onUpload} />}
             onRename={() => {}}
             onDelete={onDelete}
           />

--- a/frontend/src/hooks/useNotification.ts
+++ b/frontend/src/hooks/useNotification.ts
@@ -23,6 +23,8 @@ export function useNotification(props: NotificationProps) {
     // `role="status"` (`aria-live="polite"`).
     if (props.isLoading) {
       const loading = props.message?.loading || 'Sauvegarde...';
+      // Loading and success are non-critical: announce them politely (role
+      // "status" → aria-live polite). Errors keep the assertive "alert" role.
       toast(loading, {
         autoClose: false,
         isLoading: true,

--- a/frontend/src/mocks/handlers/data.ts
+++ b/frontend/src/mocks/handlers/data.ts
@@ -24,6 +24,10 @@ import {
 const buildings: BuildingDTO[] = [];
 
 const campaigns: CampaignDTO[] = [];
+const campaignDocuments = new Map<
+  CampaignDTO['id'],
+  ReadonlyArray<Pick<DocumentDTO, 'id'>>
+>();
 const campaignDrafts = new Map<
   CampaignDTO['id'],
   ReadonlyArray<Pick<DraftDTO, 'id'>>
@@ -132,6 +136,7 @@ function reset(): void {
 export default {
   buildings,
   campaigns,
+  campaignDocuments,
   campaignDrafts,
   campaignHousings,
   datafoncierHousings,

--- a/frontend/src/mocks/handlers/data.ts
+++ b/frontend/src/mocks/handlers/data.ts
@@ -108,6 +108,7 @@ const authSession: {
 function reset(): void {
   buildings.length = 0;
   campaigns.length = 0;
+  campaignDocuments.clear();
   campaignDrafts.clear();
   campaignHousings.clear();
   datafoncierHousings.length = 0;

--- a/frontend/src/mocks/handlers/document-handlers.ts
+++ b/frontend/src/mocks/handlers/document-handlers.ts
@@ -28,9 +28,22 @@ const findByHousing = http.get<{ id: string }, never, DocumentDTO[]>(
   }
 );
 
-const findByCampaign = http.get<{ id: string }, never, DocumentDTO[]>(
+const findByCampaign = http.get<{ id: string }, never, DocumentDTO[] | Error>(
   `${config.apiEndpoint}/campaigns/:id/documents`,
   async ({ params }) => {
+    const campaign = data.campaigns.find(
+      (campaign) => campaign.id === params.id
+    );
+    if (!campaign) {
+      return HttpResponse.json(
+        {
+          name: 'CampaignMissingError',
+          message: `Campaign ${params.id} missing`
+        },
+        { status: constants.HTTP_STATUS_NOT_FOUND }
+      );
+    }
+
     const documents = (data.campaignDocuments.get(params.id) ?? [])
       .map((ref) => data.documents.get(ref.id))
       .filter(Predicate.isNotUndefined);

--- a/frontend/src/mocks/handlers/document-handlers.ts
+++ b/frontend/src/mocks/handlers/document-handlers.ts
@@ -1,6 +1,7 @@
 import { constants } from 'node:http2';
 
 import type {
+  CampaignDTO,
   DocumentDTO,
   DocumentPayload,
   HousingDTO
@@ -23,6 +24,96 @@ const findByHousing = http.get<{ id: string }, never, DocumentDTO[]>(
 
     return HttpResponse.json(documents, {
       status: constants.HTTP_STATUS_OK
+    });
+  }
+);
+
+const findByCampaign = http.get<{ id: string }, never, DocumentDTO[]>(
+  `${config.apiEndpoint}/campaigns/:id/documents`,
+  async ({ params }) => {
+    const documents = (data.campaignDocuments.get(params.id) ?? [])
+      .map((ref) => data.documents.get(ref.id))
+      .filter(Predicate.isNotUndefined);
+
+    return HttpResponse.json(documents, {
+      status: constants.HTTP_STATUS_OK
+    });
+  }
+);
+
+const linkToCampaign = http.post<
+  { id: CampaignDTO['id'] },
+  { documentIds: DocumentDTO['id'][] },
+  DocumentDTO[] | Error
+>(
+  `${config.apiEndpoint}/campaigns/:id/documents`,
+  async ({ params, request }) => {
+    const { documentIds } = await request.json();
+
+    const campaign = data.campaigns.find(
+      (campaign) => campaign.id === params.id
+    );
+    if (!campaign) {
+      return HttpResponse.json(
+        {
+          name: 'CampaignMissingError',
+          message: `Campaign ${params.id} missing`
+        },
+        { status: constants.HTTP_STATUS_NOT_FOUND }
+      );
+    }
+
+    const documents = documentIds
+      .map((id) => data.documents.get(id))
+      .filter(Predicate.isNotUndefined);
+
+    if (documents.length !== documentIds.length) {
+      return HttpResponse.json(
+        { name: 'DocumentMissingError', message: 'Some documents not found' },
+        { status: constants.HTTP_STATUS_BAD_REQUEST }
+      );
+    }
+
+    const existingDocuments = data.campaignDocuments.get(params.id) ?? [];
+    const newRefs = documentIds.map((id) => ({ id }));
+    data.campaignDocuments.set(params.id, [...existingDocuments, ...newRefs]);
+
+    return HttpResponse.json(documents, {
+      status: constants.HTTP_STATUS_CREATED
+    });
+  }
+);
+
+const unlinkFromCampaign = http.delete<
+  { id: CampaignDTO['id']; documentId: DocumentDTO['id'] },
+  never,
+  null | Error
+>(
+  `${config.apiEndpoint}/campaigns/:id/documents/:documentId`,
+  async ({ params }) => {
+    const exists = data.campaignDocuments
+      .get(params.id)
+      ?.map((document) => document.id)
+      ?.includes(params.documentId);
+    if (!exists) {
+      return HttpResponse.json(
+        {
+          name: 'DocumentMissingError',
+          message: `Document ${params.documentId} not linked to campaign`
+        },
+        { status: constants.HTTP_STATUS_NOT_FOUND }
+      );
+    }
+
+    data.campaignDocuments.set(
+      params.id,
+      (data.campaignDocuments.get(params.id) ?? []).filter(
+        (document) => document.id !== params.documentId
+      )
+    );
+
+    return HttpResponse.json(null, {
+      status: constants.HTTP_STATUS_NO_CONTENT
     });
   }
 );
@@ -217,5 +308,8 @@ export const documentHandlers: RequestHandler[] = [
   remove,
   findByHousing,
   linkToHousing,
-  unlinkFromHousing
+  unlinkFromHousing,
+  findByCampaign,
+  linkToCampaign,
+  unlinkFromCampaign
 ];

--- a/frontend/src/mocks/handlers/document-handlers.ts
+++ b/frontend/src/mocks/handlers/document-handlers.ts
@@ -74,19 +74,30 @@ const linkToCampaign = http.post<
       );
     }
 
-    const documents = documentIds
+    // Mirror the real controller: de-duplicate ids and only accept documents
+    // owned by the caller's establishment, 404-ing on any that are missing.
+    const auth = getMockSession();
+    const uniqueIds = [...new Set(documentIds)];
+    const documents = uniqueIds
       .map((id) => data.documents.get(id))
-      .filter(Predicate.isNotUndefined);
+      .filter(Predicate.isNotUndefined)
+      .filter(
+        (document) =>
+          !auth || document.establishmentId === auth.establishment.id
+      );
 
-    if (documents.length !== documentIds.length) {
+    if (documents.length !== uniqueIds.length) {
       return HttpResponse.json(
         { name: 'DocumentMissingError', message: 'Some documents not found' },
-        { status: constants.HTTP_STATUS_BAD_REQUEST }
+        { status: constants.HTTP_STATUS_NOT_FOUND }
       );
     }
 
     const existingDocuments = data.campaignDocuments.get(params.id) ?? [];
-    const newRefs = documentIds.map((id) => ({ id }));
+    const existingIds = new Set(existingDocuments.map((ref) => ref.id));
+    const newRefs = uniqueIds
+      .filter((id) => !existingIds.has(id))
+      .map((id) => ({ id }));
     data.campaignDocuments.set(params.id, [...existingDocuments, ...newRefs]);
 
     return HttpResponse.json(documents, {
@@ -197,21 +208,31 @@ const linkToHousing = http.post<
       );
     }
 
-    // Verify all documents exist
-    const documents = documentIds
+    // Mirror the real controller: de-duplicate ids and only accept documents
+    // owned by the caller's establishment, 404-ing on any that are missing.
+    const auth = getMockSession();
+    const uniqueIds = [...new Set(documentIds)];
+    const documents = uniqueIds
       .map((id) => data.documents.get(id))
-      .filter(Predicate.isNotUndefined);
+      .filter(Predicate.isNotUndefined)
+      .filter(
+        (document) =>
+          !auth || document.establishmentId === auth.establishment.id
+      );
 
-    if (documents.length !== documentIds.length) {
+    if (documents.length !== uniqueIds.length) {
       return HttpResponse.json(
         { name: 'DocumentMissingError', message: 'Some documents not found' },
-        { status: constants.HTTP_STATUS_BAD_REQUEST }
+        { status: constants.HTTP_STATUS_NOT_FOUND }
       );
     }
 
     // Link documents to housing
     const existingDocuments = data.housingDocuments.get(params.id) ?? [];
-    const newRefs = documentIds.map((id) => ({ id }));
+    const existingIds = new Set(existingDocuments.map((ref) => ref.id));
+    const newRefs = uniqueIds
+      .filter((id) => !existingIds.has(id))
+      .map((id) => ({ id }));
     data.housingDocuments.set(params.id, [...existingDocuments, ...newRefs]);
 
     return HttpResponse.json(documents, {

--- a/frontend/src/mocks/handlers/document-handlers.ts
+++ b/frontend/src/mocks/handlers/document-handlers.ts
@@ -20,7 +20,7 @@ const findByHousing = http.get<{ id: string }, never, DocumentDTO[]>(
   async ({ params }) => {
     const documents = (data.housingDocuments.get(params.id) ?? [])
       .map((ref) => data.documents.get(ref.id))
-      .filter(Predicate.isNotUndefined);
+      .filter((document) => Predicate.isNotUndefined(document));
 
     return HttpResponse.json(documents, {
       status: constants.HTTP_STATUS_OK
@@ -31,10 +31,8 @@ const findByHousing = http.get<{ id: string }, never, DocumentDTO[]>(
 const findByCampaign = http.get<{ id: string }, never, DocumentDTO[] | Error>(
   `${config.apiEndpoint}/campaigns/:id/documents`,
   async ({ params }) => {
-    const campaign = data.campaigns.find(
-      (campaign) => campaign.id === params.id
-    );
-    if (!campaign) {
+    const exists = data.campaigns.some((campaign) => campaign.id === params.id);
+    if (!exists) {
       return HttpResponse.json(
         {
           name: 'CampaignMissingError',
@@ -46,7 +44,7 @@ const findByCampaign = http.get<{ id: string }, never, DocumentDTO[] | Error>(
 
     const documents = (data.campaignDocuments.get(params.id) ?? [])
       .map((ref) => data.documents.get(ref.id))
-      .filter(Predicate.isNotUndefined);
+      .filter((document) => Predicate.isNotUndefined(document));
 
     return HttpResponse.json(documents, {
       status: constants.HTTP_STATUS_OK

--- a/frontend/src/services/document.service.ts
+++ b/frontend/src/services/document.service.ts
@@ -1,4 +1,5 @@
 import type {
+  CampaignDTO,
   DocumentDTO,
   DocumentPayload,
   HousingDocumentDTO,
@@ -54,6 +55,65 @@ export const documentApi = zlvApi.injectEndpoints({
       invalidatesTags: (_result, _error, { housingId }) => [
         { type: 'Document', id: `LIST-${housingId}` }
       ]
+    }),
+
+    findCampaignDocuments: builder.query<DocumentDTO[], CampaignDTO['id']>({
+      query: (campaignId) => `campaigns/${campaignId}/documents`,
+      providesTags: (documents, _error, campaignId) =>
+        documents
+          ? [
+              ...documents.map((document) => ({
+                type: 'Document' as const,
+                id: document.id
+              })),
+              { type: 'Document', id: `LIST-${campaignId}` }
+            ]
+          : [{ type: 'Document', id: `LIST-${campaignId}` }]
+    }),
+
+    linkDocumentsToCampaign: builder.mutation<
+      DocumentDTO[],
+      { campaignId: CampaignDTO['id']; documentIds: DocumentDTO['id'][] }
+    >({
+      query: ({ campaignId, documentIds }) => ({
+        url: `campaigns/${campaignId}/documents`,
+        method: 'POST',
+        body: { documentIds }
+      }),
+      invalidatesTags: (_result, _error, { campaignId }) => [
+        { type: 'Document', id: `LIST-${campaignId}` }
+      ]
+    }),
+
+    unlinkCampaignDocument: builder.mutation<
+      void,
+      { campaignId: CampaignDTO['id']; documentId: DocumentDTO['id'] }
+    >({
+      query: ({ campaignId, documentId }) => ({
+        url: `campaigns/${campaignId}/documents/${documentId}`,
+        method: 'DELETE'
+      }),
+      async onQueryStarted(
+        { campaignId, documentId },
+        { dispatch, queryFulfilled }
+      ) {
+        const patchResult = dispatch(
+          documentApi.util.updateQueryData(
+            'findCampaignDocuments',
+            campaignId,
+            (documents) => {
+              const index = documents.findIndex(
+                (draft) => draft.id === documentId
+              );
+              if (index !== -1) {
+                documents.splice(index, 1);
+              }
+            }
+          )
+        );
+
+        queryFulfilled.catch(patchResult.undo);
+      }
     }),
 
     updateDocument: builder.mutation<
@@ -121,5 +181,8 @@ export const {
   useUpdateDocumentMutation,
   useUnlinkDocumentMutation,
   useDeleteDocumentMutation,
-  useGetDocumentQuery
+  useGetDocumentQuery,
+  useFindCampaignDocumentsQuery,
+  useLinkDocumentsToCampaignMutation,
+  useUnlinkCampaignDocumentMutation
 } = documentApi;

--- a/frontend/src/services/test/document.service.test.tsx
+++ b/frontend/src/services/test/document.service.test.tsx
@@ -1,0 +1,43 @@
+import { faker } from '@faker-js/faker/locale/fr';
+import { render, screen } from '@testing-library/react';
+import { UserRole } from '@zerologementvacant/models';
+import {
+  genEstablishmentDTO,
+  genUserDTO
+} from '@zerologementvacant/models/fixtures';
+import { Provider } from 'react-redux';
+import { describe, expect, it } from 'vitest';
+
+import { useFindCampaignDocumentsQuery } from '~/services/document.service';
+import { MockAuthProvider } from '~/test/auth';
+import configureTestStore from '~/utils/storeUtils';
+
+function CampaignDocumentsStatusProbe(props: { campaignId: string }) {
+  const { error } = useFindCampaignDocumentsQuery(props.campaignId);
+
+  if (!error) {
+    return null;
+  }
+
+  const status = 'status' in error ? error.status : 'unknown';
+  return <span data-testid="status">{status}</span>;
+}
+
+describe('useFindCampaignDocumentsQuery', () => {
+  it('returns a 404 error for a campaign that does not exist', async () => {
+    const establishment = genEstablishmentDTO();
+    const auth = genUserDTO(UserRole.USUAL, establishment);
+    const store = configureTestStore();
+    const campaignId = faker.string.uuid();
+
+    render(
+      <Provider store={store}>
+        <MockAuthProvider options={{ user: auth, establishment }}>
+          <CampaignDocumentsStatusProbe campaignId={campaignId} />
+        </MockAuthProvider>
+      </Provider>
+    );
+
+    expect(await screen.findByTestId('status')).toHaveTextContent('404');
+  });
+});

--- a/frontend/src/views/Campaign/CampaignView.tsx
+++ b/frontend/src/views/Campaign/CampaignView.tsx
@@ -21,6 +21,9 @@ const CampaignRecipientsNext = lazy(
   () => import('~/components/Campaign/CampaignRecipients')
 );
 const DraftForm = lazy(() => import('~/components/Draft/DraftForm'));
+const CampaignDocumentsTabLazy = lazy(
+  () => import('~/components/Campaign/CampaignDocumentsTab')
+);
 import { useHousingFilters } from '~/hooks/HousingFiltersContext';
 import { useGetCampaignDraftQuery } from '~/hooks/useGetCampaignDraftQuery';
 import { useNotification } from '~/hooks/useNotification';
@@ -190,6 +193,10 @@ function CampaignView() {
                       draft={getCampaignDraftQuery.data}
                     />
                   ) : null
+              },
+              {
+                label: 'Documents',
+                content: <CampaignDocumentsTabLazy campaign={campaign} />
               }
             ]}
           />

--- a/frontend/src/views/Campaign/test/CampaignView.test.tsx
+++ b/frontend/src/views/Campaign/test/CampaignView.test.tsx
@@ -1,12 +1,16 @@
 import { faker } from '@faker-js/faker/locale/fr';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {
   UserRole,
   type CampaignDTO,
-  type HousingDTO
+  type DocumentDTO,
+  type EstablishmentDTO,
+  type HousingDTO,
+  type UserDTO
 } from '@zerologementvacant/models';
 import {
+  genDocumentDTO,
   genDraftDTO,
   genEstablishmentDTO,
   genHousingDTO,
@@ -42,6 +46,9 @@ describe('CampaignView', () => {
 
   interface RenderViewOptions {
     housings?: HousingDTO[];
+    documents?: DocumentDTO[];
+    auth?: UserDTO;
+    establishment?: EstablishmentDTO;
   }
 
   function renderView(campaign: CampaignDTO, options?: RenderViewOptions) {
@@ -56,6 +63,15 @@ describe('CampaignView', () => {
         data.housingCampaigns.set(housing.id, [{ id: campaign.id }]);
       });
     }
+    if (options?.documents?.length) {
+      options.documents.forEach((document) => {
+        data.documents.set(document.id, document);
+      });
+      data.campaignDocuments.set(campaign.id, options.documents);
+    }
+
+    const renderAuth = options?.auth ?? auth;
+    const renderEstablishment = options?.establishment ?? establishment;
 
     const router = createMemoryRouter(
       [
@@ -298,5 +314,160 @@ describe('CampaignView', () => {
         level: 4
       })
     ).toBeInTheDocument();
+  });
+
+  describe('Documents tab', () => {
+    it('shows an empty state message when there are no documents', async () => {
+      const campaign = factories
+        .campaign(establishment)
+        .build(
+          { sentAt: null, returnCount: null },
+          { associations: { createdBy: auth } }
+        );
+
+      renderView(campaign, { documents: [] });
+
+      await screen.findByRole('heading', { level: 1 });
+      const tab = await screen.findByRole('tab', { name: 'Documents' });
+      await user.click(tab);
+      const tabpanel = await screen.findByRole('tabpanel', {
+        name: 'Documents'
+      });
+      expect(
+        await within(tabpanel).findByText(
+          /Il n’y a pas de document associé à cette campagne/i
+        )
+      ).toBeVisible();
+    });
+
+    it('displays existing documents', async () => {
+      const campaign = factories
+        .campaign(establishment)
+        .build(
+          { sentAt: null, returnCount: null },
+          { associations: { createdBy: auth } }
+        );
+      const document = genDocumentDTO(auth, establishment);
+
+      renderView(campaign, { documents: [document] });
+
+      const tab = await screen.findByRole('tab', { name: 'Documents' });
+      await user.click(tab);
+      const tabpanel = await screen.findByRole('tabpanel', {
+        name: 'Documents'
+      });
+      expect(
+        await within(tabpanel).findByText(new RegExp(document.filename, 'i'))
+      ).toBeVisible();
+    });
+
+    it('renames a document', async () => {
+      const campaign = factories
+        .campaign(establishment)
+        .build(
+          { sentAt: null, returnCount: null },
+          { associations: { createdBy: auth } }
+        );
+      const document = genDocumentDTO(auth, establishment);
+
+      renderView(campaign, { documents: [document] });
+
+      const tab = await screen.findByRole('tab', { name: 'Documents' });
+      await user.click(tab);
+      const tabpanel = await screen.findByRole('tabpanel', {
+        name: 'Documents'
+      });
+      const dropdown = await within(tabpanel).findByRole('button', {
+        name: 'Options'
+      });
+      await user.click(dropdown);
+      const renameButton = await screen.findByRole('button', {
+        name: 'Renommer'
+      });
+      await user.click(renameButton);
+      const modal = await screen.findByRole('dialog', {
+        name: 'Renommer le document'
+      });
+      const input = await within(modal).findByRole('textbox', {
+        name: /^Nouveau nom du document/
+      });
+      await user.clear(input);
+      await user.type(input, 'nouveau-nom-campagne.pdf');
+      const save = await within(modal).findByRole('button', {
+        name: 'Confirmer'
+      });
+      await user.click(save);
+
+      expect(
+        await within(tabpanel).findByText('nouveau-nom-campagne.pdf')
+      ).toBeVisible();
+    });
+
+    it('deletes a document', async () => {
+      const campaign = factories
+        .campaign(establishment)
+        .build(
+          { sentAt: null, returnCount: null },
+          { associations: { createdBy: auth } }
+        );
+      const document = genDocumentDTO(auth, establishment);
+
+      renderView(campaign, { documents: [document] });
+
+      const tab = await screen.findByRole('tab', { name: 'Documents' });
+      await user.click(tab);
+      const tabpanel = await screen.findByRole('tabpanel', {
+        name: 'Documents'
+      });
+      const dropdown = await within(tabpanel).findByRole('button', {
+        name: 'Options'
+      });
+      await user.click(dropdown);
+      const deleteButton = await screen.findByRole('button', {
+        name: 'Supprimer'
+      });
+      await user.click(deleteButton);
+      const modal = await screen.findByRole('dialog', {
+        name: 'Suppression du document'
+      });
+      const confirm = await within(modal).findByRole('button', {
+        name: 'Confirmer'
+      });
+      await user.click(confirm);
+
+      expect(
+        within(tabpanel).queryByText(new RegExp(document.filename, 'i'))
+      ).not.toBeInTheDocument();
+    });
+
+    it('hides rename and delete for a visitor', async () => {
+      const campaign = factories
+        .campaign(establishment)
+        .build(
+          { sentAt: null, returnCount: null },
+          { associations: { createdBy: auth } }
+        );
+      const document = genDocumentDTO(auth, establishment);
+      const visitor = genUserDTO(UserRole.VISITOR, establishment);
+
+      renderView(campaign, { documents: [document], auth: visitor });
+
+      const tab = await screen.findByRole('tab', { name: 'Documents' });
+      await user.click(tab);
+      const tabpanel = await screen.findByRole('tabpanel', {
+        name: 'Documents'
+      });
+      const dropdown = await within(tabpanel).findByRole('button', {
+        name: 'Options'
+      });
+      await user.click(dropdown);
+
+      expect(
+        screen.queryByRole('button', { name: 'Renommer' })
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: 'Supprimer' })
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/views/Campaign/test/CampaignView.test.tsx
+++ b/frontend/src/views/Campaign/test/CampaignView.test.tsx
@@ -84,7 +84,9 @@ describe('CampaignView', () => {
 
     render(
       <Provider store={configureTestStore()}>
-        <MockAuthProvider options={{ user: auth, establishment }}>
+        <MockAuthProvider
+          options={{ user: renderAuth, establishment: renderEstablishment }}
+        >
           <HousingFiltersProvider>
             <RouterProvider router={router} />
           </HousingFiltersProvider>

--- a/packages/models/src/CampaignDocumentDTO.ts
+++ b/packages/models/src/CampaignDocumentDTO.ts
@@ -1,0 +1,3 @@
+import type { DocumentDTO } from './DocumentDTO';
+
+export type CampaignDocumentDTO = DocumentDTO;

--- a/packages/models/src/DocumentDTO.ts
+++ b/packages/models/src/DocumentDTO.ts
@@ -3,6 +3,7 @@ import mime from 'mime';
 
 import type { EstablishmentDTO } from './EstablishmentDTO';
 import type { UserDTO } from './UserDTO';
+import { UserRole } from './UserRole';
 
 export interface DocumentDTO {
   id: string;
@@ -21,6 +22,22 @@ export interface DocumentDTO {
 
 export type DocumentPayload = Pick<DocumentDTO, 'filename'>;
 
+export const ACCEPTED_DOCUMENT_EXTENSIONS: ReadonlyArray<string> = [
+  'png',
+  'jpg',
+  'heic',
+  'webp',
+  'pdf',
+  'doc',
+  'docx',
+  'xls',
+  'xlsx',
+  'ppt',
+  'pptx'
+];
+
+export const MAX_DOCUMENT_SIZE_IN_MiB = 25;
+
 const IMAGE_TYPES = ['jpeg', 'png', 'webp'];
 
 export function isImage(document: DocumentDTO): boolean {
@@ -31,4 +48,13 @@ export function isImage(document: DocumentDTO): boolean {
 
 export function isPDF(document: DocumentDTO): boolean {
   return document.contentType === mime.getType('pdf');
+}
+
+export function canWriteDocument(
+  role: UserRole,
+  sameEstablishment: boolean
+): boolean {
+  return (
+    role === UserRole.ADMIN || (role === UserRole.USUAL && sameEstablishment)
+  );
 }

--- a/packages/models/src/EventPayloads.ts
+++ b/packages/models/src/EventPayloads.ts
@@ -136,6 +136,19 @@ export type EventPayloads = {
     filename: string;
   }>;
 
+  // Campaign-document association events
+  'campaign:document-attached': CreationEventChange<{
+    filename: string;
+  }>;
+
+  'campaign:document-detached': RemoveEventChange<{
+    filename: string;
+  }>;
+
+  'campaign:document-removed': RemoveEventChange<{
+    filename: string;
+  }>;
+
   'owner:created': CreationEventChange<{
     name: string;
     birthdate: string | null;

--- a/packages/models/src/EventType.ts
+++ b/packages/models/src/EventType.ts
@@ -25,6 +25,9 @@ export const EVENT_TYPE_VALUES = [
   'document:created',
   'document:updated',
   'document:removed',
+  'campaign:document-attached',
+  'campaign:document-detached',
+  'campaign:document-removed',
   'owner:updated',
   'campaign:updated'
 ] as const satisfies ReadonlyArray<EventType>;

--- a/packages/models/src/HousingDocumentDTO.ts
+++ b/packages/models/src/HousingDocumentDTO.ts
@@ -1,19 +1,3 @@
 import type { DocumentDTO } from './DocumentDTO';
 
 export type HousingDocumentDTO = DocumentDTO;
-
-export const ACCEPTED_HOUSING_DOCUMENT_EXTENSIONS: ReadonlyArray<string> = [
-  'png',
-  'jpg',
-  'heic',
-  'webp',
-  'pdf',
-  'doc',
-  'docx',
-  'xls',
-  'xlsx',
-  'ppt',
-  'pptx'
-];
-
-export const MAX_HOUSING_DOCUMENT_SIZE_IN_MiB = 25;

--- a/packages/models/src/index.ts
+++ b/packages/models/src/index.ts
@@ -6,6 +6,7 @@ export * from './BuildingPeriod';
 export * from './CadastralClassification';
 export * from './CampaignCount';
 export * from './CampaignDTO';
+export * from './CampaignDocumentDTO';
 export * from './ContactPoint';
 export * from './DraftDTO';
 export * from './DashboardDTO';

--- a/packages/models/src/test/DocumentDTO.test.ts
+++ b/packages/models/src/test/DocumentDTO.test.ts
@@ -1,0 +1,21 @@
+import { canWriteDocument } from '../DocumentDTO';
+import { UserRole } from '../UserRole';
+
+describe('DocumentDTO', () => {
+  describe('canWriteDocument', () => {
+    it('should allow an admin regardless of establishment', () => {
+      expect(canWriteDocument(UserRole.ADMIN, false)).toBe(true);
+      expect(canWriteDocument(UserRole.ADMIN, true)).toBe(true);
+    });
+
+    it('should allow a usual user only in the same establishment', () => {
+      expect(canWriteDocument(UserRole.USUAL, true)).toBe(true);
+      expect(canWriteDocument(UserRole.USUAL, false)).toBe(false);
+    });
+
+    it('should never allow a visitor', () => {
+      expect(canWriteDocument(UserRole.VISITOR, true)).toBe(false);
+      expect(canWriteDocument(UserRole.VISITOR, false)).toBe(false);
+    });
+  });
+});

--- a/packages/schemas/src/campaign-document-payload.ts
+++ b/packages/schemas/src/campaign-document-payload.ts
@@ -1,11 +1,11 @@
 import { DocumentDTO } from '@zerologementvacant/models';
-import { array, object, type ObjectSchema, string } from 'yup';
+import type { ObjectSchema } from 'yup';
+
+import { documentIdsPayload } from './document-ids-payload';
 
 export interface CampaignDocumentPayload {
   documentIds: Array<DocumentDTO['id']>;
 }
 
 export const campaignDocumentPayload: ObjectSchema<CampaignDocumentPayload> =
-  object({
-    documentIds: array().of(string().uuid().required()).min(1).required()
-  });
+  documentIdsPayload();

--- a/packages/schemas/src/campaign-document-payload.ts
+++ b/packages/schemas/src/campaign-document-payload.ts
@@ -1,0 +1,11 @@
+import { DocumentDTO } from '@zerologementvacant/models';
+import { array, object, type ObjectSchema, string } from 'yup';
+
+export interface CampaignDocumentPayload {
+  documentIds: Array<DocumentDTO['id']>;
+}
+
+export const campaignDocumentPayload: ObjectSchema<CampaignDocumentPayload> =
+  object({
+    documentIds: array().of(string().uuid().required()).min(1).required()
+  });

--- a/packages/schemas/src/document-ids-payload.ts
+++ b/packages/schemas/src/document-ids-payload.ts
@@ -1,0 +1,12 @@
+import { DocumentDTO } from '@zerologementvacant/models';
+import { array, object, type ObjectSchema, string } from 'yup';
+
+interface DocumentIdsPayload {
+  documentIds: Array<DocumentDTO['id']>;
+}
+
+export function documentIdsPayload(): ObjectSchema<DocumentIdsPayload> {
+  return object({
+    documentIds: array().of(string().uuid().required()).min(1).required()
+  });
+}

--- a/packages/schemas/src/housing-document-payload.ts
+++ b/packages/schemas/src/housing-document-payload.ts
@@ -1,11 +1,11 @@
 import { DocumentDTO } from '@zerologementvacant/models';
-import { array, object, type ObjectSchema, string } from 'yup';
+import type { ObjectSchema } from 'yup';
+
+import { documentIdsPayload } from './document-ids-payload';
 
 export interface HousingDocumentPayload {
   documentIds: Array<DocumentDTO['id']>;
 }
 
 export const housingDocumentPayload: ObjectSchema<HousingDocumentPayload> =
-  object({
-    documentIds: array().of(string().uuid().required()).min(1).required()
-  });
+  documentIdsPayload();

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -1,5 +1,6 @@
 import { buildingFilters } from './building-filters';
 import { campaignCreationPayload } from './campaign-creation-payload';
+import { campaignDocumentPayload } from './campaign-document-payload';
 import { campaignFilters } from './campaign-filters';
 import { campaignUpdateNextPayload } from './campaign-update-next-payload';
 import { dateString } from './date-string';
@@ -36,6 +37,7 @@ import { userUpdatePayload } from './user-update-payload';
 const schemas = {
   buildingFilters,
   campaignCreationPayload,
+  campaignDocumentPayload,
   campaignFilters,
   campaignUpdateNextPayload,
   dateString,
@@ -70,6 +72,7 @@ const schemas = {
 };
 
 export { GEO_CODE_REGEXP } from './geo-code';
+export { type CampaignDocumentPayload } from './campaign-document-payload';
 export { type HousingDocumentPayload } from './housing-document-payload';
 export { MAX_PER_PAGE } from './pagination';
 export { PHONE_REGEXP } from './phone';

--- a/packages/schemas/src/test/campaign-document-payload.test.ts
+++ b/packages/schemas/src/test/campaign-document-payload.test.ts
@@ -1,0 +1,34 @@
+import { fc, test } from '@fast-check/vitest';
+import { describe, expect } from 'vitest';
+
+import { campaignDocumentPayload } from '../campaign-document-payload';
+
+describe('Campaign document payload', () => {
+  test.prop({
+    documentIds: fc.array(fc.uuid({ version: 4 }), {
+      minLength: 1,
+      maxLength: 10
+    })
+  })('should validate valid document IDs', (payload) => {
+    const validate = () => campaignDocumentPayload.validateSync(payload);
+
+    expect(validate).not.toThrow();
+  });
+
+  test.prop({
+    documentIds: fc.constantFrom([], undefined, null)
+  })('should reject empty or missing document IDs', (documentIds) => {
+    const validate = () =>
+      campaignDocumentPayload.validateSync({ documentIds });
+
+    expect(validate).toThrow();
+  });
+
+  test.prop({
+    documentIds: fc.array(fc.string(), { minLength: 1, maxLength: 5 })
+  })('should reject non-UUID document IDs', (payload) => {
+    const validate = () => campaignDocumentPayload.validateSync(payload);
+
+    expect(validate).toThrow();
+  });
+});

--- a/server/src/controllers/documentController.ts
+++ b/server/src/controllers/documentController.ts
@@ -2,9 +2,9 @@ import { constants } from 'node:http2';
 
 import { DeleteObjectCommand } from '@aws-sdk/client-s3';
 import {
-  ACCEPTED_HOUSING_DOCUMENT_EXTENSIONS,
+  ACCEPTED_DOCUMENT_EXTENSIONS,
   HousingDocumentDTO,
-  MAX_HOUSING_DOCUMENT_SIZE_IN_MiB,
+  MAX_DOCUMENT_SIZE_IN_MiB,
   type DocumentDTO,
   type DocumentPayload,
   type HousingDTO
@@ -80,8 +80,8 @@ const create: RequestHandler<
     ): Promise<Either.Either<DocumentDTO, FileValidationError>> => {
       try {
         await validate(file, {
-          accept: ACCEPTED_HOUSING_DOCUMENT_EXTENSIONS,
-          maxSize: MAX_HOUSING_DOCUMENT_SIZE_IN_MiB * 1024 ** 2
+          accept: ACCEPTED_DOCUMENT_EXTENSIONS,
+          maxSize: MAX_DOCUMENT_SIZE_IN_MiB * 1024 ** 2
         });
 
         const id = uuidv4();

--- a/server/src/controllers/documentController.ts
+++ b/server/src/controllers/documentController.ts
@@ -289,10 +289,15 @@ const remove: RequestHandler<
     throw new DocumentMissingError(params.id);
   }
 
-  // Find all housings linked to this document
-  const housingDocuments = await housingDocumentRepository.find({
-    filters: { documentIds: [params.id] }
-  });
+  // Find all housings and campaigns linked to this document
+  const [housingDocuments, campaignDocuments] = await Promise.all([
+    housingDocumentRepository.find({
+      filters: { documentIds: [params.id] }
+    }),
+    campaignDocumentRepository.find({
+      filters: { documentIds: [params.id] }
+    })
+  ]);
   const removeEvents = housingDocuments.map<HousingDocumentEventApi>(
     (housingDocument) => ({
       id: uuidv4(),
@@ -307,10 +312,6 @@ const remove: RequestHandler<
     })
   );
 
-  // Find all campaigns linked to this document
-  const campaignDocuments = await campaignDocumentRepository.find({
-    filters: { documentIds: [params.id] }
-  });
   const campaignRemoveEvents = campaignDocuments.map<CampaignDocumentEventApi>(
     (campaignDocument) => ({
       id: uuidv4(),
@@ -353,6 +354,34 @@ const remove: RequestHandler<
   response.status(constants.HTTP_STATUS_NO_CONTENT).send();
 };
 
+/**
+ * De-duplicates documentIds before checking existence: the DB lookup below
+ * naturally collapses duplicate ids to one row, so comparing its length
+ * against a raw (possibly duplicated) request array would misreport
+ * existing documents as missing.
+ */
+async function findDocumentsOrThrow(
+  documentIds: ReadonlyArray<DocumentDTO['id']>,
+  establishmentId: string
+): Promise<DocumentApi[]> {
+  const uniqueIds = [...new Set(documentIds)];
+  const documents = await documentRepository.find({
+    filters: {
+      ids: uniqueIds,
+      establishmentIds: [establishmentId],
+      deleted: false
+    }
+  });
+
+  if (documents.length !== uniqueIds.length) {
+    const foundIds = documents.map((document) => document.id);
+    const missingIds = uniqueIds.filter((id) => !foundIds.includes(id));
+    throw new DocumentMissingError(...missingIds);
+  }
+
+  return documents;
+}
+
 const linkToHousing: RequestHandler<
   { id: HousingDTO['id'] },
   ReadonlyArray<DocumentDTO>,
@@ -384,23 +413,14 @@ const linkToHousing: RequestHandler<
   }
 
   // Validate documents exist and belong to establishment
-  const documents = await documentRepository.find({
-    filters: {
-      ids: body.documentIds,
-      establishmentIds: [establishment.id],
-      deleted: false
-    }
-  });
-
-  if (documents.length !== body.documentIds.length) {
-    const foundIds = documents.map((document) => document.id);
-    const missingIds = body.documentIds.filter((id) => !foundIds.includes(id));
-    throw new DocumentMissingError(...missingIds);
-  }
+  const documents = await findDocumentsOrThrow(
+    body.documentIds,
+    establishment.id
+  );
 
   // Create housing document links (cartesian product)
-  const links = body.documentIds.map((documentId) => ({
-    document_id: documentId,
+  const links = documents.map((document) => ({
+    document_id: document.id,
     housing_id: housing.id,
     housing_geo_code: housing.geoCode
   }));
@@ -555,12 +575,13 @@ const linkToCampaign: RequestHandler<
   CampaignDocumentPayload,
   never
 > = async (request, response) => {
-  const { establishment, params, body, user } = request as AuthenticatedRequest<
-    { id: CampaignDTO['id'] },
-    ReadonlyArray<DocumentDTO>,
-    CampaignDocumentPayload,
-    never
-  >;
+  const { effectiveGeoCodes, establishment, params, body, user } =
+    request as AuthenticatedRequest<
+      { id: CampaignDTO['id'] },
+      ReadonlyArray<DocumentDTO>,
+      CampaignDocumentPayload,
+      never
+    >;
 
   logger.info('Linking documents to campaign', {
     campaign: params.id,
@@ -569,28 +590,20 @@ const linkToCampaign: RequestHandler<
 
   const campaign = await campaignRepository.findOne({
     id: params.id,
-    establishmentId: establishment.id
+    establishmentId: establishment.id,
+    geoCodes: effectiveGeoCodes
   });
   if (!campaign) {
     throw new CampaignMissingError(params.id);
   }
 
-  const documents = await documentRepository.find({
-    filters: {
-      ids: body.documentIds,
-      establishmentIds: [establishment.id],
-      deleted: false
-    }
-  });
+  const documents = await findDocumentsOrThrow(
+    body.documentIds,
+    establishment.id
+  );
 
-  if (documents.length !== body.documentIds.length) {
-    const foundIds = documents.map((document) => document.id);
-    const missingIds = body.documentIds.filter((id) => !foundIds.includes(id));
-    throw new DocumentMissingError(...missingIds);
-  }
-
-  const links = body.documentIds.map((documentId) => ({
-    document_id: documentId,
+  const links = documents.map((document) => ({
+    document_id: document.id,
     campaign_id: campaign.id
   }));
   const attachEvents = documents.map<CampaignDocumentEventApi>((document) => ({
@@ -626,17 +639,19 @@ const listByCampaign: RequestHandler<
   never,
   never
 > = async (request, response): Promise<void> => {
-  const { establishment, params } = request as AuthenticatedRequest<
-    { id: CampaignDTO['id'] },
-    DocumentDTO[],
-    never,
-    never
-  >;
+  const { effectiveGeoCodes, establishment, params } =
+    request as AuthenticatedRequest<
+      { id: CampaignDTO['id'] },
+      DocumentDTO[],
+      never,
+      never
+    >;
 
   logger.debug('Finding documents by campaign...', { campaign: params.id });
   const campaign = await campaignRepository.findOne({
     id: params.id,
-    establishmentId: establishment.id
+    establishmentId: establishment.id,
+    geoCodes: effectiveGeoCodes
   });
   if (!campaign) {
     throw new CampaignMissingError(params.id);
@@ -661,12 +676,13 @@ const removeByCampaign: RequestHandler<
   never,
   never
 > = async (request, response) => {
-  const { establishment, params, user } = request as AuthenticatedRequest<
-    { id: CampaignDTO['id']; documentId: DocumentDTO['id'] },
-    void,
-    never,
-    never
-  >;
+  const { effectiveGeoCodes, establishment, params, user } =
+    request as AuthenticatedRequest<
+      { id: CampaignDTO['id']; documentId: DocumentDTO['id'] },
+      void,
+      never,
+      never
+    >;
 
   logger.info('Removing document-campaign association', {
     campaign: params.id,
@@ -675,16 +691,16 @@ const removeByCampaign: RequestHandler<
 
   const campaign = await campaignRepository.findOne({
     id: params.id,
-    establishmentId: establishment.id
+    establishmentId: establishment.id,
+    geoCodes: effectiveGeoCodes
   });
   if (!campaign) {
     throw new CampaignMissingError(params.id);
   }
 
-  const links = await campaignDocumentRepository.find({
-    filters: { campaignIds: [campaign.id] }
+  const document = await campaignDocumentRepository.get(params.documentId, {
+    campaign: [campaign.id]
   });
-  const document = links.find((link) => link.id === params.documentId);
   if (!document) {
     throw new DocumentMissingError(params.documentId);
   }

--- a/server/src/controllers/documentController.ts
+++ b/server/src/controllers/documentController.ts
@@ -5,11 +5,15 @@ import {
   ACCEPTED_DOCUMENT_EXTENSIONS,
   HousingDocumentDTO,
   MAX_DOCUMENT_SIZE_IN_MiB,
+  type CampaignDTO,
   type DocumentDTO,
   type DocumentPayload,
   type HousingDTO
 } from '@zerologementvacant/models';
-import { type HousingDocumentPayload } from '@zerologementvacant/schemas';
+import {
+  type CampaignDocumentPayload,
+  type HousingDocumentPayload
+} from '@zerologementvacant/schemas';
 import { createS3 } from '@zerologementvacant/utils/node';
 import async from 'async';
 import { Array, Either } from 'effect';
@@ -18,6 +22,7 @@ import { AuthenticatedRequest } from 'express-jwt';
 import { match } from 'ts-pattern';
 import { v4 as uuidv4 } from 'uuid';
 
+import CampaignMissingError from '~/errors/campaignMissingError';
 import DocumentMissingError from '~/errors/documentMissingError';
 import FilesMissingError from '~/errors/filesMissingError';
 import { FileValidationError } from '~/errors/fileValidationError';
@@ -26,15 +31,25 @@ import config from '~/infra/config';
 import { startTransaction } from '~/infra/database/transaction';
 import { createLogger } from '~/infra/logger';
 import {
+  CampaignDocumentApi,
+  toCampaignDocumentDTO
+} from '~/models/CampaignDocumentApi';
+import {
   DocumentFilenameEquivalence,
   toDocumentDTO,
   type DocumentApi
 } from '~/models/DocumentApi';
-import { DocumentEventApi, HousingDocumentEventApi } from '~/models/EventApi';
+import {
+  CampaignDocumentEventApi,
+  DocumentEventApi,
+  HousingDocumentEventApi
+} from '~/models/EventApi';
 import {
   HousingDocumentApi,
   toHousingDocumentDTO
 } from '~/models/HousingDocumentApi';
+import campaignDocumentRepository from '~/repositories/campaignDocumentRepository';
+import campaignRepository from '~/repositories/campaignRepository';
 import documentRepository from '~/repositories/documentRepository';
 import eventRepository from '~/repositories/eventRepository';
 import housingDocumentRepository from '~/repositories/housingDocumentRepository';
@@ -278,8 +293,6 @@ const remove: RequestHandler<
   const housingDocuments = await housingDocumentRepository.find({
     filters: { documentIds: [params.id] }
   });
-
-  // Create housing:document-removed events for each linked housing
   const removeEvents = housingDocuments.map<HousingDocumentEventApi>(
     (housingDocument) => ({
       id: uuidv4(),
@@ -294,7 +307,23 @@ const remove: RequestHandler<
     })
   );
 
-  // Create document:removed event
+  // Find all campaigns linked to this document
+  const campaignDocuments = await campaignDocumentRepository.find({
+    filters: { documentIds: [params.id] }
+  });
+  const campaignRemoveEvents = campaignDocuments.map<CampaignDocumentEventApi>(
+    (campaignDocument) => ({
+      id: uuidv4(),
+      type: 'campaign:document-removed',
+      nextOld: { filename: document.filename },
+      nextNew: null,
+      createdAt: new Date().toJSON(),
+      createdBy: user.id,
+      documentId: params.id,
+      campaignId: campaignDocument.campaignId
+    })
+  );
+
   const documentRemoveEvent: DocumentEventApi = {
     id: uuidv4(),
     type: 'document:removed',
@@ -312,8 +341,10 @@ const remove: RequestHandler<
   await startTransaction(async () => {
     await Promise.all([
       eventRepository.insertManyHousingDocumentEvents(removeEvents),
+      eventRepository.insertManyCampaignDocumentEvents(campaignRemoveEvents),
       eventRepository.insertManyDocumentEvents([documentRemoveEvent]),
       housingDocumentRepository.unlinkMany({ documentIds: [params.id] }),
+      campaignDocumentRepository.unlinkMany({ documentIds: [params.id] }),
       documentRepository.remove(params.id)
     ]);
     await s3.send(deleteCommand);
@@ -518,6 +549,170 @@ const removeByHousing: RequestHandler<
   response.status(constants.HTTP_STATUS_NO_CONTENT).send();
 };
 
+const linkToCampaign: RequestHandler<
+  { id: CampaignDTO['id'] },
+  ReadonlyArray<DocumentDTO>,
+  CampaignDocumentPayload,
+  never
+> = async (request, response) => {
+  const { establishment, params, body, user } = request as AuthenticatedRequest<
+    { id: CampaignDTO['id'] },
+    ReadonlyArray<DocumentDTO>,
+    CampaignDocumentPayload,
+    never
+  >;
+
+  logger.info('Linking documents to campaign', {
+    campaign: params.id,
+    documentCount: body.documentIds.length
+  });
+
+  const campaign = await campaignRepository.findOne({
+    id: params.id,
+    establishmentId: establishment.id
+  });
+  if (!campaign) {
+    throw new CampaignMissingError(params.id);
+  }
+
+  const documents = await documentRepository.find({
+    filters: {
+      ids: body.documentIds,
+      establishmentIds: [establishment.id],
+      deleted: false
+    }
+  });
+
+  if (documents.length !== body.documentIds.length) {
+    const foundIds = documents.map((document) => document.id);
+    const missingIds = body.documentIds.filter((id) => !foundIds.includes(id));
+    throw new DocumentMissingError(...missingIds);
+  }
+
+  const links = body.documentIds.map((documentId) => ({
+    document_id: documentId,
+    campaign_id: campaign.id
+  }));
+  const attachEvents = documents.map<CampaignDocumentEventApi>((document) => ({
+    id: uuidv4(),
+    type: 'campaign:document-attached',
+    nextOld: null,
+    nextNew: { filename: document.filename },
+    createdAt: new Date().toJSON(),
+    createdBy: user.id,
+    documentId: document.id,
+    campaignId: campaign.id
+  }));
+
+  await startTransaction(async () => {
+    await Promise.all([
+      campaignDocumentRepository.linkMany(links),
+      eventRepository.insertManyCampaignDocumentEvents(attachEvents)
+    ]);
+  });
+
+  const documentsWithURLs = await async.map(
+    documents,
+    async (document: DocumentApi) =>
+      toDocumentDTO(document, { s3, bucket: config.s3.bucket })
+  );
+
+  response.status(constants.HTTP_STATUS_CREATED).json(documentsWithURLs);
+};
+
+const listByCampaign: RequestHandler<
+  { id: CampaignDTO['id'] },
+  DocumentDTO[],
+  never,
+  never
+> = async (request, response): Promise<void> => {
+  const { establishment, params } = request as AuthenticatedRequest<
+    { id: CampaignDTO['id'] },
+    DocumentDTO[],
+    never,
+    never
+  >;
+
+  logger.debug('Finding documents by campaign...', { campaign: params.id });
+  const campaign = await campaignRepository.findOne({
+    id: params.id,
+    establishmentId: establishment.id
+  });
+  if (!campaign) {
+    throw new CampaignMissingError(params.id);
+  }
+
+  const documents = await campaignDocumentRepository.find({
+    filters: { campaignIds: [campaign.id], deleted: false }
+  });
+
+  const documentsWithURLs = await async.map(
+    [...documents],
+    async (document: CampaignDocumentApi) =>
+      toCampaignDocumentDTO(document, { s3, bucket: config.s3.bucket })
+  );
+
+  response.status(constants.HTTP_STATUS_OK).json(documentsWithURLs);
+};
+
+const removeByCampaign: RequestHandler<
+  { id: CampaignDTO['id']; documentId: DocumentDTO['id'] },
+  void,
+  never,
+  never
+> = async (request, response) => {
+  const { establishment, params, user } = request as AuthenticatedRequest<
+    { id: CampaignDTO['id']; documentId: DocumentDTO['id'] },
+    void,
+    never,
+    never
+  >;
+
+  logger.info('Removing document-campaign association', {
+    campaign: params.id,
+    document: params.documentId
+  });
+
+  const campaign = await campaignRepository.findOne({
+    id: params.id,
+    establishmentId: establishment.id
+  });
+  if (!campaign) {
+    throw new CampaignMissingError(params.id);
+  }
+
+  const links = await campaignDocumentRepository.find({
+    filters: { campaignIds: [campaign.id] }
+  });
+  const document = links.find((link) => link.id === params.documentId);
+  if (!document) {
+    throw new DocumentMissingError(params.documentId);
+  }
+
+  const detachEvent: CampaignDocumentEventApi = {
+    id: uuidv4(),
+    type: 'campaign:document-detached',
+    nextOld: { filename: document.filename },
+    nextNew: null,
+    createdAt: new Date().toJSON(),
+    createdBy: user.id,
+    documentId: params.documentId,
+    campaignId: campaign.id
+  };
+
+  await startTransaction(async () => {
+    await Promise.all([
+      eventRepository.insertManyCampaignDocumentEvents([detachEvent]),
+      campaignDocumentRepository.unlink({
+        documentId: params.documentId,
+        campaignId: campaign.id
+      })
+    ]);
+  });
+
+  response.status(constants.HTTP_STATUS_NO_CONTENT).send();
+};
+
 const documentController = {
   create,
   get,
@@ -525,7 +720,10 @@ const documentController = {
   remove,
   linkToHousing,
   listByHousing,
-  removeByHousing
+  removeByHousing,
+  linkToCampaign,
+  listByCampaign,
+  removeByCampaign
 };
 
 export default documentController;

--- a/server/src/controllers/documentController.ts
+++ b/server/src/controllers/documentController.ts
@@ -534,13 +534,10 @@ const removeByHousing: RequestHandler<
     throw new HousingMissingError(params.housingId);
   }
 
-  // Validate association exists
-  const links = await housingDocumentRepository.find({
-    filters: { housingIds: [housing] }
+  // Validate association exists (indexed lookup)
+  const document = await housingDocumentRepository.get(params.documentId, {
+    housing: [housing]
   });
-
-  // Get document details for event
-  const document = links.find((link) => link.id === params.documentId);
   if (!document) {
     throw new DocumentMissingError(params.documentId);
   }

--- a/server/src/controllers/documentController.ts
+++ b/server/src/controllers/documentController.ts
@@ -424,24 +424,28 @@ const linkToHousing: RequestHandler<
     housing_id: housing.id,
     housing_geo_code: housing.geoCode
   }));
-  // Create housing:document-attached events for each link
-  const attachEvents = documents.map<HousingDocumentEventApi>((document) => ({
-    id: uuidv4(),
-    type: 'housing:document-attached',
-    nextOld: null,
-    nextNew: { filename: document.filename },
-    createdAt: new Date().toJSON(),
-    createdBy: request.user!.id,
-    documentId: document.id,
-    housingGeoCode: housing.geoCode,
-    housingId: housing.id
-  }));
+  const documentsById = new Map(
+    documents.map((document) => [document.id, document])
+  );
 
   await startTransaction(async () => {
-    await Promise.all([
-      housingDocumentRepository.linkMany(links),
-      eventRepository.insertManyHousingDocumentEvents(attachEvents)
-    ]);
+    // Only the links that were actually inserted are returned (existing links
+    // are ignored on conflict), so events are created for new attachments only.
+    const inserted = await housingDocumentRepository.linkMany(links);
+    const attachEvents = inserted.map<HousingDocumentEventApi>(
+      ({ document_id }) => ({
+        id: uuidv4(),
+        type: 'housing:document-attached',
+        nextOld: null,
+        nextNew: { filename: documentsById.get(document_id)!.filename },
+        createdAt: new Date().toJSON(),
+        createdBy: request.user!.id,
+        documentId: document_id,
+        housingGeoCode: housing.geoCode,
+        housingId: housing.id
+      })
+    );
+    await eventRepository.insertManyHousingDocumentEvents(attachEvents);
   });
 
   // Generate pre-signed URLs for linked documents
@@ -555,15 +559,16 @@ const removeByHousing: RequestHandler<
   };
 
   await startTransaction(async () => {
-    await Promise.all([
-      eventRepository.insertManyHousingDocumentEvents([detachEvent]),
-      // Remove association only (keep document)
-      housingDocumentRepository.unlink({
-        documentId: params.documentId,
-        housingId: housing.id,
-        housingGeoCode: housing.geoCode
-      })
-    ]);
+    // Delete the link within the transaction and only record the detach event
+    // if a row was actually removed, so a concurrent detach cannot duplicate it.
+    const deletedCount = await housingDocumentRepository.unlink({
+      documentId: params.documentId,
+      housingId: housing.id,
+      housingGeoCode: housing.geoCode
+    });
+    if (deletedCount > 0) {
+      await eventRepository.insertManyHousingDocumentEvents([detachEvent]);
+    }
   });
 
   response.status(constants.HTTP_STATUS_NO_CONTENT).send();
@@ -606,22 +611,27 @@ const linkToCampaign: RequestHandler<
     document_id: document.id,
     campaign_id: campaign.id
   }));
-  const attachEvents = documents.map<CampaignDocumentEventApi>((document) => ({
-    id: uuidv4(),
-    type: 'campaign:document-attached',
-    nextOld: null,
-    nextNew: { filename: document.filename },
-    createdAt: new Date().toJSON(),
-    createdBy: user.id,
-    documentId: document.id,
-    campaignId: campaign.id
-  }));
+  const documentsById = new Map(
+    documents.map((document) => [document.id, document])
+  );
 
   await startTransaction(async () => {
-    await Promise.all([
-      campaignDocumentRepository.linkMany(links),
-      eventRepository.insertManyCampaignDocumentEvents(attachEvents)
-    ]);
+    // Only the links that were actually inserted are returned (existing links
+    // are ignored on conflict), so events are created for new attachments only.
+    const inserted = await campaignDocumentRepository.linkMany(links);
+    const attachEvents = inserted.map<CampaignDocumentEventApi>(
+      ({ document_id }) => ({
+        id: uuidv4(),
+        type: 'campaign:document-attached',
+        nextOld: null,
+        nextNew: { filename: documentsById.get(document_id)!.filename },
+        createdAt: new Date().toJSON(),
+        createdBy: user.id,
+        documentId: document_id,
+        campaignId: campaign.id
+      })
+    );
+    await eventRepository.insertManyCampaignDocumentEvents(attachEvents);
   });
 
   const documentsWithURLs = await async.map(
@@ -717,13 +727,15 @@ const removeByCampaign: RequestHandler<
   };
 
   await startTransaction(async () => {
-    await Promise.all([
-      eventRepository.insertManyCampaignDocumentEvents([detachEvent]),
-      campaignDocumentRepository.unlink({
-        documentId: params.documentId,
-        campaignId: campaign.id
-      })
-    ]);
+    // Delete the link within the transaction and only record the detach event
+    // if a row was actually removed, so a concurrent detach cannot duplicate it.
+    const deletedCount = await campaignDocumentRepository.unlink({
+      documentId: params.documentId,
+      campaignId: campaign.id
+    });
+    if (deletedCount > 0) {
+      await eventRepository.insertManyCampaignDocumentEvents([detachEvent]);
+    }
   });
 
   response.status(constants.HTTP_STATUS_NO_CONTENT).send();

--- a/server/src/controllers/test/document-api.test.ts
+++ b/server/src/controllers/test/document-api.test.ts
@@ -10,13 +10,18 @@ import {
   type DocumentPayload
 } from '@zerologementvacant/models';
 import { createS3 } from '@zerologementvacant/utils/node';
+import nock from 'nock';
 import request from 'supertest';
-import { beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import config from '~/infra/config';
 import { createServer } from '~/infra/server';
 import { UserApi } from '~/models/UserApi';
 import { CampaignDocuments } from '~/repositories/campaignDocumentRepository';
+import {
+  CampaignsHousing,
+  formatCampaignHousingApi
+} from '~/repositories/campaignHousingRepository';
 import { Documents, toDocumentDBO } from '~/repositories/documentRepository';
 import {
   Establishments,
@@ -35,6 +40,7 @@ import {
   formatHousingRecordApi,
   Housing
 } from '~/repositories/housingRepository';
+import userPerimeterRepository from '~/repositories/userPerimeterRepository';
 import { toUserDBO, Users } from '~/repositories/userRepository';
 import { factories } from '~/test/factories';
 import {
@@ -750,6 +756,27 @@ describe('Document API', () => {
       expect(body[0]).toMatchObject({ id: document.id });
     });
 
+    it('should link documents to campaign when documentIds contains duplicates', async () => {
+      const campaign = await factories
+        .campaign(establishment)
+        .create({}, { associations: { createdBy: user } });
+      const document = genDocumentApi({
+        createdBy: user.id,
+        creator: user,
+        establishmentId: establishment.id
+      });
+      await Documents().insert(toDocumentDBO(document));
+
+      const { status, body } = await request(url)
+        .post(testRoute(campaign.id))
+        .use(tokenProvider(user))
+        .send({ documentIds: [document.id, document.id] });
+
+      expect(status).toBe(constants.HTTP_STATUS_CREATED);
+      expect(body).toHaveLength(1);
+      expect(body[0]).toMatchObject({ id: document.id });
+    });
+
     it('should create an event "campaign:document-attached"', async () => {
       const campaign = await factories
         .campaign(establishment)
@@ -990,6 +1017,101 @@ describe('Document API', () => {
       const { status } = await request(url)
         .delete(testRoute(campaign.id, document.id))
         .use(tokenProvider(user));
+
+      expect(status).toBe(constants.HTTP_STATUS_NOT_FOUND);
+    });
+  });
+
+  describe('Campaign document endpoints respect the geographic perimeter', () => {
+    const restrictedEstablishment = genEstablishmentApi('75056', '13055');
+    const restrictedUser: UserApi = {
+      ...genUserApi(restrictedEstablishment.id),
+      role: UserRole.USUAL
+    };
+
+    beforeAll(async () => {
+      await Establishments().insert(
+        formatEstablishmentApi(restrictedEstablishment)
+      );
+      await Users().insert(toUserDBO(restrictedUser));
+      await userPerimeterRepository.upsert({
+        userId: restrictedUser.id,
+        establishmentId: restrictedEstablishment.id,
+        // Restrict the user to 75056 only: 13055 is outside their perimeter
+        geoCodes: ['75056'],
+        departments: [],
+        regions: [],
+        epci: [],
+        frEntiere: false,
+        updatedAt: new Date().toJSON()
+      });
+      // isCommuneInPerimeter falls back to GeoAPI to resolve 13055's region
+      nock('https://geo.api.gouv.fr')
+        .persist()
+        .get('/departements/13')
+        .query({ fields: 'codeRegion' })
+        .reply(200, { code: '13', nom: 'Bouches-du-Rhône', codeRegion: '93' });
+    });
+
+    afterAll(() => {
+      nock.cleanAll();
+    });
+
+    async function createCampaignOutsidePerimeter() {
+      const campaign = await factories
+        .campaign(restrictedEstablishment)
+        .create({}, { associations: { createdBy: restrictedUser } });
+      const housing = genHousingApi('13055');
+      await Housing().insert(formatHousingRecordApi(housing));
+      await CampaignsHousing().insert(
+        formatCampaignHousingApi(campaign, [housing])
+      );
+      return campaign;
+    }
+
+    it('should return 404 when linking documents to a campaign with housing outside the perimeter', async () => {
+      const campaign = await createCampaignOutsidePerimeter();
+      const document = genDocumentApi({
+        createdBy: restrictedUser.id,
+        creator: restrictedUser,
+        establishmentId: restrictedEstablishment.id
+      });
+      await Documents().insert(toDocumentDBO(document));
+
+      const { status } = await request(url)
+        .post(`/campaigns/${campaign.id}/documents`)
+        .use(tokenProvider(restrictedUser))
+        .send({ documentIds: [document.id] });
+
+      expect(status).toBe(constants.HTTP_STATUS_NOT_FOUND);
+    });
+
+    it('should return 404 when listing documents of a campaign with housing outside the perimeter', async () => {
+      const campaign = await createCampaignOutsidePerimeter();
+
+      const { status } = await request(url)
+        .get(`/campaigns/${campaign.id}/documents`)
+        .use(tokenProvider(restrictedUser));
+
+      expect(status).toBe(constants.HTTP_STATUS_NOT_FOUND);
+    });
+
+    it('should return 404 when removing a document from a campaign with housing outside the perimeter', async () => {
+      const campaign = await createCampaignOutsidePerimeter();
+      const document = genDocumentApi({
+        createdBy: restrictedUser.id,
+        creator: restrictedUser,
+        establishmentId: restrictedEstablishment.id
+      });
+      await Documents().insert(toDocumentDBO(document));
+      await CampaignDocuments().insert({
+        document_id: document.id,
+        campaign_id: campaign.id
+      });
+
+      const { status } = await request(url)
+        .delete(`/campaigns/${campaign.id}/documents/${document.id}`)
+        .use(tokenProvider(restrictedUser));
 
       expect(status).toBe(constants.HTTP_STATUS_NOT_FOUND);
     });

--- a/server/src/controllers/test/document-api.test.ts
+++ b/server/src/controllers/test/document-api.test.ts
@@ -16,12 +16,14 @@ import { beforeAll, describe, expect, it } from 'vitest';
 import config from '~/infra/config';
 import { createServer } from '~/infra/server';
 import { UserApi } from '~/models/UserApi';
+import { CampaignDocuments } from '~/repositories/campaignDocumentRepository';
 import { Documents, toDocumentDBO } from '~/repositories/documentRepository';
 import {
   Establishments,
   formatEstablishmentApi
 } from '~/repositories/establishmentRepository';
 import {
+  CAMPAIGN_DOCUMENT_EVENTS_TABLE,
   DOCUMENT_EVENTS_TABLE,
   Events,
   EVENTS_TABLE,
@@ -34,6 +36,7 @@ import {
   Housing
 } from '~/repositories/housingRepository';
 import { toUserDBO, Users } from '~/repositories/userRepository';
+import { factories } from '~/test/factories';
 import {
   genDocumentApi,
   genEstablishmentApi,
@@ -720,6 +723,316 @@ describe('Document API', () => {
         .use(tokenProvider(user));
 
       expect(status).toBe(constants.HTTP_STATUS_NOT_FOUND);
+    });
+  });
+
+  describe('POST /campaigns/:id/documents', () => {
+    const testRoute = (id: string) => `/campaigns/${id}/documents`;
+
+    it('should link documents to campaign', async () => {
+      const campaign = await factories
+        .campaign(establishment)
+        .create({}, { associations: { createdBy: user } });
+      const document = genDocumentApi({
+        createdBy: user.id,
+        creator: user,
+        establishmentId: establishment.id
+      });
+      await Documents().insert(toDocumentDBO(document));
+
+      const { status, body } = await request(url)
+        .post(testRoute(campaign.id))
+        .use(tokenProvider(user))
+        .send({ documentIds: [document.id] });
+
+      expect(status).toBe(constants.HTTP_STATUS_CREATED);
+      expect(body).toHaveLength(1);
+      expect(body[0]).toMatchObject({ id: document.id });
+    });
+
+    it('should create an event "campaign:document-attached"', async () => {
+      const campaign = await factories
+        .campaign(establishment)
+        .create({}, { associations: { createdBy: user } });
+      const document = genDocumentApi({
+        createdBy: user.id,
+        creator: user,
+        establishmentId: establishment.id
+      });
+      await Documents().insert(toDocumentDBO(document));
+
+      const { status } = await request(url)
+        .post(testRoute(campaign.id))
+        .use(tokenProvider(user))
+        .send({ documentIds: [document.id] });
+
+      expect(status).toBe(constants.HTTP_STATUS_CREATED);
+      const event = await Events()
+        .where({ type: 'campaign:document-attached' })
+        .join(
+          CAMPAIGN_DOCUMENT_EVENTS_TABLE,
+          `${CAMPAIGN_DOCUMENT_EVENTS_TABLE}.event_id`,
+          `${EVENTS_TABLE}.id`
+        )
+        .where(`${CAMPAIGN_DOCUMENT_EVENTS_TABLE}.document_id`, document.id)
+        .first();
+      expect(event).toMatchObject<
+        Partial<EventDBO<'campaign:document-attached'>>
+      >({
+        type: 'campaign:document-attached',
+        next_old: null,
+        next_new: { filename: document.filename },
+        created_by: user.id
+      });
+    });
+
+    it('should return 404 if campaign not found', async () => {
+      const { status } = await request(url)
+        .post(testRoute(faker.string.uuid()))
+        .use(tokenProvider(user))
+        .send({ documentIds: [faker.string.uuid()] });
+
+      expect(status).toBe(constants.HTTP_STATUS_NOT_FOUND);
+    });
+
+    it('should return 404 if campaign belongs to another establishment', async () => {
+      const campaign = await factories
+        .campaign(anotherEstablishment)
+        .create(
+          {},
+          { associations: { createdBy: userFromAnotherEstablishment } }
+        );
+      const document = genDocumentApi({
+        createdBy: userFromAnotherEstablishment.id,
+        creator: userFromAnotherEstablishment,
+        establishmentId: anotherEstablishment.id
+      });
+      await Documents().insert(toDocumentDBO(document));
+
+      const { status } = await request(url)
+        .post(testRoute(campaign.id))
+        .use(tokenProvider(user))
+        .send({ documentIds: [document.id] });
+
+      expect(status).toBe(constants.HTTP_STATUS_NOT_FOUND);
+    });
+
+    it('should return 403 for a visitor', async () => {
+      const campaign = await factories
+        .campaign(establishment)
+        .create({}, { associations: { createdBy: user } });
+      const document = genDocumentApi({
+        createdBy: user.id,
+        creator: user,
+        establishmentId: establishment.id
+      });
+      await Documents().insert(toDocumentDBO(document));
+
+      const { status } = await request(url)
+        .post(testRoute(campaign.id))
+        .use(tokenProvider(visitor))
+        .send({ documentIds: [document.id] });
+
+      expect(status).toBe(constants.HTTP_STATUS_FORBIDDEN);
+    });
+  });
+
+  describe('GET /campaigns/:id/documents', () => {
+    const testRoute = (id: string) => `/campaigns/${id}/documents`;
+
+    it('should return 200 OK with documents list', async () => {
+      const campaign = await factories
+        .campaign(establishment)
+        .create({}, { associations: { createdBy: user } });
+      const document = genDocumentApi({
+        createdBy: user.id,
+        creator: user,
+        establishmentId: establishment.id
+      });
+      await Documents().insert(toDocumentDBO(document));
+      await CampaignDocuments().insert({
+        document_id: document.id,
+        campaign_id: campaign.id
+      });
+
+      const { status, body } = await request(url)
+        .get(testRoute(campaign.id))
+        .use(tokenProvider(user));
+
+      expect(status).toBe(constants.HTTP_STATUS_OK);
+      expect(body).toBeArrayOfSize(1);
+      expect(body[0]).toMatchObject({
+        id: document.id,
+        url: expect.stringContaining('http')
+      });
+    });
+
+    it('should return 404 if campaign belongs to another establishment', async () => {
+      const campaign = await factories
+        .campaign(anotherEstablishment)
+        .create(
+          {},
+          { associations: { createdBy: userFromAnotherEstablishment } }
+        );
+
+      const { status } = await request(url)
+        .get(testRoute(campaign.id))
+        .use(tokenProvider(user));
+
+      expect(status).toBe(constants.HTTP_STATUS_NOT_FOUND);
+    });
+  });
+
+  describe('DELETE /campaigns/:id/documents/:documentId', () => {
+    const testRoute = (id: string, documentId: string) =>
+      `/campaigns/${id}/documents/${documentId}`;
+
+    it('should remove association only (keep document)', async () => {
+      const campaign = await factories
+        .campaign(establishment)
+        .create({}, { associations: { createdBy: user } });
+      const document = genDocumentApi({
+        createdBy: user.id,
+        creator: user,
+        establishmentId: establishment.id
+      });
+      await Documents().insert(toDocumentDBO(document));
+      await CampaignDocuments().insert({
+        document_id: document.id,
+        campaign_id: campaign.id
+      });
+
+      const { status } = await request(url)
+        .delete(testRoute(campaign.id, document.id))
+        .use(tokenProvider(user));
+
+      expect(status).toBe(constants.HTTP_STATUS_NO_CONTENT);
+
+      const links = await CampaignDocuments()
+        .where({ document_id: document.id, campaign_id: campaign.id })
+        .select('*');
+      expect(links).toHaveLength(0);
+
+      const [doc] = await Documents().where({ id: document.id }).select('*');
+      expect(doc).toBeDefined();
+      expect(doc.deleted_at).toBeNull();
+    });
+
+    it('should create an event "campaign:document-detached"', async () => {
+      const campaign = await factories
+        .campaign(establishment)
+        .create({}, { associations: { createdBy: user } });
+      const document = genDocumentApi({
+        createdBy: user.id,
+        creator: user,
+        establishmentId: establishment.id
+      });
+      await Documents().insert(toDocumentDBO(document));
+      await CampaignDocuments().insert({
+        document_id: document.id,
+        campaign_id: campaign.id
+      });
+
+      const { status } = await request(url)
+        .delete(testRoute(campaign.id, document.id))
+        .use(tokenProvider(user));
+
+      expect(status).toBe(constants.HTTP_STATUS_NO_CONTENT);
+      const event = await Events()
+        .where({ type: 'campaign:document-detached' })
+        .join(
+          CAMPAIGN_DOCUMENT_EVENTS_TABLE,
+          `${CAMPAIGN_DOCUMENT_EVENTS_TABLE}.event_id`,
+          `${EVENTS_TABLE}.id`
+        )
+        .where(`${CAMPAIGN_DOCUMENT_EVENTS_TABLE}.document_id`, document.id)
+        .first();
+      expect(event).toMatchObject<
+        Partial<EventDBO<'campaign:document-detached'>>
+      >({
+        type: 'campaign:document-detached',
+        next_old: { filename: document.filename },
+        next_new: null,
+        created_by: user.id
+      });
+    });
+
+    it('should return 404 if association not found', async () => {
+      const campaign = await factories
+        .campaign(establishment)
+        .create({}, { associations: { createdBy: user } });
+
+      const { status } = await request(url)
+        .delete(testRoute(campaign.id, faker.string.uuid()))
+        .use(tokenProvider(user));
+
+      expect(status).toBe(constants.HTTP_STATUS_NOT_FOUND);
+    });
+
+    it('should return 404 if campaign belongs to another establishment', async () => {
+      const campaign = await factories
+        .campaign(anotherEstablishment)
+        .create(
+          {},
+          { associations: { createdBy: userFromAnotherEstablishment } }
+        );
+      const document = genDocumentApi({
+        createdBy: userFromAnotherEstablishment.id,
+        creator: userFromAnotherEstablishment,
+        establishmentId: anotherEstablishment.id
+      });
+      await Documents().insert(toDocumentDBO(document));
+      await CampaignDocuments().insert({
+        document_id: document.id,
+        campaign_id: campaign.id
+      });
+
+      const { status } = await request(url)
+        .delete(testRoute(campaign.id, document.id))
+        .use(tokenProvider(user));
+
+      expect(status).toBe(constants.HTTP_STATUS_NOT_FOUND);
+    });
+  });
+
+  describe('DELETE /documents/:id (campaign cascade)', () => {
+    it('should create an event "campaign:document-removed" for each campaign the document was attached to', async () => {
+      const document = genDocumentApi({
+        createdBy: user.id,
+        creator: user,
+        establishmentId: establishment.id
+      });
+      await Documents().insert(toDocumentDBO(document));
+      const campaign = await factories
+        .campaign(establishment)
+        .create({}, { associations: { createdBy: user } });
+      await CampaignDocuments().insert({
+        document_id: document.id,
+        campaign_id: campaign.id
+      });
+
+      const { status } = await request(url)
+        .delete(`/documents/${document.id}`)
+        .use(tokenProvider(user));
+
+      expect(status).toBe(constants.HTTP_STATUS_NO_CONTENT);
+      const event = await Events()
+        .where({ type: 'campaign:document-removed' })
+        .join(
+          CAMPAIGN_DOCUMENT_EVENTS_TABLE,
+          `${CAMPAIGN_DOCUMENT_EVENTS_TABLE}.event_id`,
+          `${EVENTS_TABLE}.id`
+        )
+        .where(`${CAMPAIGN_DOCUMENT_EVENTS_TABLE}.document_id`, document.id)
+        .first();
+      expect(event).toMatchObject<
+        Partial<EventDBO<'campaign:document-removed'>>
+      >({
+        type: 'campaign:document-removed',
+        next_old: { filename: document.filename },
+        next_new: null,
+        created_by: user.id
+      });
     });
   });
 });

--- a/server/src/controllers/test/document-api.test.ts
+++ b/server/src/controllers/test/document-api.test.ts
@@ -732,6 +732,48 @@ describe('Document API', () => {
     });
   });
 
+  describe('POST /housing/:id/documents', () => {
+    const testRoute = (id: string) => `/housing/${id}/documents`;
+
+    it('should not duplicate the "housing:document-attached" event when the same document is linked twice', async () => {
+      const housing = genHousingApi(
+        faker.helpers.arrayElement(establishment.geoCodes)
+      );
+      await Housing().insert(formatHousingRecordApi(housing));
+      const document = genDocumentApi({
+        createdBy: user.id,
+        creator: user,
+        establishmentId: establishment.id
+      });
+      await Documents().insert(toDocumentDBO(document));
+
+      await request(url)
+        .post(testRoute(housing.id))
+        .use(tokenProvider(user))
+        .send({ documentIds: [document.id] });
+      const { status } = await request(url)
+        .post(testRoute(housing.id))
+        .use(tokenProvider(user))
+        .send({ documentIds: [document.id] });
+
+      expect(status).toBe(constants.HTTP_STATUS_CREATED);
+      const links = await HousingDocuments()
+        .where({ document_id: document.id, housing_id: housing.id })
+        .select('*');
+      expect(links).toHaveLength(1);
+      const events = await Events()
+        .where({ type: 'housing:document-attached' })
+        .join(
+          HOUSING_DOCUMENT_EVENTS_TABLE,
+          `${HOUSING_DOCUMENT_EVENTS_TABLE}.event_id`,
+          `${EVENTS_TABLE}.id`
+        )
+        .where(`${HOUSING_DOCUMENT_EVENTS_TABLE}.document_id`, document.id)
+        .where(`${HOUSING_DOCUMENT_EVENTS_TABLE}.housing_id`, housing.id);
+      expect(events).toHaveLength(1);
+    });
+  });
+
   describe('POST /campaigns/:id/documents', () => {
     const testRoute = (id: string) => `/campaigns/${id}/documents`;
 
@@ -811,6 +853,42 @@ describe('Document API', () => {
         next_new: { filename: document.filename },
         created_by: user.id
       });
+    });
+
+    it('should not duplicate the "campaign:document-attached" event when the same document is linked twice', async () => {
+      const campaign = await factories
+        .campaign(establishment)
+        .create({}, { associations: { createdBy: user } });
+      const document = genDocumentApi({
+        createdBy: user.id,
+        creator: user,
+        establishmentId: establishment.id
+      });
+      await Documents().insert(toDocumentDBO(document));
+
+      await request(url)
+        .post(testRoute(campaign.id))
+        .use(tokenProvider(user))
+        .send({ documentIds: [document.id] });
+      const { status } = await request(url)
+        .post(testRoute(campaign.id))
+        .use(tokenProvider(user))
+        .send({ documentIds: [document.id] });
+
+      expect(status).toBe(constants.HTTP_STATUS_CREATED);
+      const links = await CampaignDocuments()
+        .where({ document_id: document.id, campaign_id: campaign.id })
+        .select('*');
+      expect(links).toHaveLength(1);
+      const events = await Events()
+        .where({ type: 'campaign:document-attached' })
+        .join(
+          CAMPAIGN_DOCUMENT_EVENTS_TABLE,
+          `${CAMPAIGN_DOCUMENT_EVENTS_TABLE}.event_id`,
+          `${EVENTS_TABLE}.id`
+        )
+        .where(`${CAMPAIGN_DOCUMENT_EVENTS_TABLE}.document_id`, document.id);
+      expect(events).toHaveLength(1);
     });
 
     it('should return 404 if campaign not found', async () => {
@@ -1019,6 +1097,44 @@ describe('Document API', () => {
         .use(tokenProvider(user));
 
       expect(status).toBe(constants.HTTP_STATUS_NOT_FOUND);
+    });
+  });
+
+  describe('DELETE /campaigns/:id (campaign document event cleanup)', () => {
+    it('should not leave orphaned events after the campaign is deleted', async () => {
+      const campaign = await factories
+        .campaign(establishment)
+        .create({}, { associations: { createdBy: user } });
+      const document = genDocumentApi({
+        createdBy: user.id,
+        creator: user,
+        establishmentId: establishment.id
+      });
+      await Documents().insert(toDocumentDBO(document));
+
+      await request(url)
+        .post(`/campaigns/${campaign.id}/documents`)
+        .use(tokenProvider(user))
+        .send({ documentIds: [document.id] });
+
+      const attachedEvents = await Events()
+        .select(`${EVENTS_TABLE}.id`)
+        .join(
+          CAMPAIGN_DOCUMENT_EVENTS_TABLE,
+          `${CAMPAIGN_DOCUMENT_EVENTS_TABLE}.event_id`,
+          `${EVENTS_TABLE}.id`
+        )
+        .where(`${CAMPAIGN_DOCUMENT_EVENTS_TABLE}.campaign_id`, campaign.id);
+      expect(attachedEvents.length).toBeGreaterThan(0);
+      const eventIds = attachedEvents.map((event) => event.id);
+
+      const { status } = await request(url)
+        .delete(`/campaigns/${campaign.id}`)
+        .use(tokenProvider(user));
+
+      expect(status).toBe(constants.HTTP_STATUS_NO_CONTENT);
+      const orphanedEvents = await Events().whereIn('id', eventIds);
+      expect(orphanedEvents).toHaveLength(0);
     });
   });
 

--- a/server/src/infra/database/migrations/20260720100000_documents-campaigns.ts
+++ b/server/src/infra/database/migrations/20260720100000_documents-campaigns.ts
@@ -1,0 +1,27 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.createTable('documents_campaigns', (table) => {
+    table.uuid('document_id').notNullable();
+    table.uuid('campaign_id').notNullable();
+
+    table.primary(['document_id', 'campaign_id']);
+    table
+      .foreign('document_id')
+      .references('id')
+      .inTable('documents')
+      .onUpdate('CASCADE')
+      .onDelete('CASCADE');
+    table
+      .foreign('campaign_id')
+      .references('id')
+      .inTable('campaigns')
+      .onUpdate('CASCADE')
+      .onDelete('CASCADE');
+    table.index('campaign_id');
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTable('documents_campaigns');
+}

--- a/server/src/infra/database/migrations/20260720100001_campaign-document-events.ts
+++ b/server/src/infra/database/migrations/20260720100001_campaign-document-events.ts
@@ -1,0 +1,31 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.createTable('campaign_document_events', (table) => {
+    table
+      .uuid('event_id')
+      .primary()
+      .references('id')
+      .inTable('events')
+      .onDelete('CASCADE');
+    table
+      .uuid('document_id')
+      .notNullable()
+      .references('id')
+      .inTable('documents')
+      .onDelete('CASCADE');
+    table
+      .uuid('campaign_id')
+      .notNullable()
+      .references('id')
+      .inTable('campaigns')
+      .onDelete('CASCADE');
+
+    table.index('document_id');
+    table.index('campaign_id');
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTable('campaign_document_events');
+}

--- a/server/src/models/CampaignDocumentApi.ts
+++ b/server/src/models/CampaignDocumentApi.ts
@@ -1,0 +1,18 @@
+import { CampaignDocumentDTO } from '@zerologementvacant/models';
+
+import {
+  DocumentApi,
+  toDocumentDTO,
+  type FetchDocumentURLOptions
+} from './DocumentApi';
+
+export interface CampaignDocumentApi extends DocumentApi {
+  campaignId: string;
+}
+
+export async function toCampaignDocumentDTO(
+  document: CampaignDocumentApi,
+  options: FetchDocumentURLOptions
+): Promise<CampaignDocumentDTO> {
+  return toDocumentDTO(document, options);
+}

--- a/server/src/models/EventApi.ts
+++ b/server/src/models/EventApi.ts
@@ -119,6 +119,16 @@ export type HousingDocumentEventApi = EventUnion<
   documentId: string;
 };
 
+// Campaign-document association events
+export type CampaignDocumentEventApi = EventUnion<
+  | 'campaign:document-attached'
+  | 'campaign:document-detached'
+  | 'campaign:document-removed'
+> & {
+  campaignId: string;
+  documentId: string;
+};
+
 export function isUserModified(event: EventApi<EventType>): boolean {
   assert(event.creator, 'Event creator is missing');
   const isBeta = /@(zerologementvacant\.)?beta\.gouv\.fr$/;

--- a/server/src/repositories/campaignDocumentRepository.ts
+++ b/server/src/repositories/campaignDocumentRepository.ts
@@ -1,0 +1,229 @@
+import type { Knex } from 'knex';
+
+import db from '~/infra/database';
+import { withinTransaction } from '~/infra/database/transaction';
+import { createLogger } from '~/infra/logger';
+import { CampaignApi } from '~/models/CampaignApi';
+import { CampaignDocumentApi } from '~/models/CampaignDocumentApi';
+import { UserDBO, USERS_TABLE } from '~/repositories/userRepository';
+
+import {
+  Documents,
+  DOCUMENTS_TABLE,
+  fromDocumentDBO,
+  type DocumentDBO
+} from './documentRepository';
+
+const logger = createLogger('campaignDocumentRepository');
+
+export const CAMPAIGN_DOCUMENT_TABLE = 'documents_campaigns';
+
+export const CampaignDocuments = (
+  transaction: Knex<CampaignDocumentDBO> = db
+) => transaction<CampaignDocumentDBO>(CAMPAIGN_DOCUMENT_TABLE);
+
+export interface CampaignDocumentDBO {
+  document_id: string;
+  campaign_id: string;
+}
+
+type CampaignDocumentWithCreatorDBO = DocumentDBO &
+  CampaignDocumentDBO & {
+    creator: UserDBO;
+  };
+
+async function link(document: CampaignDocumentApi): Promise<void> {
+  logger.debug('Creating document-campaign link', {
+    documentId: document.id,
+    campaignId: document.campaignId
+  });
+
+  await withinTransaction(async (transaction) => {
+    await CampaignDocuments(transaction)
+      .insert(toCampaignDocumentDBO(document))
+      .onConflict(['document_id', 'campaign_id'])
+      .ignore();
+  });
+}
+
+async function linkMany(
+  campaignDocuments: ReadonlyArray<CampaignDocumentDBO>
+): Promise<void> {
+  if (campaignDocuments.length === 0) {
+    logger.debug('No campaign documents to link. Skipping...');
+    return;
+  }
+
+  logger.debug('Linking documents to campaigns...', { campaignDocuments });
+
+  await withinTransaction(async (transaction) => {
+    await CampaignDocuments(transaction)
+      .insert(campaignDocuments)
+      .onConflict(['document_id', 'campaign_id'])
+      .ignore();
+  });
+}
+
+async function unlink(link: {
+  documentId: string;
+  campaignId: string;
+}): Promise<void> {
+  logger.debug('Unlinking document from campaign...', link);
+
+  await CampaignDocuments()
+    .where({
+      document_id: link.documentId,
+      campaign_id: link.campaignId
+    })
+    .delete();
+}
+
+async function unlinkMany(params: { documentIds: string[] }): Promise<void> {
+  if (!params.documentIds.length) {
+    logger.debug('No documents to unlink. Skipping...');
+    return;
+  }
+
+  logger.debug('Unlinking documents from campaigns...', {
+    documents: params.documentIds.length
+  });
+
+  await withinTransaction(async (transaction) => {
+    await CampaignDocuments(transaction)
+      .whereIn('document_id', params.documentIds)
+      .delete();
+  });
+
+  logger.debug('Documents unlinked from campaigns', {
+    documents: params.documentIds.length
+  });
+}
+
+interface FindOptions {
+  filters?: {
+    documentIds?: string[];
+    campaignIds?: Array<CampaignApi['id']>;
+    deleted?: boolean;
+  };
+}
+
+async function find(
+  options?: FindOptions
+): Promise<ReadonlyArray<CampaignDocumentApi>> {
+  logger.debug('Finding document-campaign links...', options);
+
+  const documents = await listQuery()
+    .modify((query) => {
+      if (options?.filters?.documentIds?.length) {
+        query.whereIn(
+          `${CAMPAIGN_DOCUMENT_TABLE}.document_id`,
+          options.filters.documentIds
+        );
+      }
+
+      if (options?.filters?.campaignIds?.length) {
+        query.whereIn(
+          `${CAMPAIGN_DOCUMENT_TABLE}.campaign_id`,
+          options.filters.campaignIds
+        );
+      }
+
+      if (options?.filters?.deleted === true) {
+        query.whereNotNull(`${DOCUMENTS_TABLE}.deleted_at`);
+      } else if (options?.filters?.deleted === false) {
+        query.whereNull(`${DOCUMENTS_TABLE}.deleted_at`);
+      }
+    })
+    .orderBy(`${DOCUMENTS_TABLE}.created_at`, 'desc');
+
+  return documents.map(fromCampaignDocumentDBO);
+}
+
+interface GetOptions {
+  campaign?: Array<CampaignApi['id']>;
+}
+
+async function get(
+  id: string,
+  options?: GetOptions
+): Promise<CampaignDocumentApi | null> {
+  logger.debug('Getting campaign document...', { id });
+  const document = await listQuery()
+    .where(`${CAMPAIGN_DOCUMENT_TABLE}.document_id`, id)
+    .modify((query) => {
+      if (options?.campaign?.length) {
+        query.whereIn(
+          `${CAMPAIGN_DOCUMENT_TABLE}.campaign_id`,
+          options.campaign
+        );
+      }
+    })
+    .first();
+
+  return document ? fromCampaignDocumentDBO(document) : null;
+}
+
+async function remove(document: CampaignDocumentApi): Promise<void> {
+  logger.debug('Soft-deleting campaign document...', document);
+  await Documents().where('id', document.id).update({ deleted_at: new Date() });
+}
+
+function listQuery() {
+  return Documents()
+    .select(
+      `${DOCUMENTS_TABLE}.*`,
+      `${CAMPAIGN_DOCUMENT_TABLE}.campaign_id`,
+      db.raw(`json_build_object(
+        'id', ${USERS_TABLE}.id,
+        'email', ${USERS_TABLE}.email,
+        'first_name', ${USERS_TABLE}.first_name,
+        'last_name', ${USERS_TABLE}.last_name,
+        'role', ${USERS_TABLE}.role,
+        'establishment_id', ${USERS_TABLE}.establishment_id,
+        'time_per_week', ${USERS_TABLE}.time_per_week,
+        'phone', ${USERS_TABLE}.phone,
+        'position', ${USERS_TABLE}.position,
+        'updated_at', ${USERS_TABLE}.updated_at
+      ) as creator`)
+    )
+    .join(
+      CAMPAIGN_DOCUMENT_TABLE,
+      `${CAMPAIGN_DOCUMENT_TABLE}.document_id`,
+      `${DOCUMENTS_TABLE}.id`
+    )
+    .join(USERS_TABLE, `${USERS_TABLE}.id`, `${DOCUMENTS_TABLE}.created_by`);
+}
+
+export function toCampaignDocumentDBO(
+  document: CampaignDocumentApi
+): CampaignDocumentDBO {
+  return {
+    document_id: document.id,
+    campaign_id: document.campaignId
+  };
+}
+
+export function fromCampaignDocumentDBO(
+  dbo: CampaignDocumentWithCreatorDBO
+): CampaignDocumentApi {
+  if (!dbo.creator) {
+    throw new Error('Creator not fetched');
+  }
+
+  return {
+    ...fromDocumentDBO(dbo),
+    campaignId: dbo.campaign_id
+  };
+}
+
+const campaignDocumentRepository = {
+  link,
+  linkMany,
+  unlink,
+  unlinkMany,
+  find,
+  get,
+  remove
+};
+
+export default campaignDocumentRepository;

--- a/server/src/repositories/campaignDocumentRepository.ts
+++ b/server/src/repositories/campaignDocumentRepository.ts
@@ -48,34 +48,41 @@ async function link(document: CampaignDocumentApi): Promise<void> {
 
 async function linkMany(
   campaignDocuments: ReadonlyArray<CampaignDocumentDBO>
-): Promise<void> {
+): Promise<CampaignDocumentDBO[]> {
   if (campaignDocuments.length === 0) {
     logger.debug('No campaign documents to link. Skipping...');
-    return;
+    return [];
   }
 
   logger.debug('Linking documents to campaigns...', { campaignDocuments });
 
+  let inserted: CampaignDocumentDBO[] = [];
   await withinTransaction(async (transaction) => {
-    await CampaignDocuments(transaction)
+    inserted = await CampaignDocuments(transaction)
       .insert(campaignDocuments)
       .onConflict(['document_id', 'campaign_id'])
-      .ignore();
+      .ignore()
+      .returning(['document_id', 'campaign_id']);
   });
+  return inserted;
 }
 
 async function unlink(link: {
   documentId: string;
   campaignId: string;
-}): Promise<void> {
+}): Promise<number> {
   logger.debug('Unlinking document from campaign...', link);
 
-  await CampaignDocuments()
-    .where({
-      document_id: link.documentId,
-      campaign_id: link.campaignId
-    })
-    .delete();
+  let deletedCount = 0;
+  await withinTransaction(async (transaction) => {
+    deletedCount = await CampaignDocuments(transaction)
+      .where({
+        document_id: link.documentId,
+        campaign_id: link.campaignId
+      })
+      .delete();
+  });
+  return deletedCount;
 }
 
 async function unlinkMany(params: { documentIds: string[] }): Promise<void> {

--- a/server/src/repositories/eventRepository.ts
+++ b/server/src/repositories/eventRepository.ts
@@ -4,6 +4,7 @@ import db from '~/infra/database';
 import { withinTransaction } from '~/infra/database/transaction';
 import { createLogger } from '~/infra/logger';
 import {
+  CampaignDocumentEventApi,
   CampaignEventApi,
   CampaignHousingEventApi,
   DocumentEventApi,
@@ -59,6 +60,11 @@ export const DocumentEvents = (transaction = db) =>
   transaction<DocumentEventDBO>(DOCUMENT_EVENTS_TABLE);
 export const HousingDocumentEvents = (transaction = db) =>
   transaction<HousingDocumentEventDBO>(HOUSING_DOCUMENT_EVENTS_TABLE);
+
+export const CAMPAIGN_DOCUMENT_EVENTS_TABLE = 'campaign_document_events';
+
+export const CampaignDocumentEvents = (transaction = db) =>
+  transaction<CampaignDocumentEventDBO>(CAMPAIGN_DOCUMENT_EVENTS_TABLE);
 
 async function insertManyHousingEvents(
   events: ReadonlyArray<HousingEventApi>
@@ -230,6 +236,25 @@ async function insertManyHousingDocumentEvents(
     await transaction.batchInsert(
       HOUSING_DOCUMENT_EVENTS_TABLE,
       events.map(formatHousingDocumentEventApi)
+    );
+  });
+}
+
+async function insertManyCampaignDocumentEvents(
+  events: ReadonlyArray<CampaignDocumentEventApi>
+): Promise<void> {
+  if (!events.length) {
+    return;
+  }
+
+  logger.debug('Inserting campaign document events...', {
+    events: events.length
+  });
+  await withinTransaction(async (transaction) => {
+    await transaction.batchInsert(EVENTS_TABLE, events.map(formatEventApi));
+    await transaction.batchInsert(
+      CAMPAIGN_DOCUMENT_EVENTS_TABLE,
+      events.map(formatCampaignDocumentEventApi)
     );
   });
 }
@@ -575,9 +600,26 @@ export function formatHousingDocumentEventApi(
   };
 }
 
+export interface CampaignDocumentEventDBO {
+  event_id: string;
+  campaign_id: string;
+  document_id: string;
+}
+
+export function formatCampaignDocumentEventApi(
+  event: CampaignDocumentEventApi
+): CampaignDocumentEventDBO {
+  return {
+    event_id: event.id,
+    campaign_id: event.campaignId,
+    document_id: event.documentId
+  };
+}
+
 export default {
   insertManyCampaignEvents,
   insertManyCampaignHousingEvents,
+  insertManyCampaignDocumentEvents,
   insertManyHousingEvents,
   insertManyHousingOwnerEvents,
   insertManyGroupHousingEvents,

--- a/server/src/repositories/eventRepository.ts
+++ b/server/src/repositories/eventRepository.ts
@@ -384,13 +384,22 @@ async function removeCampaignEvents(campaignId: string): Promise<void> {
     campaign: campaignId
   });
   await withinTransaction(async (transaction) => {
+    // Delete the parent `events` rows referenced both by campaign events and by
+    // campaign document events; the join-table rows cascade from `events`.
+    // Otherwise document events would be left orphaned when a campaign is removed.
     await Events(transaction)
-      .join(
-        CAMPAIGN_EVENTS_TABLE,
-        `${CAMPAIGN_EVENTS_TABLE}.event_id`,
-        `${EVENTS_TABLE}.id`
-      )
-      .where(`${CAMPAIGN_EVENTS_TABLE}.campaign_id`, campaignId)
+      .whereIn(`${EVENTS_TABLE}.id`, (subquery) => {
+        subquery
+          .select('event_id')
+          .from(CAMPAIGN_EVENTS_TABLE)
+          .where('campaign_id', campaignId)
+          .unionAll((union) => {
+            union
+              .select('event_id')
+              .from(CAMPAIGN_DOCUMENT_EVENTS_TABLE)
+              .where('campaign_id', campaignId);
+          });
+      })
       .delete();
   });
   logger.debug('Campaign events removed', {

--- a/server/src/repositories/housingDocumentRepository.ts
+++ b/server/src/repositories/housingDocumentRepository.ts
@@ -48,38 +48,45 @@ async function link(document: HousingDocumentApi): Promise<void> {
 
 async function linkMany(
   housingDocuments: ReadonlyArray<HousingDocumentDBO>
-): Promise<void> {
+): Promise<HousingDocumentDBO[]> {
   if (housingDocuments.length === 0) {
     logger.debug('No housing documents to link. Skipping...');
-    return;
+    return [];
   }
 
   logger.debug('Linking documents to housings...', {
     housingDocuments
   });
 
+  let inserted: HousingDocumentDBO[] = [];
   await withinTransaction(async (transaction) => {
-    await HousingDocuments(transaction)
+    inserted = await HousingDocuments(transaction)
       .insert(housingDocuments)
       .onConflict(['document_id', 'housing_geo_code', 'housing_id'])
-      .ignore();
+      .ignore()
+      .returning(['document_id', 'housing_geo_code', 'housing_id']);
   });
+  return inserted;
 }
 
 async function unlink(link: {
   documentId: string;
   housingId: string;
   housingGeoCode: string;
-}): Promise<void> {
+}): Promise<number> {
   logger.debug('Unlinking document from housing...', link);
 
-  await HousingDocuments()
-    .where({
-      document_id: link.documentId,
-      housing_geo_code: link.housingGeoCode,
-      housing_id: link.housingId
-    })
-    .delete();
+  let deletedCount = 0;
+  await withinTransaction(async (transaction) => {
+    deletedCount = await HousingDocuments(transaction)
+      .where({
+        document_id: link.documentId,
+        housing_geo_code: link.housingGeoCode,
+        housing_id: link.housingId
+      })
+      .delete();
+  });
+  return deletedCount;
 }
 
 async function unlinkMany(params: { documentIds: string[] }): Promise<void> {

--- a/server/src/repositories/test/campaignDocumentRepository.test.ts
+++ b/server/src/repositories/test/campaignDocumentRepository.test.ts
@@ -1,0 +1,316 @@
+import { faker } from '@faker-js/faker/locale/fr';
+
+import { CampaignApi } from '~/models/CampaignApi';
+import { CampaignDocumentApi } from '~/models/CampaignDocumentApi';
+import campaignDocumentRepository, {
+  CampaignDocuments,
+  toCampaignDocumentDBO,
+  type CampaignDocumentDBO
+} from '~/repositories/campaignDocumentRepository';
+import { Documents, toDocumentDBO } from '~/repositories/documentRepository';
+import {
+  Establishments,
+  formatEstablishmentApi
+} from '~/repositories/establishmentRepository';
+import { toUserDBO, Users } from '~/repositories/userRepository';
+import { factories } from '~/test/factories';
+import {
+  genCampaignDocumentApi,
+  genEstablishmentApi,
+  genUserApi
+} from '~/test/testFixtures';
+
+describe('Campaign document repository', () => {
+  const establishment = genEstablishmentApi();
+  const user = genUserApi(establishment.id);
+
+  beforeAll(async () => {
+    await Establishments().insert(formatEstablishmentApi(establishment));
+    await Users().insert(toUserDBO(user));
+  });
+
+  describe('link', () => {
+    it('should create document-campaign link', async () => {
+      const campaign = await factories
+        .campaign(establishment)
+        .create({}, { associations: { createdBy: user } });
+
+      const campaignDocument = genCampaignDocumentApi({
+        createdBy: user.id,
+        creator: user,
+        campaignId: campaign.id
+      });
+      await Documents().insert(toDocumentDBO(campaignDocument));
+
+      await campaignDocumentRepository.link(campaignDocument);
+
+      const actual = await CampaignDocuments()
+        .where('document_id', campaignDocument.id)
+        .first();
+
+      expect(actual).toMatchObject({
+        document_id: campaignDocument.id,
+        campaign_id: campaign.id
+      });
+    });
+
+    it('should be idempotent (ignore duplicate links)', async () => {
+      const campaign = await factories
+        .campaign(establishment)
+        .create({}, { associations: { createdBy: user } });
+
+      const campaignDocument = genCampaignDocumentApi({
+        createdBy: user.id,
+        creator: user,
+        campaignId: campaign.id
+      });
+      await Documents().insert(toDocumentDBO(campaignDocument));
+
+      await campaignDocumentRepository.link(campaignDocument);
+      await campaignDocumentRepository.link(campaignDocument);
+
+      const actual = await CampaignDocuments().where(
+        'document_id',
+        campaignDocument.id
+      );
+      expect(actual).toHaveLength(1);
+    });
+  });
+
+  describe('linkMany', () => {
+    it('should create multiple document-campaign links (cartesian product)', async () => {
+      const campaigns = await factories
+        .campaign(establishment)
+        .createList(2, {}, { associations: { createdBy: user } });
+
+      const campaignDocuments = [
+        genCampaignDocumentApi({ createdBy: user.id, creator: user }),
+        genCampaignDocumentApi({ createdBy: user.id, creator: user })
+      ];
+      await Documents().insert(campaignDocuments.map(toDocumentDBO));
+
+      const links = campaignDocuments.flatMap((d) =>
+        campaigns.map((c) => ({
+          document_id: d.id,
+          campaign_id: c.id
+        }))
+      );
+      await campaignDocumentRepository.linkMany(links);
+
+      const allLinks = await CampaignDocuments().whereIn(
+        'document_id',
+        campaignDocuments.map((d) => d.id)
+      );
+
+      expect(allLinks).toHaveLength(4);
+    });
+
+    it('should handle empty arrays', async () => {
+      await expect(
+        campaignDocumentRepository.linkMany([])
+      ).resolves.not.toThrow();
+    });
+  });
+
+  describe('unlink', () => {
+    it('should remove document-campaign link', async () => {
+      const campaign = await factories
+        .campaign(establishment)
+        .create({}, { associations: { createdBy: user } });
+
+      const campaignDocument = genCampaignDocumentApi({
+        createdBy: user.id,
+        creator: user,
+        campaignId: campaign.id
+      });
+      await Documents().insert(toDocumentDBO(campaignDocument));
+
+      const linkDBO: CampaignDocumentDBO = {
+        document_id: campaignDocument.id,
+        campaign_id: campaign.id
+      };
+      await CampaignDocuments().insert(linkDBO);
+
+      await campaignDocumentRepository.unlink({
+        documentId: campaignDocument.id,
+        campaignId: campaign.id
+      });
+
+      const actual = await CampaignDocuments().where(
+        'document_id',
+        campaignDocument.id
+      );
+      expect(actual).toHaveLength(0);
+    });
+  });
+
+  describe('get', () => {
+    let campaign: CampaignApi;
+    let document: CampaignDocumentApi;
+
+    beforeAll(async () => {
+      campaign = await factories
+        .campaign(establishment)
+        .create({}, { associations: { createdBy: user } });
+      document = genCampaignDocumentApi({
+        createdBy: user.id,
+        creator: user,
+        campaignId: campaign.id
+      });
+      await Documents().insert(toDocumentDBO(document));
+      await CampaignDocuments().insert(toCampaignDocumentDBO(document));
+    });
+
+    it('should return null if the document is missing', async () => {
+      const actual = await campaignDocumentRepository.get(faker.string.uuid());
+
+      expect(actual).toBeNull();
+    });
+
+    it('should return the document if it exists', async () => {
+      const actual = await campaignDocumentRepository.get(document.id);
+
+      expect(actual).toBeDefined();
+      expect(actual).toMatchObject<Partial<CampaignDocumentApi>>({
+        id: document.id,
+        filename: document.filename,
+        s3Key: document.s3Key,
+        contentType: document.contentType,
+        sizeBytes: document.sizeBytes,
+        campaignId: campaign.id,
+        createdBy: user.id
+      });
+    });
+
+    it('should include creator information', async () => {
+      const actual = await campaignDocumentRepository.get(document.id);
+
+      expect(actual).toBeDefined();
+      expect(actual!.creator).toBeDefined();
+      expect(actual!.creator.id).toBe(user.id);
+      expect(actual!.creator.email).toBe(user.email);
+    });
+
+    it('should return null when campaign does not match', async () => {
+      const differentCampaign = await factories
+        .campaign(establishment)
+        .create({}, { associations: { createdBy: user } });
+
+      const actual = await campaignDocumentRepository.get(document.id, {
+        campaign: [differentCampaign.id]
+      });
+
+      expect(actual).toBeNull();
+    });
+  });
+
+  describe('remove', () => {
+    it('should soft-delete the document', async () => {
+      const campaign = await factories
+        .campaign(establishment)
+        .create({}, { associations: { createdBy: user } });
+      const document = genCampaignDocumentApi({
+        createdBy: user.id,
+        creator: user,
+        campaignId: campaign.id
+      });
+      await Documents().insert(toDocumentDBO(document));
+      await CampaignDocuments().insert(toCampaignDocumentDBO(document));
+
+      await campaignDocumentRepository.remove(document);
+
+      const actualDocument = await Documents()
+        .where({ id: document.id })
+        .first();
+
+      expect(actualDocument).toBeDefined();
+      expect(actualDocument!.deleted_at).not.toBeNull();
+
+      const actualLink = await CampaignDocuments()
+        .where({ document_id: document.id, campaign_id: campaign.id })
+        .first();
+
+      expect(actualLink).toBeDefined();
+    });
+  });
+
+  describe('unlinkMany', () => {
+    it('should unlink multiple documents from all campaigns', async () => {
+      const campaigns = await factories
+        .campaign(establishment)
+        .createList(2, {}, { associations: { createdBy: user } });
+      const campaignDocuments = [
+        genCampaignDocumentApi({ createdBy: user.id, creator: user }),
+        genCampaignDocumentApi({ createdBy: user.id, creator: user })
+      ];
+
+      await Documents().insert(campaignDocuments.map(toDocumentDBO));
+
+      const links = campaignDocuments.flatMap((doc) =>
+        campaigns.map((c) => ({
+          document_id: doc.id,
+          campaign_id: c.id
+        }))
+      );
+      await campaignDocumentRepository.linkMany(links);
+
+      const linksBefore = await CampaignDocuments().whereIn(
+        'document_id',
+        campaignDocuments.map((doc) => doc.id)
+      );
+      expect(linksBefore).toHaveLength(4);
+
+      await campaignDocumentRepository.unlinkMany({
+        documentIds: campaignDocuments.map((doc) => doc.id)
+      });
+
+      const linksAfter = await CampaignDocuments().whereIn(
+        'document_id',
+        campaignDocuments.map((doc) => doc.id)
+      );
+      expect(linksAfter).toBeEmpty();
+    });
+
+    it('should handle empty array', async () => {
+      await expect(
+        campaignDocumentRepository.unlinkMany({ documentIds: [] })
+      ).resolves.not.toThrow();
+    });
+
+    it('should only unlink specified documents', async () => {
+      const campaign = await factories
+        .campaign(establishment)
+        .create({}, { associations: { createdBy: user } });
+      const documents = [
+        genCampaignDocumentApi({
+          createdBy: user.id,
+          creator: user,
+          campaignId: campaign.id
+        }),
+        genCampaignDocumentApi({
+          createdBy: user.id,
+          creator: user,
+          campaignId: campaign.id
+        })
+      ];
+
+      await Documents().insert(documents.map(toDocumentDBO));
+
+      const links = documents.map((doc) => ({
+        document_id: doc.id,
+        campaign_id: campaign.id
+      }));
+      await campaignDocumentRepository.linkMany(links);
+
+      await campaignDocumentRepository.unlinkMany({
+        documentIds: [documents[0].id]
+      });
+
+      const remainingLinks = await CampaignDocuments().where({
+        campaign_id: campaign.id
+      });
+      expect(remainingLinks).toHaveLength(1);
+      expect(remainingLinks[0].document_id).toBe(documents[1].id);
+    });
+  });
+});

--- a/server/src/repositories/test/campaignDocumentRepository.test.ts
+++ b/server/src/repositories/test/campaignDocumentRepository.test.ts
@@ -313,4 +313,142 @@ describe('Campaign document repository', () => {
       expect(remainingLinks[0].document_id).toBe(documents[1].id);
     });
   });
+
+  describe('find', () => {
+    it('should filter by campaign ids', async () => {
+      const [campaignA, campaignB] = await factories
+        .campaign(establishment)
+        .createList(2, {}, { associations: { createdBy: user } });
+
+      const campaignADocuments = [
+        genCampaignDocumentApi({
+          createdBy: user.id,
+          creator: user,
+          campaignId: campaignA.id
+        }),
+        genCampaignDocumentApi({
+          createdBy: user.id,
+          creator: user,
+          campaignId: campaignA.id
+        })
+      ];
+      const campaignBDocument = genCampaignDocumentApi({
+        createdBy: user.id,
+        creator: user,
+        campaignId: campaignB.id
+      });
+      const allDocuments = [...campaignADocuments, campaignBDocument];
+
+      await Documents().insert(allDocuments.map(toDocumentDBO));
+      await campaignDocumentRepository.linkMany(
+        allDocuments.map(toCampaignDocumentDBO)
+      );
+
+      const actual = await campaignDocumentRepository.find({
+        filters: { campaignIds: [campaignA.id] }
+      });
+
+      expect(actual.map((document) => document.id).sort()).toEqual(
+        campaignADocuments.map((document) => document.id).sort()
+      );
+    });
+
+    it('should filter by document ids', async () => {
+      const campaign = await factories
+        .campaign(establishment)
+        .create({}, { associations: { createdBy: user } });
+
+      const documents = [
+        genCampaignDocumentApi({
+          createdBy: user.id,
+          creator: user,
+          campaignId: campaign.id
+        }),
+        genCampaignDocumentApi({
+          createdBy: user.id,
+          creator: user,
+          campaignId: campaign.id
+        }),
+        genCampaignDocumentApi({
+          createdBy: user.id,
+          creator: user,
+          campaignId: campaign.id
+        })
+      ];
+
+      await Documents().insert(documents.map(toDocumentDBO));
+      await campaignDocumentRepository.linkMany(
+        documents.map(toCampaignDocumentDBO)
+      );
+
+      const actual = await campaignDocumentRepository.find({
+        filters: { documentIds: [documents[1].id] }
+      });
+
+      expect(actual).toHaveLength(1);
+      expect(actual[0].id).toBe(documents[1].id);
+    });
+
+    it('should filter by deleted status', async () => {
+      const campaign = await factories
+        .campaign(establishment)
+        .create({}, { associations: { createdBy: user } });
+
+      const activeDocument = genCampaignDocumentApi({
+        createdBy: user.id,
+        creator: user,
+        campaignId: campaign.id
+      });
+      const deletedDocument = genCampaignDocumentApi({
+        createdBy: user.id,
+        creator: user,
+        campaignId: campaign.id
+      });
+
+      await Documents().insert(
+        [activeDocument, deletedDocument].map(toDocumentDBO)
+      );
+      await campaignDocumentRepository.linkMany(
+        [activeDocument, deletedDocument].map(toCampaignDocumentDBO)
+      );
+      await campaignDocumentRepository.remove(deletedDocument);
+
+      // Scoped to this test's campaign so that documents soft-deleted by
+      // other tests in this file don't affect the assertions below.
+      const active = await campaignDocumentRepository.find({
+        filters: { campaignIds: [campaign.id], deleted: false }
+      });
+      expect(active.map((document) => document.id)).toEqual([
+        activeDocument.id
+      ]);
+
+      const deleted = await campaignDocumentRepository.find({
+        filters: { campaignIds: [campaign.id], deleted: true }
+      });
+      expect(deleted.map((document) => document.id)).toEqual([
+        deletedDocument.id
+      ]);
+    });
+
+    it('should return all linked documents when no filters are provided', async () => {
+      const campaign = await factories
+        .campaign(establishment)
+        .create({}, { associations: { createdBy: user } });
+
+      const document = genCampaignDocumentApi({
+        createdBy: user.id,
+        creator: user,
+        campaignId: campaign.id
+      });
+
+      await Documents().insert(toDocumentDBO(document));
+      await campaignDocumentRepository.linkMany([
+        toCampaignDocumentDBO(document)
+      ]);
+
+      const actual = await campaignDocumentRepository.find();
+
+      expect(actual.map((linked) => linked.id)).toContain(document.id);
+    });
+  });
 });

--- a/server/src/routers/protected.ts
+++ b/server/src/routers/protected.ts
@@ -1,6 +1,6 @@
 import {
-  ACCEPTED_HOUSING_DOCUMENT_EXTENSIONS,
-  MAX_HOUSING_DOCUMENT_SIZE_IN_MiB,
+  ACCEPTED_DOCUMENT_EXTENSIONS,
+  MAX_DOCUMENT_SIZE_IN_MiB,
   UserRole
 } from '@zerologementvacant/models';
 import schemas from '@zerologementvacant/schemas';
@@ -55,9 +55,9 @@ router.post(
   '/documents',
   hasRole([UserRole.USUAL, UserRole.ADMIN]),
   upload({
-    accept: ACCEPTED_HOUSING_DOCUMENT_EXTENSIONS as string[],
+    accept: ACCEPTED_DOCUMENT_EXTENSIONS as string[],
     multiple: true,
-    maxSizeMiB: MAX_HOUSING_DOCUMENT_SIZE_IN_MiB
+    maxSizeMiB: MAX_DOCUMENT_SIZE_IN_MiB
   }),
   documentController.create
 );

--- a/server/src/routers/protected.ts
+++ b/server/src/routers/protected.ts
@@ -329,6 +329,31 @@ router.delete(
   campaignController.removeHousings
 );
 
+router.get(
+  '/campaigns/:id/documents',
+  validator.validate({
+    params: object({ id: schemas.id })
+  }),
+  documentController.listByCampaign
+);
+router.post(
+  '/campaigns/:id/documents',
+  hasRole([UserRole.USUAL, UserRole.ADMIN]),
+  validator.validate({
+    params: object({ id: schemas.id }),
+    body: schemas.campaignDocumentPayload
+  }),
+  documentController.linkToCampaign
+);
+router.delete(
+  '/campaigns/:id/documents/:documentId',
+  hasRole([UserRole.USUAL, UserRole.ADMIN]),
+  validator.validate({
+    params: object({ id: schemas.id, documentId: schemas.id })
+  }),
+  documentController.removeByCampaign
+);
+
 router.get('/drafts', draftController.list);
 router.post(
   '/drafts',

--- a/server/src/services/document-upload.ts
+++ b/server/src/services/document-upload.ts
@@ -33,7 +33,7 @@ export async function upload(
       ContentType: file.mimetype,
       ACL: 'authenticated-read',
       Metadata: {
-        originalName: file.originalname,
+        originalName: encodeURIComponent(file.originalname),
         fieldName: file.fieldname
       }
     });

--- a/server/src/test/testFixtures.ts
+++ b/server/src/test/testFixtures.ts
@@ -41,6 +41,7 @@ import { logger } from '~/infra/logger';
 import { AddressApi } from '~/models/AddressApi';
 import { BuildingApi } from '~/models/BuildingApi';
 import { CampaignApi } from '~/models/CampaignApi';
+import { CampaignDocumentApi } from '~/models/CampaignDocumentApi';
 import { DocumentApi } from '~/models/DocumentApi';
 import { DraftApi } from '~/models/DraftApi';
 import { EstablishmentApi } from '~/models/EstablishmentApi';
@@ -578,5 +579,16 @@ export function genHousingDocumentApi(
     housingId: overrides?.housingId ?? faker.string.uuid(),
     housingGeoCode:
       overrides?.housingGeoCode ?? faker.location.zipCode('######')
+  };
+}
+
+export function genCampaignDocumentApi(
+  overrides?: Partial<CampaignDocumentApi>
+): CampaignDocumentApi {
+  const baseDocument = genDocumentApi(overrides);
+
+  return {
+    ...baseDocument,
+    campaignId: overrides?.campaignId ?? faker.string.uuid()
   };
 }


### PR DESCRIPTION
## Summary

Adds a "Documents" tab to the campaign detail page, letting users upload, view, rename, and delete documents attached to a campaign — mirroring the existing housing-documents feature end-to-end.

- **Backend**: new `documents_campaigns` junction table + `campaign_document_events` audit table, `campaignDocumentRepository`, three new `documentController` endpoints (`GET/POST /campaigns/:id/documents`, `DELETE /campaigns/:id/documents/:documentId`), and an extension of the existing generic document-cascade-delete logic to also unlink campaigns.
- **Frontend**: RTK Query endpoints + MSW mocks, a `CampaignDocumentUpload` component, a `CampaignDocumentsTab` component, and wiring into the campaign detail page's existing tab bar (after "Destinataires"/"Courrier").
- **Refactor**: extracted a shared `canWriteDocument` permission helper and generalized two housing-specific upload constants (`ACCEPTED_DOCUMENT_EXTENSIONS`/`MAX_DOCUMENT_SIZE_IN_MiB`) so both housing and campaign documents share them.
- **De-duplication**: `DocumentsTab.tsx` (the existing housing-side render component) gained two new optional props (`uploadSlot`, `emptyStateMessage`) so `CampaignDocumentsTab` delegates rendering to it instead of duplicating ~150-180 lines of render/modal logic — its two existing consumers (`HousingDetailsCard.tsx`, `HousingEditionSideMenu.tsx`) were updated accordingly, with zero behavior change (verified via the full `HousingView.test.tsx` suite).
- **RGAA**: added a "(nouvelle fenêtre)" screen-reader cue to the external CNIL link in both the new and pre-existing document-upload hint text (critère 13.2), closing an inherited gap this branch would otherwise have propagated into a second file.

Design spec: `docs/superpowers/specs/2026-07-20-campaign-documents-design.md`
Implementation plan: `docs/superpowers/plans/2026-07-20-campaign-documents.md`

## Test plan

- [x] Backend: `campaignDocumentRepository.test.ts` (17/17) and `document-api.test.ts` (42/42, including 12 new campaign-document tests) — real Postgres via supertest, establishment-scoping and role-gating covered (404 cross-establishment, 403 visitor).
- [x] Frontend: `CampaignDocumentUpload.test.tsx` (3/3), `CampaignDocumentsTab.test.tsx` (4/4), `CampaignView.test.tsx` (16/16, including 5 new Documents-tab tests) — real MSW handlers.
- [x] Regression: `HousingView.test.tsx` (49/49, 4 todo) — confirms the `DocumentsTab.tsx` refactor and `canWriteDocument` extraction are fully behavior-preserving for the pre-existing housing-documents feature.
- [x] `yarn nx run-many -t typecheck` — clean across all 9 projects.
- [x] Every task implemented via subagent-driven development with a dedicated task-level code review (spec compliance + quality) plus a final whole-branch review (Ready to merge: Yes, 0 Critical, 0 Important).
- [ ] Manual verification against the Figma mockup (upload, list, rename, delete, permission gating) — not yet done in a live browser session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)