### PR TITLE
fix: give AdvancedTable's per-page selector a label and stop emitting spurious aria-selected

### DIFF
--- a/frontend/src/components/AdvancedTable/AdvancedTable.tsx
+++ b/frontend/src/components/AdvancedTable/AdvancedTable.tsx
@@ -251,7 +251,11 @@ function AdvancedTable<Data extends object>(props: AdvancedTableProps<Data>) {
                   {rows.map((row, i) => (
                     <tr
                       key={i}
-                      aria-selected={all !== row.getIsSelected()}
+                      aria-selected={
+                        enableSelection
+                          ? all !== row.getIsSelected()
+                          : undefined
+                      }
                       ref={rowRefs[row.id]}
                       style={
                         props.tableProps?.fixedRowHeight
@@ -326,6 +330,7 @@ function AdvancedTable<Data extends object>(props: AdvancedTableProps<Data>) {
               value: String(option)
             }))}
             nativeSelectProps={{
+              'aria-label': 'Résultats par page',
               value: String(table.getState().pagination.pageSize),
               onChange: (event) => {
                 const value = Number(event.target.value);

--- a/frontend/src/components/AdvancedTable/test/AdvancedTable.test.tsx
+++ b/frontend/src/components/AdvancedTable/test/AdvancedTable.test.tsx
@@ -1,0 +1,57 @@
+import { createColumnHelper } from '@tanstack/react-table';
+import { render, screen, within } from '@testing-library/react';
+
+import AdvancedTable from '~/components/AdvancedTable/AdvancedTable';
+
+interface Row {
+  id: string;
+  name: string;
+}
+
+const columnHelper = createColumnHelper<Row>();
+const columns = [columnHelper.accessor('name', { header: 'Nom' })];
+
+function buildRows(count: number): Row[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `row-${i}`,
+    name: `Row ${i}`
+  }));
+}
+
+describe('AdvancedTable', () => {
+  it('gives the results-per-page selector an accessible name', async () => {
+    render(<AdvancedTable columns={columns} data={buildRows(3)} />);
+
+    await screen.findByRole('table');
+    expect(
+      screen.getByRole('combobox', { name: 'Résultats par page' })
+    ).toBeInTheDocument();
+  });
+
+  it('omits aria-selected on rows when selection is disabled', async () => {
+    render(<AdvancedTable columns={columns} data={buildRows(2)} />);
+
+    const table = await screen.findByRole('table');
+    const bodyRows = within(table).getAllByRole('row').slice(1);
+    bodyRows.forEach((row) => {
+      expect(row).not.toHaveAttribute('aria-selected');
+    });
+  });
+
+  it('sets aria-selected on rows when selection is enabled', async () => {
+    render(
+      <AdvancedTable
+        columns={columns}
+        data={buildRows(2)}
+        selection={{ all: false, ids: [] }}
+        onSelectionChange={vi.fn()}
+      />
+    );
+
+    const table = await screen.findByRole('table');
+    const bodyRows = within(table).getAllByRole('row').slice(1);
+    bodyRows.forEach((row) => {
+      expect(row).toHaveAttribute('aria-selected');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `aria-label="Résultats par page"` to the results-per-page `<select>` in `AdvancedTable`, which previously had no accessible name (RGAA 11.1 — screen readers announced an unlabelled combobox).
- Only emits `aria-selected` on table rows when row selection is actually enabled (RGAA 4.1 — rows in non-selectable tables were announced as "not selected", implying an interaction that doesn't exist).

Both defects are app-wide, affecting every consumer of `AdvancedTable` (`CampaignTable`, `GeoPerimetersTable`, and future consumers). They were surfaced during review of #1918 but predate it and are unrelated to that PR's scope, so they're fixed here independently off `main`.

## Test plan
- [x] New `AdvancedTable.test.tsx` (TDD: written first, confirmed failing pre-fix) covers both fixes plus the existing selected-row behavior.
- [x] `yarn nx test frontend -- AdvancedTable.test.tsx` — 3/3 passing.
- [x] Regression: `yarn nx test frontend -- CampaignListView.test.tsx CampaignView.test.tsx AnalysisCard.test.tsx` — 45/45 passing (covers `CampaignTable` and indirectly `AdvancedTable`'s sort/selection behavior).
- [x] `yarn nx typecheck frontend` — clean.
- [x] `yarn lint` (oxlint) — no new warnings/errors.
- [x] `yarn format` (oxfmt) — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)