### PR TITLE
fix(frontend): restore building square markers on the housing map

### DIFF
--- a/frontend/src/hooks/test/useMapImage.test.tsx
+++ b/frontend/src/hooks/test/useMapImage.test.tsx
@@ -1,0 +1,48 @@
+import { act, renderHook } from '@testing-library/react';
+import type { MapRef } from 'react-map-gl/maplibre';
+import { vi } from 'vitest';
+
+import { type MapImage, useMapImages } from '../useMapImage';
+
+describe('useMapImages', () => {
+  it('registers an image while map sources are still loading', async () => {
+    const image = {
+      id: 'square-fill-0',
+      path: '/map/square-fill-0.png'
+    } satisfies MapImage;
+    const imageData = {
+      width: 17,
+      height: 17,
+      data: new Uint8ClampedArray(17 * 17 * 4)
+    };
+    let resolveImage!: (response: { data: typeof imageData }) => void;
+    const loadImage = vi.fn(
+      () =>
+        new Promise<{ data: typeof imageData }>((resolve) => {
+          resolveImage = resolve;
+        })
+    );
+    const registeredImages = new Set<string>();
+    const map = {
+      addImage: vi.fn((id: string) => {
+        registeredImages.add(id);
+      }),
+      hasImage: vi.fn((id: string) => registeredImages.has(id)),
+      isStyleLoaded: vi.fn().mockReturnValueOnce(true).mockReturnValue(false),
+      loadImage,
+      off: vi.fn(),
+      on: vi.fn()
+    } as unknown as MapRef;
+
+    renderHook(() => useMapImages(map, [image]));
+
+    expect(loadImage).toHaveBeenCalledWith(image.path);
+
+    await act(async () => {
+      resolveImage({ data: imageData });
+      await Promise.resolve();
+    });
+
+    expect(registeredImages.has(image.id)).toBe(true);
+  });
+});

--- a/frontend/src/hooks/useMapImage.tsx
+++ b/frontend/src/hooks/useMapImage.tsx
@@ -19,24 +19,20 @@ export function useMapImages(
     let cancelled = false;
 
     async function registerImage(image: MapImage) {
-      if (!isStyleLoaded(mapRef) || hasImage(mapRef, image.id) !== false) {
+      if (hasImage(mapRef, image.id) !== false) {
         return;
       }
 
       try {
         const response = await mapRef.loadImage(image.path);
 
-        if (
-          !cancelled &&
-          isStyleLoaded(mapRef) &&
-          hasImage(mapRef, image.id) === false
-        ) {
+        if (!cancelled && hasImage(mapRef, image.id) === false) {
           mapRef.addImage(image.id, response.data, {
             sdf: false
           });
         }
       } catch (error) {
-        if (!cancelled && isStyleLoaded(mapRef)) {
+        if (!cancelled && hasImage(mapRef, image.id) !== undefined) {
           console.error(error);
         }
       }
@@ -58,14 +54,6 @@ export function useMapImages(
       mapRef.off('style.load', onStyleLoad);
     };
   }, [map, images]);
-}
-
-function isStyleLoaded(map: MapRef): boolean {
-  try {
-    return Boolean(map.isStyleLoaded());
-  } catch {
-    return false;
-  }
 }
 
 function hasImage(map: MapRef, id: string): boolean | undefined {


### PR DESCRIPTION
## Summary

- register MapLibre building marker images while map sources are still loading
- keep safe handling for a map style that has been destroyed
- add a regression test for square marker registration

## Root cause

The image hook required `isStyleLoaded()` before and after the asynchronous image load. MapLibre can report `false` while sources are loading even though runtime images can be registered, causing `square-fill-*` images to be skipped without another retry.

## Validation

- frontend regression test
- full frontend suite: 400 passed, 1 skipped
- frontend typecheck, lint, formatting and Node 24 build
- local verification with two housings at the same Paris address
