### PR TITLE
fix(frontend): associate form validation errors with fields for RGAA 11.10

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -235,6 +235,10 @@ fileignoreconfig:
   checksum: 45db32afbf267b94ffb071c725691dad57b28c8bb12554e0b8397a5bf0a9d141
 - filename: docs/superpowers/plans/2026-07-20-campaign-documents.md
   checksum: 1e3050356fc1503522f81a38384a26cf11310d81881707ccc34df0279ca6b90f
+- filename: frontend/src/views/Account/test/ResetPasswordView.test.tsx
+  checksum: b12f479967fe4f69f83a4312427bb1a39a18d04d8a556dccadb5bae1f7d1570b
+- filename: frontend/src/views/Login/LoginView.test.tsx
+  checksum: 34a869dcb5164bf14fce4abb0352711ed164c5309cb19bdb161a4e3dda63d786
 scopeconfig:
 - scope: node
 allowed_patterns:

--- a/frontend/src/components/SearchableSelectNext/SearchableSelectNext.tsx
+++ b/frontend/src/components/SearchableSelectNext/SearchableSelectNext.tsx
@@ -261,7 +261,8 @@ function SearchableSelectNext<
             // Non-customizable props
             placeholder: placeholder,
             disabled: disabled,
-            type: 'search'
+            type: 'search',
+            'aria-invalid': props.error ? 'true' : undefined
           }}
           ref={params.InputProps.ref}
           state={props.error ? 'error' : 'default'}

--- a/frontend/src/components/_app/AppTextInput/AppTextInput.tsx
+++ b/frontend/src/components/_app/AppTextInput/AppTextInput.tsx
@@ -39,6 +39,9 @@ function AppTextInput<T extends ObjectShape>(props: AppTextInputProps<T>) {
     ...textInputProps
   } = props;
 
