### PR TITLE
fix(frontend): make Tooltip trigger keyboard-operable (RGAA 7.3)

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -5,6 +5,8 @@ fileignoreconfig:
 - filename: server/src/infra/database/db.d.ts
   ignore_detectors:
     - filecontent
+- filename: frontend/src/components/ui/Tooltip/test/Tooltip.test.tsx
+  checksum: b58f25cc1f0f02598ad33b9832b20a14cfbf9dedbd17e6a85bca0a120b9eb6c1
 - filename: .github/workflows/release.yml
   checksum: 5b3a281c32a6fab83c8385a64a45faddcac10f226b8daa85bdbf6a29d6b062a8
 - filename: README.md

--- a/frontend/src/components/ui/Tooltip/Tooltip.tsx
+++ b/frontend/src/components/ui/Tooltip/Tooltip.tsx
@@ -1,10 +1,7 @@
-import { fr } from '@codegouvfr/react-dsfr';
 import DSFRTooltip, {
   type TooltipProps as DSFRTooltipProps
 } from '@codegouvfr/react-dsfr/Tooltip';
 import { memo, useEffect, useId, useRef } from 'react';
-
-import Icon from '~/components/ui/Icon';
 
 /**
  * If defined, the tooltip will be positioned manually according to the `align` and `place` props.
@@ -20,9 +17,7 @@ type ManualPlacement = {
   place?: 'top' | 'right' | 'bottom' | 'left';
 };
 
-export type TooltipProps = DSFRTooltipProps.Common &
-  DSFRTooltipProps.WithHoverAction &
-  ManualPlacement;
+export type TooltipProps = DSFRTooltipProps.Common & ManualPlacement;
 
 function Tooltip(props: TooltipProps) {
   const ref = useRef<HTMLSpanElement>(null);
@@ -56,16 +51,10 @@ function Tooltip(props: TooltipProps) {
     };
   }, [props.align, props.place]);
 
-  return (
-    <DSFRTooltip {...props} ref={ref} id={id}>
-      <Icon
-        className="fr-px-1w fr-py-1v"
-        name="fr-icon-question-line"
-        size="sm"
-        color={fr.colors.decisions.artwork.major.blueFrance.default}
-      />
-    </DSFRTooltip>
-  );
+  // "click" renders a native, focusable <button> trigger — the DSFR-recommended
+  // pattern for an icon-only trigger with no natural interactive host. A
+  // hover-only trigger here would never be reachable by keyboard (RGAA 7.3).
+  return <DSFRTooltip {...props} kind="click" ref={ref} id={id} />;
 }
 
 export default memo(Tooltip);

--- a/frontend/src/components/ui/Tooltip/test/Tooltip.test.tsx
+++ b/frontend/src/components/ui/Tooltip/test/Tooltip.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import Tooltip from '../Tooltip';
+
+describe('Tooltip', () => {
+  it('renders a focusable button as the trigger, described by the tooltip content', () => {
+    render(<Tooltip title="Informations utiles" />);
+
+    const trigger = screen.getByRole('button', {
+      name: /information contextuelle/i
+    });
+    const tooltip = screen.getByRole('tooltip');
+
+    expect(trigger).toHaveAttribute('aria-describedby', tooltip.id);
+    expect(tooltip).toHaveTextContent('Informations utiles');
+  });
+
+  it('is reachable by keyboard (Tab), unlike a hover-only trigger', async () => {
+    const user = userEvent.setup();
+    render(
+      <>
+        <button type="button">Avant</button>
+        <Tooltip title="Informations utiles" />
+      </>
+    );
+
+    await user.tab();
+    expect(screen.getByRole('button', { name: 'Avant' })).toHaveFocus();
+
+    await user.tab();
+    expect(
+      screen.getByRole('button', { name: /information contextuelle/i })
+    ).toHaveFocus();
+  });
+});


### PR DESCRIPTION
## Summary
- The shared `Tooltip` wrapper always rendered its trigger as a non-focusable `<span>`, so keyboard users could never Tab to it and reveal the tooltip — only mouse hover worked. This was a **blocking RGAA 7.3** violation ("chaque script est contrôlable par le clavier") flagged on Accueil / Parc de logements.
- Switch the wrapper to DSFR's click-triggered variant (`kind="click"`), which renders a native `<button class="fr-btn--tooltip fr-btn">`: focusable via Tab, activatable via click/Enter/Space, closes on Escape/click-outside — all already handled by the DSFR core script, no custom JS needed. This is the pattern the DSFR itself recommends (see [démonstration](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/infobulle/demonstration-de-l-infobulle) / [accessibilité](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/infobulle/accessibilite-de-l-infobulle)) for an icon-only trigger with no natural interactive host.
- Single-file fix in `frontend/src/components/ui/Tooltip/Tooltip.tsx` — all 6 usages across the app (Parc de logements ×2, fiche logement, statistiques de campagne ×2) share this one component and none pass custom `children`, so no call site needed changes.
- Known, intentional UX change: mouse users now click the "?" icon instead of hovering it (DSFR disables hover for the button-trigger variant by design, for reliability with screen readers/voice control).

## Test plan
- [x] New test `frontend/src/components/ui/Tooltip/test/Tooltip.test.tsx` (TDD): asserts the trigger is a real `<button>` linked via `aria-describedby`, and a keyboard regression test (`userEvent.tab()`) that failed before the fix and passes after.
- [x] `yarn nx test frontend` — new tests pass, no regressions in views/components consuming `Tooltip` (57 tests).
- [x] `yarn nx typecheck frontend` — passes (the wrapper's exported `TooltipProps` type narrowed to drop the now-unused hover/children variant).
- [ ] Manual check in browser: Tab to the "?" icon on Parc de logements (search bar + filters panel) → tooltip shows on focus, closes on Escape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)