### PR TITLE
fix(frontend): add landmark roles for RGAA 12.6 (Connexion, Parc de logements, Mon compte)

### DIFF
--- a/frontend/src/components/Header/SmallHeader.tsx
+++ b/frontend/src/components/Header/SmallHeader.tsx
@@ -132,6 +132,7 @@ function SmallHeader() {
         className="fr-header"
         component="header"
         id="fr-header"
+        role="banner"
         square
         sx={(theme) => ({
           position: 'sticky',

--- a/frontend/src/views/Account/AccountSideMenu.tsx
+++ b/frontend/src/views/Account/AccountSideMenu.tsx
@@ -70,7 +70,13 @@ function AccountSideMenu() {
   ];
 
   return (
-    <SideMenu burgerMenuButtonText="Menu" items={menuItems} fullHeight sticky />
+    <SideMenu
+      title="Menu du profil"
+      burgerMenuButtonText="Menu"
+      items={menuItems}
+      fullHeight
+      sticky
+    />
   );
 }
 


### PR DESCRIPTION
## Summary

Fixes the RGAA 12.6 non-conformity reported on the Connexion, Parc de logements, and Mon compte pages (landmark zones must be reachable/avoidable).

- `frontend/src/components/Header/SmallHeader.tsx`: added explicit `role="banner"` on the custom MUI `Paper`-as-`<header>` used by all authenticated pages (Parc de logements, Mon compte). Static analysis tools can't resolve `Paper component="header"` to a real `<header>` tag, so this makes the landmark discoverable to tools/auditors that check literal attributes, in addition to the implicit native semantics already present at runtime.
- `frontend/src/views/Account/AccountSideMenu.tsx`: the left-column profile menu (`<SideMenu>` from `@codegouvfr/react-dsfr`) rendered a `<nav>` with **no accessible name at all** — it coexists with two other navs on the "Mon compte" page (main site nav, account dropdown nav) with no way to distinguish it. Added `title="Menu du profil"`, which is the component's supported mechanism for setting `aria-labelledby` on the nav (visible label, matches the audit's own suggested wording).

### What I deliberately did *not* add, and why

The audit also flagged explicit `role="main"` (on `<main>`) and `role="navigation"` (on the account-dropdown `<nav>`) as missing on all three pages. I investigated and did not add them:

- The official RGAA 12.6.1 test only requires that each zone **"possède un rôle WAI-ARIA de type landmark correspondant à sa nature"** — native `<main>`/`<nav>` elements already carry this role implicitly per the HTML-AAM spec, recognized by all screen readers (NVDA/JAWS/VoiceOver). Both `<main id="fr-content">` wrappers and the account nav (`<nav aria-label="Navigation du compte utilisateur">`) already exist on all three pages.
- This repo's own lint rule (`jsx-a11y/no-redundant-roles`, error-level in `oxlint`) actively strips an explicit `role="main"`/`role="navigation"` from native elements as redundant — confirmed by testing; it silently reverted these two additions during the pre-commit hook on the first attempt at this fix.
- There's direct precedent in this codebase: `096f2ffa9` (RGAA 9.2 fix, same author) added the exact same account-dropdown `<nav aria-label="...">` **without** an explicit `role`, establishing native semantics as the accepted pattern here.

Net effect: the underlying accessibility gap (landmarks reachable via AT) was almost entirely already closed by existing native HTML; the one real, confirmed gap was the unlabeled profile-menu nav on "Mon compte", now fixed.

## Test plan

- [x] `tsc --build` clean (fresh `yarn install` was needed first — worktree `node_modules` was stale)
- [ ] Manually verify with a screen reader (NVDA/VoiceOver) that all landmark zones (banner, main, nav) are announced and navigable on Connexion, Parc de logements, and Mon compte
- [ ] Visually confirm the new "Menu du profil" label above the profile side menu on `/compte` looks correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)