### PR TITLE
fix(frontend): remove duplicate <main> landmark on Resources page

### DIFF
--- a/frontend/src/views/Resources/ResourcesView.tsx
+++ b/frontend/src/views/Resources/ResourcesView.tsx
@@ -58,7 +58,7 @@ function ResourcesView() {
   useDocumentTitle('Ressources');
 
   return (
-    <Container component="main" maxWidth="xl" sx={{ py: '2rem' }}>
+    <Container maxWidth="xl" sx={{ py: '2rem' }}>
       <Typography component="h1" variant="h3" sx={{ mb: '1.5rem' }}>
         Ressources
       </Typography>


### PR DESCRIPTION
## Summary
- RGAA 9.2 (structure du document cohérente) requires that a page have only one visible `<main>` landmark.
- The Ressources page (`/ressources`) rendered two: the one from `AuthenticatedLayout` (`<main id="fr-content">`) and a second one from `ResourcesView`'s `Container component="main"`.
- Removed the redundant `component="main"` prop from `ResourcesView`'s `Container`, aligning it with other views under the same layout (e.g. `SiteMapView`, `CampaignListView`) which use a plain `Container`.

## Test plan
- [x] `yarn nx typecheck frontend` passes
- [x] Confirmed only one `<main>` remains in `ResourcesView.tsx` (`grep` check)
- [ ] Manual visual check in browser on `/ressources` (not run in this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)