### PR TITLE
fix(analytics): keep LOVAC FIL cutoff at 2025

### DIFF
--- a/analytics/dbt/.dbt-test-coverage-allowlist.txt
+++ b/analytics/dbt/.dbt-test-coverage-allowlist.txt
@@ -94,7 +94,6 @@ marts_admin_departements
 marts_admin_epci
 marts_admin_regions
 marts_common_cities
-marts_common_morphology
 marts_production_events
 marts_production_housing_out
 marts_production_join_campaigns_housing

--- a/analytics/dbt/models/marts/common/marts_common_morphology.sql
+++ b/analytics/dbt/models/marts/common/marts_common_morphology.sql
@@ -281,7 +281,7 @@ SELECT
     , lovac.count_vacant_housing_private
     , lovac.count_vacant_housing_private_fil
     , lovac.count_vacant_housing_private_fil_ccthp
-    , CASE WHEN year > 2025 THEN lovac.count_vacant_housing_private_fil ELSE count_vacant_housing_private_fil_ccthp END AS count_vacant_housing_private_fil_public
+    , CASE WHEN year >= 2025 THEN lovac.count_vacant_housing_private_fil ELSE count_vacant_housing_private_fil_ccthp END AS count_vacant_housing_private_fil_public
     , lovac.sum_living_area_vacant_housing_private_fil_ccthp
     , lovac.sum_plot_area_vacant_housing_private_fil_ccthp
     , ff.count_housing

--- a/analytics/dbt/tests/data_quality/test_marts_common_morphology_public_fil_cutover.sql
+++ b/analytics/dbt/tests/data_quality/test_marts_common_morphology_public_fil_cutover.sql
@@ -1,0 +1,26 @@
+-- Regression: LOVAC 2025 introduced the FIL definition without the legacy
+-- CCTHP restriction. This cutoff must not move when a new vintage is added.
+
+{{ config(severity='error', error_if='>0') }}
+
+WITH expected AS (
+    SELECT
+        year,
+        geo_code,
+        count_vacant_housing_private_fil_public AS actual_count,
+        CASE
+            WHEN year >= 2025 THEN count_vacant_housing_private_fil
+            ELSE count_vacant_housing_private_fil_ccthp
+        END AS expected_count
+    FROM {{ ref('marts_common_morphology') }}
+    WHERE year IN (2024, 2025, 2026)
+)
+
+SELECT
+    year,
+    geo_code,
+    actual_count,
+    expected_count,
+    'Public LOVAC count uses the wrong yearly definition' AS issue
+FROM expected
+WHERE actual_count IS DISTINCT FROM expected_count


### PR DESCRIPTION
LOVAC 2025 introduced the public FIL count without the legacy CCTHP restriction. Moving the cutoff while adding LOVAC 2026 made the 2025 analysis fall back to FIL+CCTHP and diverge from the housing list.

Keep the cutoff fixed at 2025 and add a dbt regression test covering the 2024, 2025, and 2026 definitions.