+  const resolvedState = state ?? inputForm.messageType(String(inputKey));
+  const isInvalid = resolvedState === 'error';
+
   return (
     <>
       {textArea ? (
@@ -50,9 +53,10 @@ function AppTextInput<T extends ObjectShape>(props: AppTextInputProps<T>) {
           nativeTextAreaProps={{
             ...textInputProps,
             placeholder,
-            onBlur: () => inputForm.validateAt(String(inputKey))
+            onBlur: () => inputForm.validateAt(String(inputKey)),
+            'aria-invalid': isInvalid ? 'true' : undefined
           }}
-          state={state ?? inputForm.messageType(String(inputKey))}
+          state={resolvedState}
           stateRelatedMessage={
             stateRelatedMessage ??
             inputForm.message(String(inputKey), whenValid)
@@ -65,9 +69,10 @@ function AppTextInput<T extends ObjectShape>(props: AppTextInputProps<T>) {
           nativeInputProps={{
             ...textInputProps,
             placeholder,
-            onBlur: () => inputForm.validateAt(String(inputKey))
+            onBlur: () => inputForm.validateAt(String(inputKey)),
+            'aria-invalid': isInvalid ? 'true' : undefined
           }}
-          state={state ?? inputForm.messageType(String(inputKey))}
+          state={resolvedState}
           stateRelatedMessage={
             stateRelatedMessage ??
             inputForm.message(String(inputKey), whenValid)

--- a/frontend/src/components/_app/AppTextInput/AppTextInputNext.tsx
+++ b/frontend/src/components/_app/AppTextInput/AppTextInputNext.tsx
@@ -124,7 +124,8 @@ function AppTextInputNext<
       ref: field.ref,
       value: value,
       onBlur: field.onBlur,
-      onChange: onChange
+      onChange: onChange,
+      'aria-invalid': fieldState.invalid ? 'true' : undefined
     }
   };
   const textAreaProps: Pick<
@@ -142,7 +143,8 @@ function AppTextInputNext<
       ref: field.ref,
       value: value,
       onBlur: field.onBlur,
-      onChange: onChange
+      onChange: onChange,
+      'aria-invalid': fieldState.invalid ? 'true' : undefined
     }
   };
 

--- a/frontend/src/components/establishment/EstablishmentSearchableSelect.tsx
+++ b/frontend/src/components/establishment/EstablishmentSearchableSelect.tsx
@@ -15,6 +15,8 @@ type Props<Multiple extends boolean, DisableClearable extends boolean> = Pick<
 > & {
   className?: string;
   label?: ReactNode;
+  /** An error message. */
+  error?: string;
   /** Pre-defined options to use instead of API search. When provided, no API call is made. */
   options?: ReadonlyArray<Establishment>;
   value: AutocompleteValue<Establishment, Multiple, DisableClearable, false>;
@@ -60,6 +62,7 @@ function EstablishmentSearchableSelect<
       options={options}
       loading={hasPreDefinedOptions ? false : isFetching}
       label={props.label ?? null}
+      error={props.error}
       getOptionKey={(option) => option.id}
       getOptionLabel={(option) => option.name}
       isOptionEqualToValue={(option, value) => option.id === value.id}

--- a/frontend/src/views/Account/test/ResetPasswordView.test.tsx
+++ b/frontend/src/views/Account/test/ResetPasswordView.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { Provider } from 'react-redux';
+import { createMemoryRouter, RouterProvider } from 'react-router';
+
+import { mockAPI } from '~/mocks/mock-api';
+import config from '~/utils/config';
+
+import configureTestStore from '../../../utils/storeUtils';
+import ResetPasswordView from '../ResetPasswordView';
+
+describe('ResetPasswordView', () => {
+  const user = userEvent.setup();
+  const linkId = 'a1b2c3d4-0000-4000-8000-000000000000';
+
+  function setup() {
+    mockAPI.use(
+      http.get(`${config.apiEndpoint}/reset-links/:id`, ({ params }) =>
+        HttpResponse.json({
+          id: params.id,
+          createdAt: new Date().toJSON(),
+          expiresAt: new Date(Date.now() + 60 * 60 * 1000).toJSON()
+        })
+      ),
+      http.post(`${config.apiEndpoint}/account/reset-password`, () =>
+        HttpResponse.json(null, { status: 200 })
+      )
+    );
+
+    const store = configureTestStore();
+    const router = createMemoryRouter(
+      [
+        {
+          path: '/mot-de-passe/nouveau',
+          element: <ResetPasswordView />
+        }
+      ],
+      {
+        initialEntries: [
+          { pathname: '/mot-de-passe/nouveau', hash: `#${linkId}` }
+        ]
+      }
+    );
+    render(
+      <Provider store={store}>
+        <RouterProvider router={router} />
+      </Provider>
+    );
+  }
+
+  it('should mark a mismatched password confirmation as invalid and associate the error to the field (RGAA 11.10)', async () => {
+    setup();
+
+    // Both fields must be non-empty to pass native HTML `required` validation
+    // (this legacy form has no `noValidate`) and reach the custom yup check.
+    const password = await screen.findByLabelText(/^Créer votre mot de passe/);
+    await user.type(password, 'Abcdefghij1');
+    const passwordConfirmation = screen.getByLabelText(
+      /^Confirmer votre mot de passe/
+    );
+    await user.type(passwordConfirmation, 'somethingElse1');
+
+    const submit = screen.getByRole('button', {
+      name: /Enregistrer le nouveau mot de passe/i
+    });
+    await user.click(submit);
+
+    await screen.findByText('Les mots de passe doivent être identiques.');
+
+    expect(passwordConfirmation).toHaveAttribute('aria-invalid', 'true');
+    expect(passwordConfirmation).toHaveAccessibleDescription(
+      'Les mots de passe doivent être identiques.'
+    );
+  });
+
+  it('should clear the invalid state once the passwords match', async () => {
+    setup();
+
+    const password = await screen.findByLabelText(/^Créer votre mot de passe/);
+    await user.type(password, 'Abcdefghij1');
+    const passwordConfirmation = screen.getByLabelText(
+      /^Confirmer votre mot de passe/
+    );
+    await user.type(passwordConfirmation, 'somethingElse1');
+
+    const submit = screen.getByRole('button', {
+      name: /Enregistrer le nouveau mot de passe/i
+    });
+    await user.click(submit);
+
+    await screen.findByText('Les mots de passe doivent être identiques.');
+    expect(passwordConfirmation).toHaveAttribute('aria-invalid', 'true');
+
+    await user.clear(passwordConfirmation);
+    await user.type(passwordConfirmation, 'Abcdefghij1');
+    await user.click(submit);
+
+    expect(passwordConfirmation).not.toHaveAttribute('aria-invalid');
+  });
+});

--- a/frontend/src/views/Login/LoginView.test.tsx
+++ b/frontend/src/views/Login/LoginView.test.tsx
@@ -14,11 +14,12 @@ import LoginView from './LoginView';
 describe('login view', () => {
   const user = userEvent.setup();
 
-  function setup(options?: { auth?: AuthContextValue }) {
+  function setup(options?: { auth?: AuthContextValue; initialEntry?: string }) {
     const store = configureTestStore();
     const router = createMemoryRouter(
       [
         { path: '/connexion', element: <LoginView /> },
+        { path: '/admin', element: <LoginView /> },
         {
           path: '/mot-de-passe/oublie',
           element: 'Mot de passe oublié'
@@ -26,9 +27,13 @@ describe('login view', () => {
         {
           path: '/parc-de-logements',
           element: 'Parc de logements'
+        },
+        {
+          path: '/verification-2fa',
+          element: 'Vérification en deux étapes'
         }
       ],
-      { initialEntries: ['/connexion'] }
+      { initialEntries: [options?.initialEntry ?? '/connexion'] }
     );
     const view = (
       <Provider store={store}>
@@ -129,5 +134,61 @@ describe('login view', () => {
 
     expect(signIn).toHaveBeenCalledTimes(1);
     expect(await screen.findByText(/Connexion en cours/)).toBeInTheDocument();
+  });
+
+  it('should mark required fields as invalid and associate the error to the field when submitted empty (RGAA 11.10)', async () => {
+    setup();
+
+    const logIn = screen.getByRole('button', { name: /^Se connecter/ });
+    await user.click(logIn);
+
+    const email = await screen.findByLabelText(/^Adresse e-mail/);
+    expect(email).toHaveAttribute('aria-invalid', 'true');
+    expect(email).toHaveAttribute('aria-required', 'true');
+    expect(email).toHaveAccessibleDescription(
+      'Veuillez renseigner votre adresse email.'
+    );
+
+    const password = screen.getByLabelText(/^Mot de passe/);
+    expect(password).toHaveAttribute('aria-invalid', 'true');
+    expect(password).toHaveAttribute('aria-required', 'true');
+    expect(password).toHaveAccessibleDescription(
+      'Veuillez renseigner un mot de passe.'
+    );
+  });
+
+  it('should clear the invalid state once a valid value is entered', async () => {
+    setup();
+
+    const logIn = screen.getByRole('button', { name: /^Se connecter/ });
+    await user.click(logIn);
+
+    const email = await screen.findByLabelText(/^Adresse e-mail/);
+    expect(email).toHaveAttribute('aria-invalid', 'true');
+
+    await user.type(email, 'test@test.test');
+    await user.click(logIn);
+
+    expect(email).not.toHaveAttribute('aria-invalid');
+  });
+
+  it('should associate the establishment error to the field when an admin submits without selecting one (RGAA 11.10)', async () => {
+    setup({ initialEntry: '/admin' });
+
+    const email = screen.getByLabelText(/^Adresse e-mail/);
+    await user.type(email, 'admin@zlv.fr');
+    const password = screen.getByLabelText(/^Mot de passe/);
+    await user.type(password, 'password');
+
+    const logIn = screen.getByRole('button', { name: /^Se connecter/ });
+    await user.click(logIn);
+
+    const establishment = await screen.findByLabelText(
+      /^Collectivité \(obligatoire\)/
+    );
+    expect(establishment).toHaveAccessibleDescription(
+      'Veuillez sélectionner un établissement.'
+    );
+    expect(establishment).toHaveAttribute('aria-invalid', 'true');
   });
 });

--- a/frontend/src/views/Login/LoginView.tsx
+++ b/frontend/src/views/Login/LoginView.tsx
@@ -160,7 +160,8 @@ const LoginView = () => {
                 hintText="Format attendu : prenom.nom@domaine.fr"
                 nativeInputProps={{
                   type: 'email',
-                  autoComplete: 'email'
+                  autoComplete: 'email',
+                  'aria-required': 'true'
                 }}
               />
               <AppTextInputNext
@@ -169,18 +170,22 @@ const LoginView = () => {
                 className={isAdminView ? '' : 'fr-mb-1w'}
                 nativeInputProps={{
                   type: 'password',
-                  autoComplete: 'current-password'
+                  autoComplete: 'current-password',
+                  'aria-required': 'true'
                 }}
               />
               {isAdminView && (
                 <EstablishmentSearchableSelect
                   className={fr.cx('fr-mb-2w')}
-                  label="Collectivité"
+                  label="Collectivité (obligatoire)"
                   value={establishment}
+                  error={form.formState.errors.establishmentId?.message}
                   onChange={(establishment) => {
                     if (establishment) {
                       setEstablishment(establishment);
-                      form.setValue('establishmentId', establishment.id);
+                      form.setValue('establishmentId', establishment.id, {
+                        shouldValidate: true
+                      });
                     }
                   }}
                 />


### PR DESCRIPTION
## Summary

Fixes RGAA criterion 11.10 (form input validation must be conveyed appropriately to assistive technologies) on the login page, and applies the same fix everywhere else the affected shared components are used.

- `aria-invalid` was never set anywhere in the app (confirmed via a full-repo grep) — DSFR's `Input` component wires `aria-describedby` automatically when `state="error"`, but never sets `aria-invalid` itself, and nothing in this codebase supplied it. Added it to the three shared input wrappers that render every text/searchable-select field in the app:
  - `AppTextInputNext.tsx` (react-hook-form-based, ~25 call sites)
  - `AppTextInput.tsx` (legacy, still used by `ResetPasswordView.tsx`)
  - `SearchableSelectNext.tsx` (used by `EstablishmentSearchableSelect` and 4 other searchable selects)
- Added `aria-required="true"` to the login form's email/password fields, matching the existing convention in `AccountForm.tsx`.
- Found and fixed a second bug while in there: the admin login's establishment picker had a `form.setError('establishmentId', ...)` call that was **never rendered anywhere** — `EstablishmentSearchableSelect` didn't accept or forward an `error` prop at all, so that validation error was completely invisible, visually and to assistive tech. Wired it through and added the missing "(obligatoire)" label indication.

## Verified

- New tests (TDD) for both fixes, covering `aria-invalid`, `aria-required`, and `aria-describedby`/accessible-description association: `LoginView.test.tsx`, `Account/test/ResetPasswordView.test.tsx`.
- Full frontend suite: 48 test files / 407 tests passing, no regressions from touching the shared components.
- Typecheck clean.
- Manually verified in a real browser (DOM inspection) that `aria-invalid="true"`, `aria-required="true"` and `aria-describedby` correctly point to the visible error text, for both the login form and the admin establishment picker.

## Test plan

- [x] `yarn nx test frontend` — 407/407 passing
- [x] `yarn nx typecheck frontend` — clean
- [x] Manual check in browser: submit `/connexion` empty → email/password show `aria-invalid`/`aria-required`/`aria-describedby` correctly
- [x] Manual check in browser: submit `/admin` without selecting an établissement → error is now visible and associated to the field

🤖 Generated with [Claude Code](https://claude.com/claude-code)