### PR TITLE
fix(frontend): avoid loading Livestorm outside onboarding

### DIFF
--- a/frontend/src/components/modals/OnboardingModal/OnboardingModal.tsx
+++ b/frontend/src/components/modals/OnboardingModal/OnboardingModal.tsx
@@ -32,30 +32,32 @@ function OnboardingModal() {
 
   return (
     <modal.Component size="large" title="Bienvenue sur Zéro Logement Vacant !">
-      <Grid container rowSpacing={3}>
-        <Grid component="section" sx={{ display: 'inline-flex' }} size={12}>
-          <img src={image} alt="Communauté" aria-hidden="true" />
-          <Typography sx={{ ml: 1 }} variant="subtitle2">
-            Pour prendre en main rapidement ZLV, inscrivez-vous à une session de
-            prise en main (1h) afin de découvrir les principales fonctionnalités
-            de la plateforme. Cette inscription est optionnelle, mais
-            recommandée.
-          </Typography>
-        </Grid>
+      {onboarding ? (
+        <Grid container rowSpacing={3}>
+          <Grid component="section" sx={{ display: 'inline-flex' }} size={12}>
+            <img src={image} alt="Communauté" aria-hidden="true" />
+            <Typography sx={{ ml: 1 }} variant="subtitle2">
+              Pour prendre en main rapidement ZLV, inscrivez-vous à une session
+              de prise en main (1h) afin de découvrir les principales
+              fonctionnalités de la plateforme. Cette inscription est
+              optionnelle, mais recommandée.
+            </Typography>
+          </Grid>
 
-        <Grid
-          component="section"
-          sx={{ display: 'flex', justifyContent: 'center' }}
-          size={12}
-        >
-          <iframe
-            width="75%"
-            height="600"
-            title="Inscription session de prise en main Zéro Logement Vacant"
-            src="https://app.livestorm.co/p/1b26afab-3332-4b6d-a9e4-3f38b4cc6c43/form"
-          />
+          <Grid
+            component="section"
+            sx={{ display: 'flex', justifyContent: 'center' }}
+            size={12}
+          >
+            <iframe
+              width="75%"
+              height="600"
+              title="Inscription session de prise en main Zéro Logement Vacant"
+              src="https://app.livestorm.co/p/1b26afab-3332-4b6d-a9e4-3f38b4cc6c43/form"
+            />
+          </Grid>
         </Grid>
-      </Grid>
+      ) : null}
     </modal.Component>
   );
 }

--- a/frontend/src/components/modals/OnboardingModal/test/OnboardingModal.test.tsx
+++ b/frontend/src/components/modals/OnboardingModal/test/OnboardingModal.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from '@testing-library/react';
+import { createMemoryRouter, RouterProvider } from 'react-router';
+
+import OnboardingModal from '../OnboardingModal';
+
+describe('OnboardingModal', () => {
+  function setup(onboarding = false) {
+    const router = createMemoryRouter(
+      [
+        {
+          path: '/parc-de-logements',
+          element: <OnboardingModal />
+        }
+      ],
+      {
+        initialEntries: [
+          {
+            pathname: '/parc-de-logements',
+            state: { onboarding }
+          }
+        ]
+      }
+    );
+
+    render(<RouterProvider router={router} />);
+  }
+
+  it('should not load the registration form outside onboarding', () => {
+    setup();
+
+    expect(
+      screen.queryByTitle(
+        'Inscription session de prise en main Zéro Logement Vacant'
+      )
+    ).not.toBeInTheDocument();
+  });
+
+  it('should load the registration form during onboarding', () => {
+    setup(true);
+
+    expect(
+      screen.getByTitle(
+        'Inscription session de prise en main Zéro Logement Vacant'
+      )
+    ).toHaveAttribute(
+      'src',
+      'https://app.livestorm.co/p/1b26afab-3332-4b6d-a9e4-3f38b4cc6c43/form'
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Render the Livestorm registration form only when the onboarding flow is active.
- Keep the existing onboarding experience unchanged for newly created accounts.
- Add regression coverage for regular authenticated visits and onboarding visits.

## Problem

`AuthenticatedLayout` mounts `OnboardingModal` on every authenticated page. The modal was closed for returning users, but its Livestorm iframe was still rendered unconditionally.

Livestorm enables CAPTCHA on this embedded registration form, so every regular login loaded the Livestorm widget and its reCAPTCHA chain (`recaptcha.net`, `gstatic.com`, anchor and challenge frames). These unrelated third-party requests consume network and CPU while the authenticated application is loading.

The behavior dates back to the introduction of the authenticated onboarding modal in `42376fb06e`; it is not caused by the recent Better Auth migration.

## Root cause

The `onboarding` condition controlled `modal.open()`, but did not control whether the iframe content was mounted.

## Impact

Returning users no longer load Livestorm or reCAPTCHA after signing in. The registration form remains available during the intended account onboarding flow.

## Validation

- `yarn nx test frontend -- OnboardingModal.test.tsx`
- `yarn nx test frontend -- AccountPasswordCreationView.test.tsx`
- `yarn nx typecheck frontend`
- Targeted Oxlint and Oxfmt checks
- `yarn nx build frontend`
- `git diff --check`
