### PR TITLE
refactor(cerema): remove legacy Portail DF authentication

### DIFF
--- a/.github/workflows/python-scripts.yml
+++ b/.github/workflows/python-scripts.yml
@@ -43,6 +43,14 @@ jobs:
           python -m pip install --upgrade pip
           pip install pytest pytest-cov
 
+      - name: Test Portail DF JWT authentication
+        run: |
+          pip install -r server/src/scripts/perimeters-portaildf/requirements.txt tqdm
+          pytest \
+            server/src/scripts/perimeters-portaildf/test_fetch_groups_perimeters.py \
+            server/src/scripts/sync-user-kind/test_sync_user_kind.py \
+            -v --tb=short
+
       - name: Test owner-housing-distances
         run: |
           cd server/src/scripts/owner-housing-distances

--- a/.github/workflows/python-scripts.yml
+++ b/.github/workflows/python-scripts.yml
@@ -45,7 +45,12 @@ jobs:
 
       - name: Test Portail DF JWT authentication
         run: |
-          pip install -r server/src/scripts/perimeters-portaildf/requirements.txt tqdm
+          python -m pip install --only-binary :all: \
+            "click==8.1.8" \
+            "psycopg2-binary==2.9.12" \
+            "python-dateutil==2.9.0.post0" \
+            "requests==2.32.5" \
+            "tqdm==4.70.0"
           pytest \
             server/src/scripts/perimeters-portaildf/test_fetch_groups_perimeters.py \
             server/src/scripts/sync-user-kind/test_sync_user_kind.py \

--- a/clevercloud/README.md
+++ b/clevercloud/README.md
@@ -54,21 +54,24 @@ The following environment variables must be configured on Clever Cloud:
 
 #### For Cerema API
 
+- `CEREMA_API`: Cerema DataFoncier API URL (`https://datafoncier.cerema.fr`)
 - `CEREMA_USERNAME`: Username for Cerema DF Portal API
 - `CEREMA_PASSWORD`: Password for Cerema DF Portal API
 
-> **Note**: The script automatically authenticates on each execution by calling `https://portaildf.cerema.fr/api/api-token-auth/` with these credentials as form-data. The JSON response contains the temporary token:
+> **Note**: Authentication uses the JWT endpoint `${CEREMA_API}/api/token/`
+> with a JSON payload. The response contains an access token and a refresh token:
 >
 > ```bash
-> # Request: POST https://portaildf.cerema.fr/api/api-token-auth/
-> # Form data: username=xxx&password=xxx
+> # Request: POST ${CEREMA_API}/api/token/
+> # JSON: {"username":"xxx","password":"xxx"}
 > # Response:
 > {
->   "token": "222a9ac058496742ff2922533d90847621314629"
+>   "access": "eyJ...",
+>   "refresh": "eyJ..."
 > }
 > ```
 >
-> This token is then used as `CEREMA_BEARER_TOKEN` for all API calls in the session.
+> The access token is then sent as `Authorization: Bearer <access>` for API calls.
 
 #### For Database (Clever Cloud naming convention)
 

--- a/clevercloud/README.md
+++ b/clevercloud/README.md
@@ -54,7 +54,7 @@ The following environment variables must be configured on Clever Cloud:
 
 #### For Cerema API
 
-- `CEREMA_API`: Cerema DataFoncier API URL (`https://datafoncier.cerema.fr`)
+- `CEREMA_API`: Cerema Portail DF API URL (`https://portaildf.cerema.fr`)
 - `CEREMA_USERNAME`: Username for Cerema DF Portal API
 - `CEREMA_PASSWORD`: Password for Cerema DF Portal API
 

--- a/clevercloud/SETUP_CHECKLIST.md
+++ b/clevercloud/SETUP_CHECKLIST.md
@@ -11,14 +11,9 @@ Configure in Clever Cloud dashboard → "Environment variables" tab:
 CC_PYTHON_VERSION=3.11
 
 # Cerema API Authentication
+CEREMA_API=https://datafoncier.cerema.fr
 CEREMA_USERNAME=your_cerema_username
 CEREMA_PASSWORD=your_cerema_password
-# Auth version: v1 (legacy Portail DF) or v2 (new DataFoncier API)
-CEREMA_AUTH_VERSION=v1
-# V1 API URL (default)
-CEREMA_API=https://portaildf.cerema.fr
-# V2 API URL (only used when CEREMA_AUTH_VERSION=v2)
-CEREMA_API_V2=https://datafoncier.cerema.fr
 
 # Database (automatically set by Clever Cloud PostgreSQL addon)
 POSTGRESQL_ADDON_HOST=your_postgresql_host
@@ -135,18 +130,11 @@ application logs, not cron logs.
 
 ### Cerema Authentication Fails
 
-1. Check `CEREMA_USERNAME` and `CEREMA_PASSWORD`
-2. Check `CEREMA_AUTH_VERSION` (v1 or v2)
-3. Test manually:
+1. Check `CEREMA_API`, `CEREMA_USERNAME`, and `CEREMA_PASSWORD`
+2. Test manually:
 
    ```bash
-   # V1 (legacy)
-   curl -X POST https://portaildf.cerema.fr/api/api-token-auth/ \
-     -d "username=XXX" \
-     -d "password=XXX"
-
-   # V2 (DataFoncier)
-   curl -X POST https://datafoncier.cerema.fr/api/token/ \
+   curl -X POST "$CEREMA_API/api/token/" \
      -H "Content-Type: application/json" \
      -d '{"username": "XXX", "password": "XXX"}'
    ```

--- a/clevercloud/SETUP_CHECKLIST.md
+++ b/clevercloud/SETUP_CHECKLIST.md
@@ -11,7 +11,7 @@ Configure in Clever Cloud dashboard → "Environment variables" tab:
 CC_PYTHON_VERSION=3.11
 
 # Cerema API Authentication
-CEREMA_API=https://datafoncier.cerema.fr
+CEREMA_API=https://portaildf.cerema.fr
 CEREMA_USERNAME=your_cerema_username
 CEREMA_PASSWORD=your_cerema_password
 

--- a/docs/architecture/00-system-overview.md
+++ b/docs/architecture/00-system-overview.md
@@ -111,13 +111,13 @@ flowchart TB
 
     Services --> BAN
     Services --> Brevo
+    Services --> Cerema
 
     PostgreSQL --> Dagster
     Dagster --> dbt
     dbt --> DuckDB
     DuckDB --> Metabase
 
-    Cerema -.->|Cron sync| PostgreSQL
 ```
 
 ## Technology Stack Summary
@@ -209,9 +209,8 @@ flowchart LR
     DGFIP --> Scripts
     Scripts --> PG
 
-    Cerema -->|Cron 30min| PG
-
     PG <--> App
+    App -->|JWT rights check on login| Cerema
 
     PG --> Dagster
     Dagster --> dbt

--- a/docs/architecture/05-scripts-architecture.md
+++ b/docs/architecture/05-scripts-architecture.md
@@ -19,7 +19,7 @@ flowchart TB
     end
 
     subgraph Sync["Synchronization Scripts"]
-        Cerema[cerema-sync]
+        Cerema[Portail DF manual audits]
         UserKind[sync-user-kind]
     end
 

--- a/docs/architecture/05-scripts-architecture.md
+++ b/docs/architecture/05-scripts-architecture.md
@@ -45,10 +45,9 @@ flowchart TB
 
 Configured in `clevercloud/cron.json`:
 
-| Schedule       | Script                   | Description                                 |
-| -------------- | ------------------------ | ------------------------------------------- |
-| `*/30 * * * *` | `cerema-sync.sh`         | Sync users/structures from Cerema DF Portal |
-| `0 3 1 * *`    | `export-monthly-logs.sh` | Export Elasticsearch logs to S3             |
+| Schedule    | Script                   | Description                     |
+| ----------- | ------------------------ | ------------------------------- |
+| `0 3 1 * *` | `export-monthly-logs.sh` | Export Elasticsearch logs to S3 |
 
 ## Script Directory Structure
 
@@ -66,8 +65,7 @@ server/src/scripts/
 ├── perimeters-portaildf/      # Cerema sync pipeline
 │   ├── 01-cerema-scraper/
 │   ├── 02-establishment-verifier/
-│   ├── 03-users-verifier/
-│   └── cerema-sync.sh
+│   └── 03-users-verifier/
 ├── fix-campaign-housing-status/
 ├── sync-user-kind/
 ├── logs/                      # Log export scripts
@@ -77,36 +75,36 @@ server/src/scripts/
 
 ## Key Scripts
 
-### Cerema Sync Pipeline
+### Cerema Audit Pipeline
 
-Automated synchronization with Cerema DF Portal every 30 minutes.
+The former 30-minute cron has been removed. Rights are synchronized by the
+application during login and account creation. These scripts remain available
+for manual audits and troubleshooting.
 
 ```mermaid
 sequenceDiagram
-    participant Cron
-    participant Script as cerema-sync.sh
+    participant Operator
     participant Scraper as 01-cerema-scraper
     participant EstabVerifier as 02-establishment-verifier
     participant UserVerifier as 03-users-verifier
     participant API as Cerema API
     participant DB as PostgreSQL
 
-    Cron->>Script: Execute (*/30 * * * *)
-    Script->>API: POST /api/api-token-auth/
-    API-->>Script: Bearer token
+    Operator->>API: POST /api/token/ (JSON credentials)
+    API-->>Operator: access + refresh JWT
 
-    Script->>Scraper: Run with token
+    Operator->>Scraper: Run with Authorization: Bearer access
     Scraper->>API: GET /api/structures
     Scraper->>API: GET /api/utilisateurs
     Scraper->>API: GET /api/groupes
     API-->>Scraper: JSON data
-    Scraper-->>Script: structures.jsonl, users.jsonl, groups.jsonl
+    Scraper-->>Operator: structures.jsonl, users.jsonl, groups.jsonl
 
-    Script->>EstabVerifier: Verify establishments
+    Operator->>EstabVerifier: Verify establishments
     EstabVerifier->>DB: Check SIREN, LOVAC expiry
     EstabVerifier->>DB: Suspend/delete invalid establishments
 
-    Script->>UserVerifier: Verify users
+    Operator->>UserVerifier: Verify users
     UserVerifier->>DB: Check ToS, rights, structure access
     UserVerifier->>DB: Suspend/delete invalid users
 ```
@@ -315,11 +313,12 @@ def save_state(state: dict):
 
 ### Cerema Sync
 
-| Variable             | Description         |
-| -------------------- | ------------------- |
-| `CEREMA_USERNAME`    | Cerema API username |
-| `CEREMA_PASSWORD`    | Cerema API password |
-| `POSTGRESQL_ADDON_*` | Database connection |
+| Variable             | Description                                           |
+| -------------------- | ----------------------------------------------------- |
+| `CEREMA_API`         | DataFoncier API URL (`https://datafoncier.cerema.fr`) |
+| `CEREMA_USERNAME`    | Cerema API username                                   |
+| `CEREMA_PASSWORD`    | Cerema API password                                   |
+| `POSTGRESQL_ADDON_*` | Database connection                                   |
 
 ### DPE Import
 

--- a/docs/architecture/05-scripts-architecture.md
+++ b/docs/architecture/05-scripts-architecture.md
@@ -313,12 +313,12 @@ def save_state(state: dict):
 
 ### Cerema Sync
 
-| Variable             | Description                                           |
-| -------------------- | ----------------------------------------------------- |
-| `CEREMA_API`         | DataFoncier API URL (`https://datafoncier.cerema.fr`) |
-| `CEREMA_USERNAME`    | Cerema API username                                   |
-| `CEREMA_PASSWORD`    | Cerema API password                                   |
-| `POSTGRESQL_ADDON_*` | Database connection                                   |
+| Variable             | Description                                        |
+| -------------------- | -------------------------------------------------- |
+| `CEREMA_API`         | Portail DF API URL (`https://portaildf.cerema.fr`) |
+| `CEREMA_USERNAME`    | Cerema API username                                |
+| `CEREMA_PASSWORD`    | Cerema API password                                |
+| `POSTGRESQL_ADDON_*` | Database connection                                |
 
 ### DPE Import
 

--- a/docs/architecture/06-infrastructure.md
+++ b/docs/architecture/06-infrastructure.md
@@ -1,6 +1,6 @@
 # Infrastructure & Deployment Architecture
 
-> **Last Updated:** 2026-02-19
+> **Last Updated:** 2026-07-29
 
 ## Overview
 
@@ -54,7 +54,7 @@ flowchart TB
     Queue --> PostgreSQL
     Queue --> Cellar
 
-    Cerema -->|Cron| Backend
+    Backend -->|JWT rights check on login| Cerema
 
     PostgreSQL --> Dagster
     Dagster --> MotherDuck
@@ -86,11 +86,11 @@ clevercloud/
 ### Cron Jobs
 
 ```json
-[
-  "*/30 * * * * $ROOT/server/src/scripts/perimeters-portaildf/cerema-sync.sh",
-  "0 3 1 * * $ROOT/server/src/scripts/logs/export-monthly-logs.sh"
-]
+["0 3 1 * * $ROOT/server/src/scripts/logs/export-monthly-logs.sh"]
 ```
+
+Cerema rights are checked by the application during login and account creation,
+not by a scheduled task. The Portail DF scripts are reserved for manual audits.
 
 ### Environment Variables
 

--- a/docs/architecture/07-integrations.md
+++ b/docs/architecture/07-integrations.md
@@ -58,50 +58,47 @@ flowchart TB
 
 **Purpose:** User and establishment synchronization
 
-| Aspect        | Details                          |
-| ------------- | -------------------------------- |
-| **Type**      | REST API                         |
-| **Auth**      | Username/Password → Bearer Token |
-| **Frequency** | Every 30 minutes (cron)          |
-| **Direction** | Pull                             |
+| Aspect        | Details                                                |
+| ------------- | ------------------------------------------------------ |
+| **Type**      | REST API                                               |
+| **Base URL**  | `CEREMA_API=https://datafoncier.cerema.fr`             |
+| **Auth**      | Username/Password → JWT access/refresh → Bearer access |
+| **Frequency** | Login/account creation; manual audit scripts           |
+| **Direction** | Pull                                                   |
 
 #### Endpoints
 
-| Endpoint               | Method | Description                      |
-| ---------------------- | ------ | -------------------------------- |
-| `/api/api-token-auth/` | POST   | Get authentication token         |
-| `/api/structures`      | GET    | List structures (establishments) |
-| `/api/utilisateurs`    | GET    | List users                       |
-| `/api/groupes`         | GET    | List groups                      |
-| `/api/perimetres`      | GET    | List perimeters                  |
+| Endpoint            | Method | Description                       |
+| ------------------- | ------ | --------------------------------- |
+| `/api/token/`       | POST   | Get JWT access and refresh tokens |
+| `/api/structures`   | GET    | List structures (establishments)  |
+| `/api/utilisateurs` | GET    | List users                        |
+| `/api/groupes`      | GET    | List groups                       |
+| `/api/perimetres`   | GET    | List perimeters                   |
 
 #### Data Flow
 
 ```mermaid
 sequenceDiagram
-    participant Cron
-    participant Script as cerema-sync.sh
+    participant ZLV as ZLV backend
     participant Cerema as Cerema API
     participant DB as PostgreSQL
 
-    Cron->>Script: Execute (*/30 * * * *)
-    Script->>Cerema: POST /api/api-token-auth/
-    Cerema-->>Script: Bearer token
+    ZLV->>Cerema: POST /api/token/ (JSON credentials)
+    Cerema-->>ZLV: access + refresh JWT
 
-    Script->>Cerema: GET /api/structures
-    Script->>Cerema: GET /api/utilisateurs
-    Cerema-->>Script: JSON data
+    ZLV->>Cerema: GET /api/utilisateurs (Bearer access)
+    ZLV->>Cerema: GET structures/groups/perimeters (Bearer access)
+    Cerema-->>ZLV: JSON data
 
-    Script->>DB: Compare with local data
-    Script->>DB: Suspend/delete invalid records
-    Script->>DB: Update user access rights
+    ZLV->>DB: Update user access rights and perimeters
 ```
 
 #### Error Handling
 
-- Token refresh on 401
-- Exponential backoff on rate limits
-- State file for resume on failure
+- A fresh access token is requested before each rights lookup
+- Authentication and API failures are logged
+- Manual scraper state files support resuming interrupted audits
 
 ---
 

--- a/docs/architecture/07-integrations.md
+++ b/docs/architecture/07-integrations.md
@@ -61,7 +61,7 @@ flowchart TB
 | Aspect        | Details                                                |
 | ------------- | ------------------------------------------------------ |
 | **Type**      | REST API                                               |
-| **Base URL**  | `CEREMA_API=https://datafoncier.cerema.fr`             |
+| **Base URL**  | `CEREMA_API=https://portaildf.cerema.fr`               |
 | **Auth**      | Username/Password → JWT access/refresh → Bearer access |
 | **Frequency** | Login/account creation; manual audit scripts           |
 | **Direction** | Pull                                                   |

--- a/docs/operations/runbooks/incident-response.md
+++ b/docs/operations/runbooks/incident-response.md
@@ -214,28 +214,31 @@ CREATE INDEX CONCURRENTLY idx_name ON table(column);
 
 ---
 
-### 2.7 Cerema Sync Failures (P3)
+### 2.7 Portail DF Rights Check Failures (P3)
 
-**Symptoms:** Users/establishments not syncing
+**Symptoms:** Users cannot complete login/account creation, or their Portail DF
+rights are not reflected in ZLV.
 
 **Diagnosis:**
 
 ```bash
-# Check cron logs
-clever logs | grep cerema
+# Check application logs (the check is not a cron task)
+clever logs | grep -i "cerema\|portail df"
 
-# Check state files
-cat server/src/scripts/perimeters-portaildf/01-cerema-scraper/api_*_state.json
+# Confirm that the JWT route exists; 400 JSON is expected without credentials
+curl -sS -o /dev/null -w "%{http_code} %{content_type}\n" \
+  -X POST -H "Content-Type: application/json" -d '{}' \
+  "https://portaildf.cerema.fr/api/token/"
 ```
 
 **Resolution:**
 
-```bash
-# Reset and retry manually
-cd server/src/scripts/perimeters-portaildf
-rm -f 01-cerema-scraper/api_*_state.json
-./cerema-sync.sh
-```
+1. Verify in the Clever Cloud dashboard that `CEREMA_API` is
+   `https://portaildf.cerema.fr` and that the credentials are configured.
+2. Validate a login on staging while watching the application logs.
+3. If a full manual audit is required, follow
+   `server/src/scripts/perimeters-portaildf/README.md`; no Cerema cron is
+   configured.
 
 ---
 

--- a/docs/operations/runbooks/troubleshooting.md
+++ b/docs/operations/runbooks/troubleshooting.md
@@ -313,42 +313,51 @@ clever logs | grep -i "failed\|error"
 
 ---
 
-## 5. Cron Job Issues
+## 5. Portail DF Rights Check Issues
 
-### 5.1 Cerema Sync Not Running
+### 5.1 Rights Check Not Running
 
 **Diagnosis:**
 
 ```bash
-# Check cron configuration
-cat clevercloud/cron.json
-
-# Check recent executions
-clever logs | grep cerema
-
-# Check state files
-ls -la server/src/scripts/perimeters-portaildf/01-cerema-scraper/api_*_state.json
+# Check application logs: rights are checked during login/account creation
+clever logs | grep -i "cerema\|portail df"
 ```
 
 **Solutions:**
 
-| Cause                | Solution                    |
-| -------------------- | --------------------------- |
-| Cron not registered  | Redeploy to register crons  |
-| Auth failure         | Check Cerema credentials    |
-| Script error         | Run manually to debug       |
-| State file corrupted | Delete state files, restart |
+| Cause                 | Solution                                                   |
+| --------------------- | ---------------------------------------------------------- |
+| Incorrect API URL     | Set `CEREMA_API=https://portaildf.cerema.fr`               |
+| Authentication failed | Check or rotate the Cerema credentials                     |
+| Integration disabled  | Check `CEREMA_ENABLED` in the Clever Cloud dashboard       |
+| Manual audit failed   | Follow `server/src/scripts/perimeters-portaildf/README.md` |
 
 ---
 
-### 5.2 Manual Cron Execution
+### 5.2 Manual JWT Authentication Check
 
 ```bash
-# Run cerema sync manually
-cd server/src/scripts/perimeters-portaildf
-export CEREMA_USERNAME="..."
-export CEREMA_PASSWORD="..."
-./cerema-sync.sh
+# Uses CEREMA_API, CEREMA_USERNAME and CEREMA_PASSWORD from the environment.
+# The access token is validated but never printed.
+python3 - <<'PY'
+import os
+import requests
+
+base_url = os.environ["CEREMA_API"].rstrip("/")
+response = requests.post(
+    f"{base_url}/api/token/",
+    json={
+        "username": os.environ["CEREMA_USERNAME"],
+        "password": os.environ["CEREMA_PASSWORD"],
+    },
+    timeout=60,
+)
+response.raise_for_status()
+if not response.json().get("access"):
+    raise RuntimeError("Portail DF response has no access token")
+print("Portail DF JWT authentication: OK")
+PY
 ```
 
 ---

--- a/docs/technical/DAT-Dossier-Architecture-Technique.md
+++ b/docs/technical/DAT-Dossier-Architecture-Technique.md
@@ -573,12 +573,11 @@ sequenceDiagram
 
 ## 7.3 Types de tâches
 
-| Tâche                  | Description                       | Durée typique |
-| ---------------------- | --------------------------------- | ------------- |
-| Export de données      | Génération de fichiers Excel/CSV  | 1-5 minutes   |
-| Envoi de campagne      | Envoi d'emails groupés            | 5-30 minutes  |
-| Import LOVAC           | Intégration des nouvelles données | 30-60 minutes |
-| Synchronisation Cerema | Mise à jour des périmètres        | 10-20 minutes |
+| Tâche             | Description                       | Durée typique |
+| ----------------- | --------------------------------- | ------------- |
+| Export de données | Génération de fichiers Excel/CSV  | 1-5 minutes   |
+| Envoi de campagne | Envoi d'emails groupés            | 5-30 minutes  |
+| Import LOVAC      | Intégration des nouvelles données | 30-60 minutes |
 
 ---
 

--- a/docs/technical/DE-Dossier-Exploitation.md
+++ b/docs/technical/DE-Dossier-Exploitation.md
@@ -712,20 +712,22 @@ Un "cron" est une tâche programmée qui s'exécute automatiquement à intervall
 
 Les tâches sont définies dans `clevercloud/cron.json` :
 
-| Tâche                  | Fréquence         | Description                                   |
-| ---------------------- | ----------------- | --------------------------------------------- |
-| Synchronisation Cerema | Toutes les 30 min | Met à jour les périmètres depuis l'API Cerema |
-| Export des logs        | 1er du mois à 3h  | Archive les logs du mois précédent vers S3    |
+| Tâche           | Fréquence        | Description                                |
+| --------------- | ---------------- | ------------------------------------------ |
+| Export des logs | 1er du mois à 3h | Archive les logs du mois précédent vers S3 |
+
+Le contrôle des droits Portail DF est réalisé par l'application lors de la
+connexion ou de la création du compte. Il ne dépend pas d'une tâche planifiée.
 
 ### 6.3 Vérifier l'exécution des crons
 
 ```bash
-# Voir les logs de la synchronisation Cerema
-clever logs | grep cerema
+# Vérifier la configuration réellement déployée
+cat clevercloud/cron.json
 
-# Exécuter manuellement pour tester
+# Tester manuellement l'export mensuel
 clever ssh
-/app/server/src/scripts/perimeters-portaildf/cerema-sync.sh
+/app/server/src/scripts/logs/export-monthly-logs.sh
 ```
 
 ### 6.4 En cas d'échec d'un cron
@@ -733,10 +735,6 @@ clever ssh
 1. **Vérifier les logs** : `clever logs | grep <nom-du-script>`
 2. **Vérifier les variables d'environnement** nécessaires
 3. **Tester manuellement** via SSH
-4. **Si fichier d'état corrompu** :
-   ```bash
-   rm -f server/src/scripts/perimeters-portaildf/01-cerema-scraper/api_*_state.json
-   ```
 
 ---
 

--- a/docs/technical/DI-Dossier-Installation.md
+++ b/docs/technical/DI-Dossier-Installation.md
@@ -579,11 +579,11 @@ clever env set S3_BUCKET=zlv-production
 # Monitoring (Sentry)
 clever env set SENTRY_DSN=<dsn-sentry>
 
-# Python pour les scripts cron
+# Python pour les scripts opérationnels
 clever env set CC_PYTHON_VERSION=3.11
 
-# API Cerema (synchronisation des périmètres)
-clever env set CEREMA_API=https://datafoncier.cerema.fr
+# API Cerema (contrôle des droits utilisateurs)
+clever env set CEREMA_API=https://portaildf.cerema.fr
 clever env set CEREMA_USERNAME=<username>
 clever env set CEREMA_PASSWORD=<password>
 ```
@@ -605,16 +605,16 @@ clevercloud/
 #### Fichier cron.json (tâches planifiées)
 
 ```json
-[
-  "*/30 * * * * $ROOT/server/src/scripts/perimeters-portaildf/cerema-sync.sh",
-  "0 3 1 * * $ROOT/server/src/scripts/logs/export-monthly-logs.sh"
-]
+["0 3 1 * * $ROOT/server/src/scripts/logs/export-monthly-logs.sh"]
 ```
 
 **Explication de la syntaxe :**
 
-- `*/30 * * * *` = toutes les 30 minutes
 - `0 3 1 * *` = le 1er du mois à 3h du matin
+
+Il n'existe plus de tâche planifiée pour la synchronisation Cerema. Le contrôle
+des droits est effectué par l'application lors de la connexion ou de la création
+du compte ; les scripts Portail DF restent disponibles pour les audits manuels.
 
 #### Script post_build.sh
 
@@ -717,7 +717,7 @@ curl -X GET "https://api.brevo.com/v3/account" \
 
 1. Obtenir les identifiants API Cerema
 2. Configurer les variables :
-   - `CEREMA_API=https://datafoncier.cerema.fr`
+   - `CEREMA_API=https://portaildf.cerema.fr`
    - `CEREMA_USERNAME`
    - `CEREMA_PASSWORD`
 

--- a/docs/technical/DI-Dossier-Installation.md
+++ b/docs/technical/DI-Dossier-Installation.md
@@ -986,7 +986,7 @@ Pour tester manuellement un script :
 
 ```bash
 clever ssh
-/app/server/src/scripts/perimeters-portaildf/cerema-sync.sh
+/app/server/src/scripts/logs/export-monthly-logs.sh
 ```
 
 #### Python non trouvé (pour les scripts)

--- a/docs/technical/DI-Dossier-Installation.md
+++ b/docs/technical/DI-Dossier-Installation.md
@@ -583,6 +583,7 @@ clever env set SENTRY_DSN=<dsn-sentry>
 clever env set CC_PYTHON_VERSION=3.11
 
 # API Cerema (synchronisation des périmètres)
+clever env set CEREMA_API=https://datafoncier.cerema.fr
 clever env set CEREMA_USERNAME=<username>
 clever env set CEREMA_PASSWORD=<password>
 ```
@@ -716,15 +717,19 @@ curl -X GET "https://api.brevo.com/v3/account" \
 
 1. Obtenir les identifiants API Cerema
 2. Configurer les variables :
+   - `CEREMA_API=https://datafoncier.cerema.fr`
    - `CEREMA_USERNAME`
    - `CEREMA_PASSWORD`
 
 **Tester l'authentification :**
 
 ```bash
-curl -X POST https://portaildf.cerema.fr/api/api-token-auth/ \
-  -d "username=$CEREMA_USERNAME" \
-  -d "password=$CEREMA_PASSWORD"
+curl -X POST "$CEREMA_API/api/token/" \
+  -H "Content-Type: application/json" \
+  -d "{\"username\":\"$CEREMA_USERNAME\",\"password\":\"$CEREMA_PASSWORD\"}"
+
+# Réponse : {"access": "eyJ...", "refresh": "eyJ..."}
+# Utilisation : Authorization: Bearer <access>
 ```
 
 ### 6.5 BAN (Base Adresse Nationale)

--- a/server/.env.example
+++ b/server/.env.example
@@ -40,13 +40,9 @@ MAILER_API_KEY=
 MAILER_EVENT_API_KEY=
 
 CEREMA_ENABLED=true
-CEREMA_API=https://portaildf.cerema.fr
+CEREMA_API=https://datafoncier-dev.osc-fr1.scalingo.io
 CEREMA_USERNAME=username
 CEREMA_PASSWORD=password
-# Auth version: v1 (legacy) or v2 (new DataFoncier API)
-CEREMA_AUTH_VERSION=v1
-# V2 API URL (only used when CEREMA_AUTH_VERSION=v2)
-CEREMA_API_V2=https://datafoncier-dev.osc-fr1.scalingo.io
 
 DATAFONCIER_ENABLED=false
 DATAFONCIER_API=https://apidf-preprod.cerema.fr

--- a/server/src/infra/config.ts
+++ b/server/src/infra/config.ts
@@ -80,11 +80,9 @@ export const configSchema = z.object({
   cerema: z
     .object({
       enabled: z.stringbool().default(isProduction),
-      api: z.url().default('https://getdf.cerema.fr'),
+      api: z.url().default('https://datafoncier-dev.osc-fr1.scalingo.io'),
       username: z.string().nullable().default(null),
-      password: z.string().nullable().default(null),
-      authVersion: z.literal(['v1', 'v2']).default('v1'),
-      apiV2: z.url().default('https://datafoncier-dev.osc-fr1.scalingo.io')
+      password: z.string().nullable().default(null)
     })
     .superRefine((val, ctx) => {
       if (val.enabled) {
@@ -298,9 +296,7 @@ const config = configSchema.parse({
     enabled: env('CEREMA_ENABLED'),
     api: env('CEREMA_API'),
     username: env('CEREMA_USERNAME'),
-    password: env('CEREMA_PASSWORD'),
-    authVersion: env('CEREMA_AUTH_VERSION'),
-    apiV2: env('CEREMA_API_V2')
+    password: env('CEREMA_PASSWORD')
   },
   datafoncier: {
     api: env('DATAFONCIER_API'),

--- a/server/src/infra/test/config.test.ts
+++ b/server/src/infra/test/config.test.ts
@@ -35,11 +35,9 @@ const validRaw = {
   },
   cerema: {
     enabled: 'false',
-    api: 'https://getdf.cerema.fr',
+    api: 'https://datafoncier-dev.osc-fr1.scalingo.io',
     username: null,
-    password: null,
-    authVersion: 'v1',
-    apiV2: 'https://datafoncier-dev.osc-fr1.scalingo.io'
+    password: null
   },
   datafoncier: {
     api: 'https://apidf-preprod.cerema.fr',
@@ -165,15 +163,6 @@ describe('configSchema', () => {
     ).toThrow();
   });
 
-  it('rejects an invalid cerema authVersion', () => {
-    expect(() =>
-      configSchema.shape.cerema.parse({
-        ...validRaw.cerema,
-        authVersion: 'v3'
-      })
-    ).toThrow();
-  });
-
   it('rejects cerema config when enabled but username/password missing', () => {
     expect(() =>
       configSchema.parse({
@@ -200,6 +189,16 @@ describe('configSchema', () => {
         }
       })
     ).not.toThrow();
+  });
+
+  it('defaults to the JWT-compatible DataFoncier API', () => {
+    const result = configSchema.shape.cerema.parse({
+      enabled: 'false',
+      username: null,
+      password: null
+    });
+
+    expect(result.api).toBe('https://datafoncier-dev.osc-fr1.scalingo.io');
   });
 
   it('rejects datafoncier config when enabled but token missing', () => {

--- a/server/src/scripts/fix-users-portaildf/index.ts
+++ b/server/src/scripts/fix-users-portaildf/index.ts
@@ -1,19 +1,12 @@
 import fs from 'fs';
 
-import axios from 'axios';
 import { parse as csvParse } from 'csv-parse';
 
-import userRepository from '~/repositories/userRepository';
-import {
-  authenticate,
-  type CeremaAuth
-} from '~/services/ceremaService/ceremaAuthProvider';
+import { authenticate } from '~/services/ceremaService/ceremaAuthProvider';
+
+import { verifyUsers } from './verification';
 
 const CSV_INPUT_PATH = 'users.csv';
-
-function sleep(ms: number) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
 
 async function readEmailsFromCSV(): Promise<string[]> {
   return new Promise((resolve, reject) => {
@@ -31,70 +24,6 @@ async function readEmailsFromCSV(): Promise<string[]> {
       .on('end', () => resolve(emails))
       .on('error', reject);
   });
-}
-
-async function checkEmailWithRetry(email: string, auth: CeremaAuth) {
-  const { default: pRetry } = await import('p-retry');
-  return pRetry(
-    async () => {
-      const response = await axios.get(
-        `${auth.apiUrl}/api/utilisateurs?email=${encodeURIComponent(email)}`,
-        {
-          headers: { Authorization: auth.authorization },
-          timeout: 5000
-        }
-      );
-      return response.data;
-    },
-    {
-      retries: 3,
-      minTimeout: 500,
-      maxTimeout: 2000,
-      factor: 2
-    }
-  );
-}
-
-async function verifyUsers(auth: CeremaAuth, emails: string[]) {
-  for (const email of emails) {
-    try {
-      const data = await checkEmailWithRetry(email, auth);
-
-      if (data.results.length === 0) {
-        console.log(`Utilisateur non trouvé pour l'email : ${email}`);
-        const user = await userRepository.getByEmail(email);
-        if (user) {
-          await userRepository.remove(user.id);
-          console.log(`Utilisateur local supprimé : ${email} (ID: ${user.id})`);
-        } else {
-          console.log(`Utilisateur local introuvable : ${email}`);
-        }
-      } else {
-        console.log(`Utilisateur trouvé pour l'email : ${email}`);
-        const user = await userRepository.getByEmail(email);
-        if (user) {
-          await userRepository.remove(user.id);
-          console.log(`Utilisateur local supprimé : ${email} (ID: ${user.id})`);
-        } else {
-          console.log(`Utilisateur local introuvable : ${email}`);
-        }
-      }
-    } catch (error) {
-      if (error instanceof Error) {
-        console.error(
-          `Échec après plusieurs tentatives pour l'email ${email} :`,
-          error.message
-        );
-      } else {
-        console.error(
-          `Échec après plusieurs tentatives pour l'email ${email} :`,
-          error
-        );
-      }
-    }
-
-    await sleep(200);
-  }
 }
 
 (async () => {

--- a/server/src/scripts/fix-users-portaildf/index.ts
+++ b/server/src/scripts/fix-users-portaildf/index.ts
@@ -3,26 +3,16 @@ import fs from 'fs';
 import axios from 'axios';
 import { parse as csvParse } from 'csv-parse';
 
-import config from '~/infra/config';
 import userRepository from '~/repositories/userRepository';
-import { createAuthProvider } from '~/services/ceremaService/ceremaAuthProvider';
+import {
+  authenticate,
+  type CeremaAuth
+} from '~/services/ceremaService/ceremaAuthProvider';
 
 const CSV_INPUT_PATH = 'users.csv';
 
 function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-const authProvider = createAuthProvider();
-
-interface AuthResult {
-  token: string;
-  authPrefix: string;
-  apiUrl: string;
-}
-
-async function getAuth(): Promise<AuthResult> {
-  return authProvider.authenticate();
 }
 
 async function readEmailsFromCSV(): Promise<string[]> {
@@ -43,14 +33,14 @@ async function readEmailsFromCSV(): Promise<string[]> {
   });
 }
 
-async function checkEmailWithRetry(email: string, auth: AuthResult) {
+async function checkEmailWithRetry(email: string, auth: CeremaAuth) {
   const { default: pRetry } = await import('p-retry');
   return pRetry(
     async () => {
       const response = await axios.get(
         `${auth.apiUrl}/api/utilisateurs?email=${encodeURIComponent(email)}`,
         {
-          headers: { Authorization: `${auth.authPrefix} ${auth.token}` },
+          headers: { Authorization: auth.authorization },
           timeout: 5000
         }
       );
@@ -65,7 +55,7 @@ async function checkEmailWithRetry(email: string, auth: AuthResult) {
   );
 }
 
-async function verifyUsers(auth: AuthResult, emails: string[]) {
+async function verifyUsers(auth: CeremaAuth, emails: string[]) {
   for (const email of emails) {
     try {
       const data = await checkEmailWithRetry(email, auth);
@@ -109,8 +99,7 @@ async function verifyUsers(auth: AuthResult, emails: string[]) {
 
 (async () => {
   try {
-    const auth = await getAuth();
-    console.log(`Using auth version: ${config.cerema.authVersion}`);
+    const auth = await authenticate();
     const emails = await readEmailsFromCSV();
     await verifyUsers(auth, emails);
   } catch (err) {

--- a/server/src/scripts/fix-users-portaildf/verification.test.ts
+++ b/server/src/scripts/fix-users-portaildf/verification.test.ts
@@ -1,0 +1,48 @@
+import nock from 'nock';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import userRepository from '~/repositories/userRepository';
+import { genEstablishmentApi, genUserApi } from '~/test/testFixtures';
+
+import { verifyUsers } from './verification';
+
+vi.mock('~/repositories/userRepository', () => ({
+  default: { getByEmail: vi.fn(), remove: vi.fn() }
+}));
+
+const auth = {
+  apiUrl: 'https://portail-df.example.test',
+  authorization: 'Bearer access-token'
+};
+
+describe('verifyUsers', () => {
+  beforeEach(() => {
+    nock.cleanAll();
+    nock.disableNetConnect();
+    vi.clearAllMocks();
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+    nock.enableNetConnect();
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    { label: 'missing from Portail DF', results: [] },
+    { label: 'present in Portail DF', results: [{}] }
+  ])('removes a listed local user when it is $label', async ({ results }) => {
+    const email = 'user@example.test';
+    const user = genUserApi(genEstablishmentApi().id);
+    vi.mocked(userRepository.getByEmail).mockResolvedValue(user);
+    nock(auth.apiUrl)
+      .get('/api/utilisateurs')
+      .query({ email })
+      .reply(200, { results });
+
+    await verifyUsers(auth, [email]);
+
+    expect(userRepository.remove).toHaveBeenCalledWith(user.id);
+  });
+});

--- a/server/src/scripts/fix-users-portaildf/verification.ts
+++ b/server/src/scripts/fix-users-portaildf/verification.ts
@@ -1,0 +1,66 @@
+import axios from 'axios';
+
+import userRepository from '~/repositories/userRepository';
+import type { CeremaAuth } from '~/services/ceremaService/ceremaAuthProvider';
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function checkEmailWithRetry(email: string, auth: CeremaAuth) {
+  const { default: pRetry } = await import('p-retry');
+  return pRetry(
+    async () => {
+      const response = await axios.get(
+        `${auth.apiUrl}/api/utilisateurs?email=${encodeURIComponent(email)}`,
+        {
+          headers: { Authorization: auth.authorization },
+          timeout: 5000
+        }
+      );
+      return response.data;
+    },
+    {
+      retries: 3,
+      minTimeout: 500,
+      maxTimeout: 2000,
+      factor: 2
+    }
+  );
+}
+
+async function removeLocalUser(email: string): Promise<void> {
+  const user = await userRepository.getByEmail(email);
+  if (!user) {
+    console.log(`Utilisateur local introuvable : ${email}`);
+    return;
+  }
+
+  await userRepository.remove(user.id);
+  console.log(`Utilisateur local supprimé : ${email} (ID: ${user.id})`);
+}
+
+async function verifyUser(auth: CeremaAuth, email: string): Promise<void> {
+  try {
+    const data = await checkEmailWithRetry(email, auth);
+    const status = data.results.length === 0 ? 'non trouvé' : 'trouvé';
+    console.log(`Utilisateur ${status} pour l'email : ${email}`);
+    await removeLocalUser(email);
+  } catch (error) {
+    const details = error instanceof Error ? error.message : error;
+    console.error(
+      `Échec après plusieurs tentatives pour l'email ${email} :`,
+      details
+    );
+  }
+}
+
+export async function verifyUsers(
+  auth: CeremaAuth,
+  emails: string[]
+): Promise<void> {
+  for (const email of emails) {
+    await verifyUser(auth, email);
+    await sleep(200);
+  }
+}

--- a/server/src/scripts/perimeters-portaildf/01-cerema-scraper/README.md
+++ b/server/src/scripts/perimeters-portaildf/01-cerema-scraper/README.md
@@ -24,7 +24,8 @@ pip install requests click
 export CEREMA_BEARER_TOKEN="your_api_token_here"
 
 # Canonical DataFoncier API URL
-export CEREMA_API="https://datafoncier.cerema.fr"
+export CEREMA_API="https://portaildf.cerema.fr"
+export CEREMA_BASE_URL="$CEREMA_API/api"
 ```
 
 ### Command Line Options
@@ -291,4 +292,4 @@ The script automatically constructs the following endpoints:
 - **Structures**: `{base_url}/structures`
 - **Users**: `{base_url}/utilisateurs`
 
-Default base URL: `https://datafoncier.cerema.fr/api`
+Default base URL: `https://portaildf.cerema.fr/api`

--- a/server/src/scripts/perimeters-portaildf/01-cerema-scraper/README.md
+++ b/server/src/scripts/perimeters-portaildf/01-cerema-scraper/README.md
@@ -23,8 +23,8 @@ pip install requests click
 # Required: API Bearer Token
 export CEREMA_BEARER_TOKEN="your_api_token_here"
 
-# Optional: Custom API base URL
-export CEREMA_BASE_URL="https://portaildf.cerema.fr/api"
+# Canonical DataFoncier API URL
+export CEREMA_API="https://datafoncier.cerema.fr"
 ```
 
 ### Command Line Options
@@ -51,7 +51,7 @@ export CEREMA_BASE_URL="https://portaildf.cerema.fr/api"
 export CEREMA_BEARER_TOKEN="your_token_here"
 
 # Run the script (scrapes both structures and users)
-python cerema-scraper.py
+python cerema-scraper.py --base-url "$CEREMA_API/api"
 ```
 
 Execution takes several minutes depending on the number of structures and users.
@@ -291,4 +291,4 @@ The script automatically constructs the following endpoints:
 - **Structures**: `{base_url}/structures`
 - **Users**: `{base_url}/utilisateurs`
 
-Default base URL: `https://portaildf.cerema.fr/api`
+Default base URL: `https://datafoncier.cerema.fr/api`

--- a/server/src/scripts/perimeters-portaildf/01-cerema-scraper/cerema-scraper.py
+++ b/server/src/scripts/perimeters-portaildf/01-cerema-scraper/cerema-scraper.py
@@ -857,9 +857,9 @@ def run_scraper(config: Config, data_types: list):
 )
 @click.option(
     '--base-url', '-u',
-    default='https://datafoncier.cerema.fr/api',
+    default='https://portaildf.cerema.fr/api',
     envvar='CEREMA_BASE_URL',
-    help='Base API URL (default: https://datafoncier.cerema.fr/api)'
+    help='Base API URL (default: https://portaildf.cerema.fr/api)'
 )
 @click.option(
     '--structures-output',

--- a/server/src/scripts/perimeters-portaildf/01-cerema-scraper/cerema-scraper.py
+++ b/server/src/scripts/perimeters-portaildf/01-cerema-scraper/cerema-scraper.py
@@ -857,9 +857,9 @@ def run_scraper(config: Config, data_types: list):
 )
 @click.option(
     '--base-url', '-u',
-    default='https://portaildf.cerema.fr/api',
+    default='https://datafoncier.cerema.fr/api',
     envvar='CEREMA_BASE_URL',
-    help='Base API URL (default: https://portaildf.cerema.fr/api)'
+    help='Base API URL (default: https://datafoncier.cerema.fr/api)'
 )
 @click.option(
     '--structures-output',

--- a/server/src/scripts/perimeters-portaildf/INSTALLATION.md
+++ b/server/src/scripts/perimeters-portaildf/INSTALLATION.md
@@ -65,11 +65,15 @@ pip3 install --user -r /app/server/src/scripts/perimeters-portaildf/requirements
    pip3 list | grep -E "requests|click|psycopg2|dateutil"
    ```
 
-3. **Test the synchronization script**:
+3. **Check that the manual audit CLI loads**:
+
    ```bash
    cd /app/server/src/scripts/perimeters-portaildf
-   ./cerema-sync.sh
+   python3 01-cerema-scraper/cerema-scraper.py --help
    ```
+
+   For an authenticated audit, follow `README.md`. Cerema rights checks run in
+   the application during login/account creation and are not scheduled by cron.
 
 ### In Deployment Logs
 

--- a/server/src/scripts/perimeters-portaildf/README.md
+++ b/server/src/scripts/perimeters-portaildf/README.md
@@ -40,7 +40,7 @@ graph TD
 pip install requests click psycopg2-binary python-dateutil
 
 # Set up Cerema API credentials and canonical API URL
-export CEREMA_API="https://datafoncier.cerema.fr"
+export CEREMA_API="https://portaildf.cerema.fr"
 export CEREMA_USERNAME="your_cerema_username"
 export CEREMA_PASSWORD="your_cerema_password"
 
@@ -49,6 +49,7 @@ export CEREMA_BEARER_TOKEN="$(curl -sS -X POST "$CEREMA_API/api/token/" \
   -H "Content-Type: application/json" \
   -d "{\"username\":\"$CEREMA_USERNAME\",\"password\":\"$CEREMA_PASSWORD\"}" \
   | python -c 'import json, sys; print(json.load(sys.stdin)["access"])')"
+export CEREMA_BASE_URL="$CEREMA_API/api"
 
 # Set up database credentials (Clever Cloud naming convention)
 export POSTGRESQL_ADDON_HOST="localhost"
@@ -62,14 +63,14 @@ export POSTGRESQL_ADDON_PASSWORD="your_password"
 
 L'API Portail DF utilise des jetons JWT :
 
-| Endpoint           | Response                                | Header                           | URL                             |
-| ------------------ | --------------------------------------- | -------------------------------- | ------------------------------- |
-| `POST /api/token/` | `{ "access": "...", "refresh": "..." }` | `Authorization: Bearer <access>` | `https://datafoncier.cerema.fr` |
+| Endpoint           | Response                                | Header                           | URL                           |
+| ------------------ | --------------------------------------- | -------------------------------- | ----------------------------- |
+| `POST /api/token/` | `{ "access": "...", "refresh": "..." }` | `Authorization: Bearer <access>` | `https://portaildf.cerema.fr` |
 
 #### Configuration (variables d'environnement)
 
 ```bash
-export CEREMA_API=https://datafoncier.cerema.fr
+export CEREMA_API=https://portaildf.cerema.fr
 export CEREMA_USERNAME=your_cerema_username
 export CEREMA_PASSWORD=your_cerema_password
 ```

--- a/server/src/scripts/perimeters-portaildf/README.md
+++ b/server/src/scripts/perimeters-portaildf/README.md
@@ -39,10 +39,16 @@ graph TD
 # Install dependencies
 pip install requests click psycopg2-binary python-dateutil
 
-# Set up Cerema API credentials (username and password)
-# The script will automatically authenticate and get a temporary token
+# Set up Cerema API credentials and canonical API URL
+export CEREMA_API="https://datafoncier.cerema.fr"
 export CEREMA_USERNAME="your_cerema_username"
 export CEREMA_PASSWORD="your_cerema_password"
+
+# Request a JWT access token for the scraper
+export CEREMA_BEARER_TOKEN="$(curl -sS -X POST "$CEREMA_API/api/token/" \
+  -H "Content-Type: application/json" \
+  -d "{\"username\":\"$CEREMA_USERNAME\",\"password\":\"$CEREMA_PASSWORD\"}" \
+  | python -c 'import json, sys; print(json.load(sys.stdin)["access"])')"
 
 # Set up database credentials (Clever Cloud naming convention)
 export POSTGRESQL_ADDON_HOST="localhost"
@@ -52,25 +58,20 @@ export POSTGRESQL_ADDON_USER="your_username"
 export POSTGRESQL_ADDON_PASSWORD="your_password"
 ```
 
-### Authentication Versions
+### JWT Authentication
 
-L'API Portail DF supporte deux versions d'authentification :
+L'API Portail DF utilise des jetons JWT :
 
-| Version              | Endpoint                    | Response                                | Header                           | URL                             |
-| -------------------- | --------------------------- | --------------------------------------- | -------------------------------- | ------------------------------- |
-| **V1** (legacy)      | `POST /api/api-token-auth/` | `{ "token": "..." }`                    | `Authorization: Token <token>`   | `https://portaildf.cerema.fr`   |
-| **V2** (DataFoncier) | `POST /api/token/`          | `{ "access": "...", "refresh": "..." }` | `Authorization: Bearer <access>` | `https://datafoncier.cerema.fr` |
+| Endpoint           | Response                                | Header                           | URL                             |
+| ------------------ | --------------------------------------- | -------------------------------- | ------------------------------- |
+| `POST /api/token/` | `{ "access": "...", "refresh": "..." }` | `Authorization: Bearer <access>` | `https://datafoncier.cerema.fr` |
 
 #### Configuration (variables d'environnement)
 
 ```bash
-# V1 (défaut)
-export CEREMA_AUTH_VERSION=v1
-export CEREMA_API=https://portaildf.cerema.fr
-
-# V2 (nouvelle API DataFoncier)
-export CEREMA_AUTH_VERSION=v2
-export CEREMA_API_V2=https://datafoncier.cerema.fr
+export CEREMA_API=https://datafoncier.cerema.fr
+export CEREMA_USERNAME=your_cerema_username
+export CEREMA_PASSWORD=your_cerema_password
 ```
 
 ### 2. Data Retrieval
@@ -252,12 +253,12 @@ export CEREMA_PASSWORD="your_cerema_password"
 export DB_PASSWORD="your_database_password"
 
 # Manual token retrieval (for testing only)
-curl -X POST https://portaildf.cerema.fr/api/api-token-auth/ \
-  -d "username=your_cerema_username" \
-  -d "password=your_cerema_password"
+curl -X POST "$CEREMA_API/api/token/" \
+  -H "Content-Type: application/json" \
+  -d '{"username": "your_cerema_username", "password": "your_cerema_password"}'
 
 # Response format:
-# {"token": "222a9ac058496742ff2922533d90847621314629"}
+# {"access": "eyJ...", "refresh": "eyJ..."}
 ```
 
 ### File Permissions
@@ -308,23 +309,9 @@ python cerema-scraper.py --max-retries 5
 
 ### API Token Authentication
 
-#### V1 Authentication (Legacy)
-
 ```bash
 # Using curl
-curl -X POST https://portaildf.cerema.fr/api/api-token-auth/ \
-    -H "Content-Type: application/json" \
-    -d '{"username": "your_username", "password": "your_password"}'
-
-# Response: { "token": "abcd1234..." }
-# Use as: Authorization: Token abcd1234...
-```
-
-#### V2 Authentication (DataFoncier)
-
-```bash
-# Using curl
-curl -X POST https://datafoncier.cerema.fr/api/token/ \
+curl -X POST "$CEREMA_API/api/token/" \
     -H "Content-Type: application/json" \
     -d '{"username": "your_username", "password": "your_password"}'
 
@@ -335,20 +322,12 @@ curl -X POST https://datafoncier.cerema.fr/api/token/ \
 #### Using Python
 
 ```python
+import os
 import requests
 
-# V1
+api_url = os.environ['CEREMA_API'].rstrip('/')
 response = requests.post(
-    'https://portaildf.cerema.fr/api/api-token-auth/',
-    headers={'Content-Type': 'application/json'},
-    json={'username': 'your_username', 'password': 'your_password'}
-)
-token = response.json()['token']
-print(f'Authorization: Token {token}')
-
-# V2
-response = requests.post(
-    'https://datafoncier.cerema.fr/api/token/',
+    f'{api_url}/api/token/',
     headers={'Content-Type': 'application/json'},
     json={'username': 'your_username', 'password': 'your_password'}
 )
@@ -358,8 +337,7 @@ print(f'Authorization: Bearer {access}')
 
 **Important Notes:**
 
-- V1 tokens don't expire automatically but may be revoked
-- V2 tokens (JWT) have expiration times
+- JWT access tokens expire and can be renewed with the refresh token
 - Store tokens securely using environment variables
 - Never commit tokens to version control
 

--- a/server/src/scripts/perimeters-portaildf/export-lovac-users.py
+++ b/server/src/scripts/perimeters-portaildf/export-lovac-users.py
@@ -46,7 +46,7 @@ def clean_url(url: str) -> str:
 class LovacUsersExporter:
     """Export users with LOVAC access from Portail DF."""
 
-    def __init__(self, token: str, base_url: str = "https://portaildf.cerema.fr/api"):
+    def __init__(self, token: str, base_url: str = "https://datafoncier.cerema.fr/api"):
         self.token = token
         self.base_url = base_url.rstrip("/")
         self.session = requests.Session()
@@ -268,7 +268,7 @@ def main():
     )
     parser.add_argument(
         "--base-url",
-        default="https://portaildf.cerema.fr/api",
+        default="https://datafoncier.cerema.fr/api",
         help="API base URL",
     )
 

--- a/server/src/scripts/perimeters-portaildf/export-lovac-users.py
+++ b/server/src/scripts/perimeters-portaildf/export-lovac-users.py
@@ -46,7 +46,7 @@ def clean_url(url: str) -> str:
 class LovacUsersExporter:
     """Export users with LOVAC access from Portail DF."""
 
-    def __init__(self, token: str, base_url: str = "https://datafoncier.cerema.fr/api"):
+    def __init__(self, token: str, base_url: str = "https://portaildf.cerema.fr/api"):
         self.token = token
         self.base_url = base_url.rstrip("/")
         self.session = requests.Session()
@@ -268,7 +268,7 @@ def main():
     )
     parser.add_argument(
         "--base-url",
-        default="https://datafoncier.cerema.fr/api",
+        default="https://portaildf.cerema.fr/api",
         help="API base URL",
     )
 

--- a/server/src/scripts/perimeters-portaildf/fetch-groups-perimeters.py
+++ b/server/src/scripts/perimeters-portaildf/fetch-groups-perimeters.py
@@ -26,7 +26,7 @@ from datetime import datetime
 from typing import Optional, Dict, Set, List
 
 # Configuration
-API_BASE_URL = "https://portaildf.cerema.fr/api"
+API_BASE_URL = "https://datafoncier.cerema.fr/api"
 DELAY_BETWEEN_REQUESTS = 0.3  # seconds
 MAX_RETRIES = 3
 
@@ -36,12 +36,13 @@ def authenticate(username: str, password: str) -> Optional[str]:
 
     try:
         response = requests.post(
-            f"{API_BASE_URL}/api-token-auth/",
-            data={"username": username, "password": password}
+            f"{API_BASE_URL}/token/",
+            json={"username": username, "password": password},
+            timeout=60,
         )
 
         if response.status_code == 200:
-            token = response.json().get("token")
+            token = response.json().get("access")
             print("✅ Authentication successful")
             return token
         else:
@@ -111,7 +112,7 @@ def fetch_all_groups(token: str, group_ids: Set[int], output_file: str) -> Dict[
     print(f"\n📦 Fetching {len(group_ids)} groups...")
 
     headers = {
-        "Authorization": f"Token {token}",
+        "Authorization": f"Bearer {token}",
         "Content-Type": "application/json"
     }
 
@@ -170,7 +171,7 @@ def fetch_all_perimeters(token: str, perimeter_ids: Set[int], output_file: str) 
     print(f"\n🗺️ Fetching {len(perimeter_ids)} perimeters...")
 
     headers = {
-        "Authorization": f"Token {token}",
+        "Authorization": f"Bearer {token}",
         "Content-Type": "application/json"
     }
 

--- a/server/src/scripts/perimeters-portaildf/fetch-groups-perimeters.py
+++ b/server/src/scripts/perimeters-portaildf/fetch-groups-perimeters.py
@@ -26,7 +26,7 @@ from datetime import datetime
 from typing import Optional, Dict, Set, List
 
 # Configuration
-API_BASE_URL = "https://datafoncier.cerema.fr/api"
+API_BASE_URL = "https://portaildf.cerema.fr/api"
 DELAY_BETWEEN_REQUESTS = 0.3  # seconds
 MAX_RETRIES = 3
 

--- a/server/src/scripts/perimeters-portaildf/test_fetch_groups_perimeters.py
+++ b/server/src/scripts/perimeters-portaildf/test_fetch_groups_perimeters.py
@@ -1,0 +1,74 @@
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+from unittest.mock import Mock, call
+
+
+SCRIPT_PATH = Path(__file__).with_name("fetch-groups-perimeters.py")
+SPEC = spec_from_file_location("fetch_groups_perimeters", SCRIPT_PATH)
+assert SPEC and SPEC.loader
+fetch_groups_perimeters = module_from_spec(SPEC)
+SPEC.loader.exec_module(fetch_groups_perimeters)
+
+
+def test_jwt_authentication_is_used_for_group_and_perimeter_requests(
+    monkeypatch, tmp_path
+):
+    auth_response = Mock(status_code=200)
+    auth_response.json.return_value = {
+        "access": "jwt-access-token",
+        "refresh": "jwt-refresh-token",
+    }
+    post = Mock(return_value=auth_response)
+
+    group_response = Mock(status_code=200)
+    group_response.json.return_value = {
+        "id_groupe": 42,
+        "perimetre": 7,
+        "lovac": True,
+    }
+    perimeter_response = Mock(status_code=200)
+    perimeter_response.json.return_value = {
+        "perimetre_id": 7,
+        "fr_entiere": True,
+    }
+    get = Mock(side_effect=[group_response, perimeter_response])
+
+    monkeypatch.setattr(fetch_groups_perimeters.requests, "post", post)
+    monkeypatch.setattr(fetch_groups_perimeters.requests, "get", get)
+    monkeypatch.setattr(fetch_groups_perimeters.time, "sleep", lambda _: None)
+
+    token = fetch_groups_perimeters.authenticate("zlv-user", "zlv-password")
+    groups, perimeter_ids = fetch_groups_perimeters.fetch_all_groups(
+        token,
+        {42},
+        str(tmp_path / "groups.jsonl"),
+    )
+    perimeters = fetch_groups_perimeters.fetch_all_perimeters(
+        token,
+        perimeter_ids,
+        str(tmp_path / "perimeters.jsonl"),
+    )
+
+    post.assert_called_once_with(
+        "https://datafoncier.cerema.fr/api/token/",
+        json={"username": "zlv-user", "password": "zlv-password"},
+        timeout=60,
+    )
+    bearer_headers = {
+        "Authorization": "Bearer jwt-access-token",
+        "Content-Type": "application/json",
+    }
+    assert get.call_args_list == [
+        call(
+            "https://datafoncier.cerema.fr/api/groupes/42/",
+            headers=bearer_headers,
+            timeout=30,
+        ),
+        call(
+            "https://datafoncier.cerema.fr/api/perimetres/7/",
+            headers=bearer_headers,
+            timeout=30,
+        ),
+    ]
+    assert groups[42]["perimetre"] == 7
+    assert perimeters[7]["fr_entiere"] is True

--- a/server/src/scripts/perimeters-portaildf/test_fetch_groups_perimeters.py
+++ b/server/src/scripts/perimeters-portaildf/test_fetch_groups_perimeters.py
@@ -50,7 +50,7 @@ def test_jwt_authentication_is_used_for_group_and_perimeter_requests(
     )
 
     post.assert_called_once_with(
-        "https://datafoncier.cerema.fr/api/token/",
+        "https://portaildf.cerema.fr/api/token/",
         json={"username": "zlv-user", "password": "zlv-password"},
         timeout=60,
     )
@@ -60,12 +60,12 @@ def test_jwt_authentication_is_used_for_group_and_perimeter_requests(
     }
     assert get.call_args_list == [
         call(
-            "https://datafoncier.cerema.fr/api/groupes/42/",
+            "https://portaildf.cerema.fr/api/groupes/42/",
             headers=bearer_headers,
             timeout=30,
         ),
         call(
-            "https://datafoncier.cerema.fr/api/perimetres/7/",
+            "https://portaildf.cerema.fr/api/perimetres/7/",
             headers=bearer_headers,
             timeout=30,
         ),

--- a/server/src/scripts/perimeters-portaildf/utils/establishments-sync.py
+++ b/server/src/scripts/perimeters-portaildf/utils/establishments-sync.py
@@ -34,7 +34,7 @@ BEARER_TOKEN = os.getenv('CEREMA_API_TOKEN')  # Get token from environment varia
 
 # Portail DF API Configuration
 PORTAIL_DF_API_CONFIG = {
-    'base_url': 'https://portaildf.cerema.fr/api',
+    'base_url': 'https://datafoncier.cerema.fr/api',
     'headers': {
         'User-Agent': 'ZLV-Sync/1.0',
         'Accept': 'application/json'

--- a/server/src/scripts/perimeters-portaildf/utils/establishments-sync.py
+++ b/server/src/scripts/perimeters-portaildf/utils/establishments-sync.py
@@ -34,7 +34,7 @@ BEARER_TOKEN = os.getenv('CEREMA_API_TOKEN')  # Get token from environment varia
 
 # Portail DF API Configuration
 PORTAIL_DF_API_CONFIG = {
-    'base_url': 'https://datafoncier.cerema.fr/api',
+    'base_url': 'https://portaildf.cerema.fr/api',
     'headers': {
         'User-Agent': 'ZLV-Sync/1.0',
         'Accept': 'application/json'

--- a/server/src/scripts/sync-user-kind/README.md
+++ b/server/src/scripts/sync-user-kind/README.md
@@ -30,23 +30,12 @@ This script fetches user information from the Portail DF API and updates the loc
 
 ## Authentication
 
-The script supports two authentication versions for the Portail DF API:
-
-### V1 (Legacy - Default)
-
-- **Endpoint**: POST `/api/api-token-auth/`
-- **Response**: `{ "token": "..." }`
-- **Header**: `Authorization: Token <token>`
-- **URL**: `https://portaildf.cerema.fr/api`
-
-### V2 (New DataFoncier API)
+The script uses JWT authentication with the DataFoncier API:
 
 - **Endpoint**: POST `/api/token/`
 - **Response**: `{ "access": "...", "refresh": "..." }`
 - **Header**: `Authorization: Bearer <access>`
-- **URL**: `https://datafoncier.cerema.fr/api`
-
-Use `--auth-version v2` to switch to the new API.
+- **URL**: `$CEREMA_API/api`, with `CEREMA_API=https://datafoncier.cerema.fr`
 
 Credentials must be provided via command-line arguments.
 
@@ -55,30 +44,13 @@ Credentials must be provided via command-line arguments.
 ### Basic Usage
 
 ```bash
+export CEREMA_API="https://datafoncier.cerema.fr"
+
 python sync_user_kind.py \
   --db-url "postgresql://user:pass@localhost:5432/dbname" \
-  --api-url "https://portaildf.cerema.fr/api"
-```
-
-### With V1 Authentication (Legacy - Default)
-
-```bash
-python sync_user_kind.py \
-  --db-url "postgresql://user:pass@localhost:5432/dbname" \
-  --api-url "https://portaildf.cerema.fr/api" \
+  --api-url "$CEREMA_API/api" \
   --username "my_user" \
   --password "my_password"
-```
-
-### With V2 Authentication (New DataFoncier API)
-
-```bash
-python sync_user_kind.py \
-  --db-url "postgresql://user:pass@localhost:5432/dbname" \
-  --api-url "https://datafoncier.cerema.fr/api" \
-  --username "my_user" \
-  --password "my_password" \
-  --auth-version v2
 ```
 
 ### Dry Run (Test Mode)
@@ -88,7 +60,9 @@ Test the script without making database changes:
 ```bash
 python sync_user_kind.py \
   --db-url "postgresql://user:pass@localhost:5432/dbname" \
-  --api-url "https://portaildf.cerema.fr/api" \
+  --api-url "$CEREMA_API/api" \
+  --username "my_user" \
+  --password "my_password" \
   --dry-run
 ```
 
@@ -99,7 +73,9 @@ Process only first 100 users:
 ```bash
 python sync_user_kind.py \
   --db-url "postgresql://user:pass@localhost:5432/dbname" \
-  --api-url "https://portaildf.cerema.fr/api" \
+  --api-url "$CEREMA_API/api" \
+  --username "my_user" \
+  --password "my_password" \
   --limit 100
 ```
 
@@ -108,7 +84,9 @@ python sync_user_kind.py \
 ```bash
 python sync_user_kind.py \
   --db-url "postgresql://user:pass@localhost:5432/dbname" \
-  --api-url "https://portaildf.cerema.fr/api" \
+  --api-url "$CEREMA_API/api" \
+  --username "my_user" \
+  --password "my_password" \
   --verbose
 ```
 
@@ -117,31 +95,32 @@ python sync_user_kind.py \
 ```bash
 python sync_user_kind.py \
   --db-url "postgresql://user:pass@localhost:5432/dbname" \
-  --api-url "https://portaildf.cerema.fr/api" \
+  --api-url "$CEREMA_API/api" \
+  --username "my_user" \
+  --password "my_password" \
   --debug
 ```
 
 ## Command-Line Arguments
 
-| Argument          | Required | Default | Description                                       |
-| ----------------- | -------- | ------- | ------------------------------------------------- |
-| `--db-url`        | Yes      | -       | PostgreSQL connection URI                         |
-| `--api-url`       | Yes      | -       | Portail DF API base URL                           |
-| `--username`      | Yes      | -       | API username for authentication                   |
-| `--password`      | Yes      | -       | API password for authentication                   |
-| `--auth-version`  | No       | `v1`    | Auth version: `v1` (legacy) or `v2` (DataFoncier) |
-| `--dry-run`       | No       | `false` | Simulation mode (no DB changes)                   |
-| `--limit`         | No       | -       | Limit number of users to process                  |
-| `--batch-size`    | No       | `1000`  | Batch size for DB updates                         |
-| `--num-workers`   | No       | `4`     | Number of parallel workers                        |
-| `--verbose`, `-v` | No       | `false` | Verbose output                                    |
-| `--debug`         | No       | `false` | Debug logging                                     |
+| Argument          | Required | Default | Description                      |
+| ----------------- | -------- | ------- | -------------------------------- |
+| `--db-url`        | Yes      | -       | PostgreSQL connection URI        |
+| `--api-url`       | Yes      | -       | DataFoncier API base URL         |
+| `--username`      | Yes      | -       | API username for authentication  |
+| `--password`      | Yes      | -       | API password for authentication  |
+| `--dry-run`       | No       | `false` | Simulation mode (no DB changes)  |
+| `--limit`         | No       | -       | Limit number of users to process |
+| `--batch-size`    | No       | `1000`  | Batch size for DB updates        |
+| `--num-workers`   | No       | `4`     | Number of parallel workers       |
+| `--verbose`, `-v` | No       | `false` | Verbose output                   |
+| `--debug`         | No       | `false` | Debug logging                    |
 
 ## How It Works
 
-1. **Authenticate**: Obtains a token from `/api-token-auth/` using username/password
+1. **Authenticate**: Obtains JWT access and refresh tokens from `/api/token/` using username/password
 2. **Fetch Users**: Retrieves all users with email addresses from local database
-3. **API Lookup**: For each user, queries Portail DF API: `/utilisateurs?email=<email>` with `Authorization: Token <token>` header
+3. **API Lookup**: For each user, queries Portail DF API: `/utilisateurs?email=<email>` with `Authorization: Bearer <access>` header
 4. **Determine Kind**: Applies mapping rules based on `exterieur` and `gestionnaire` flags
 5. **Batch Update**: Updates database in batches with parallel workers
 6. **Summary**: Displays statistics about processed users
@@ -165,7 +144,7 @@ python sync_user_kind.py \
 ================================================================================
 USER KIND SYNCHRONIZATION
 ================================================================================
-API URL: https://portaildf.cerema.fr/api
+API URL: https://datafoncier.cerema.fr/api
 Dry run: False
 
 📋 Found 1,234 users to sync

--- a/server/src/scripts/sync-user-kind/README.md
+++ b/server/src/scripts/sync-user-kind/README.md
@@ -35,7 +35,7 @@ The script uses JWT authentication with the DataFoncier API:
 - **Endpoint**: POST `/api/token/`
 - **Response**: `{ "access": "...", "refresh": "..." }`
 - **Header**: `Authorization: Bearer <access>`
-- **URL**: `$CEREMA_API/api`, with `CEREMA_API=https://datafoncier.cerema.fr`
+- **URL**: `$CEREMA_API/api`, with `CEREMA_API=https://portaildf.cerema.fr`
 
 Credentials must be provided via command-line arguments.
 
@@ -44,7 +44,7 @@ Credentials must be provided via command-line arguments.
 ### Basic Usage
 
 ```bash
-export CEREMA_API="https://datafoncier.cerema.fr"
+export CEREMA_API="https://portaildf.cerema.fr"
 
 python sync_user_kind.py \
   --db-url "postgresql://user:pass@localhost:5432/dbname" \
@@ -144,7 +144,7 @@ python sync_user_kind.py \
 ================================================================================
 USER KIND SYNCHRONIZATION
 ================================================================================
-API URL: https://datafoncier.cerema.fr/api
+API URL: https://portaildf.cerema.fr/api
 Dry run: False
 
 📋 Found 1,234 users to sync

--- a/server/src/scripts/sync-user-kind/sync_user_kind.py
+++ b/server/src/scripts/sync-user-kind/sync_user_kind.py
@@ -456,7 +456,7 @@ def main():
     parser.add_argument(
         "--api-url",
         required=True,
-        help="Portail DF API base URL (e.g., https://datafoncier.cerema.fr/api)",
+        help="Portail DF API base URL (e.g., https://portaildf.cerema.fr/api)",
     )
     parser.add_argument(
         "--username",

--- a/server/src/scripts/sync-user-kind/sync_user_kind.py
+++ b/server/src/scripts/sync-user-kind/sync_user_kind.py
@@ -40,7 +40,6 @@ class UserKindSync:
         dry_run: bool = False,
         batch_size: int = 1000,
         num_workers: int = 4,
-        auth_version: str = "v1",
     ):
         """
         Initialize the sync processor.
@@ -53,7 +52,6 @@ class UserKindSync:
             dry_run: Simulation mode (no database modifications)
             batch_size: Batch size for database operations
             num_workers: Number of parallel workers
-            auth_version: Authentication version ('v1' or 'v2')
         """
         self.db_url = db_url
         self.api_url = api_url.rstrip("/")
@@ -62,7 +60,6 @@ class UserKindSync:
         self.dry_run = dry_run
         self.batch_size = batch_size
         self.num_workers = num_workers
-        self.auth_version = auth_version
         self.conn = None
         self.cursor = None
         self.auth_token = None
@@ -87,48 +84,29 @@ class UserKindSync:
     def authenticate(self):
         """Authenticate with Portail DF API and get token."""
         try:
-            if self.auth_version == "v2":
-                # V2: POST /api/token/ with JSON body, returns { access, refresh }
-                auth_url = f"{self.api_url}/token/"
-                response = requests.post(
-                    auth_url,
-                    json={
-                        "username": self.username,
-                        "password": self.password,
-                    },
-                    headers={"Content-Type": "application/json"},
-                    timeout=60,
-                )
-                response.raise_for_status()
+            auth_url = f"{self.api_url}/token/"
+            response = requests.post(
+                auth_url,
+                json={
+                    "username": self.username,
+                    "password": self.password,
+                },
+                headers={"Content-Type": "application/json"},
+                timeout=60,
+            )
+            response.raise_for_status()
 
-                data = response.json()
-                self.auth_token = data.get("access")
-                auth_prefix = "Bearer"
-            else:
-                # V1: POST /api-token-auth/ with form-data, returns { token }
-                auth_url = f"{self.api_url}/api-token-auth/"
-                response = requests.post(
-                    auth_url,
-                    files={
-                        "username": (None, self.username),
-                        "password": (None, self.password),
-                    },
-                    timeout=60,
-                )
-                response.raise_for_status()
-
-                data = response.json()
-                self.auth_token = data.get("token")
-                auth_prefix = "Token"
+            data = response.json()
+            self.auth_token = data.get("access")
 
             if not self.auth_token:
                 raise ValueError("No token in authentication response")
 
             # Update session headers with token
             self.session.headers.update(
-                {"Authorization": f"{auth_prefix} {self.auth_token}"}
+                {"Authorization": f"Bearer {self.auth_token}"}
             )
-            logging.info(f"✅ Portail DF API authentication successful (version: {self.auth_version})")
+            logging.info("✅ Portail DF API authentication successful")
 
         except requests.exceptions.RequestException as e:
             print(f"❌ Portail DF API authentication failed: {e}")
@@ -478,7 +456,7 @@ def main():
     parser.add_argument(
         "--api-url",
         required=True,
-        help="Portail DF API base URL (e.g., https://portaildf.cerema.fr/api)",
+        help="Portail DF API base URL (e.g., https://datafoncier.cerema.fr/api)",
     )
     parser.add_argument(
         "--username",
@@ -489,12 +467,6 @@ def main():
         "--password",
         required=True,
         help="API password for authentication",
-    )
-    parser.add_argument(
-        "--auth-version",
-        choices=["v1", "v2"],
-        default="v1",
-        help="API authentication version: v1 (legacy) or v2 (new DataFoncier API)",
     )
     parser.add_argument(
         "--dry-run", action="store_true", help="Simulation mode (no database changes)"
@@ -547,7 +519,6 @@ def main():
         dry_run=args.dry_run,
         batch_size=args.batch_size,
         num_workers=args.num_workers,
-        auth_version=args.auth_version,
     )
 
     try:

--- a/server/src/scripts/sync-user-kind/test_sync_user_kind.py
+++ b/server/src/scripts/sync-user-kind/test_sync_user_kind.py
@@ -1,0 +1,38 @@
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+from unittest.mock import Mock
+
+
+SCRIPT_PATH = Path(__file__).with_name("sync_user_kind.py")
+SPEC = spec_from_file_location("sync_user_kind", SCRIPT_PATH)
+assert SPEC and SPEC.loader
+sync_user_kind = module_from_spec(SPEC)
+SPEC.loader.exec_module(sync_user_kind)
+
+
+def test_authenticate_uses_jwt_access_token_and_bearer_header(monkeypatch):
+    response = Mock()
+    response.json.return_value = {
+        "access": "jwt-access-token",
+        "refresh": "jwt-refresh-token",
+    }
+    post = Mock(return_value=response)
+    monkeypatch.setattr(sync_user_kind.requests, "post", post)
+
+    sync = sync_user_kind.UserKindSync(
+        db_url="postgresql://localhost/zlv",
+        api_url="https://datafoncier.example/api/",
+        username="zlv-user",
+        password="zlv-password",
+    )
+
+    sync.authenticate()
+
+    post.assert_called_once_with(
+        "https://datafoncier.example/api/token/",
+        json={"username": "zlv-user", "password": "zlv-password"},
+        headers={"Content-Type": "application/json"},
+        timeout=60,
+    )
+    assert sync.auth_token == "jwt-access-token"
+    assert sync.session.headers["Authorization"] == "Bearer jwt-access-token"

--- a/server/src/services/ceremaService/ceremaAuthProvider.test.ts
+++ b/server/src/services/ceremaService/ceremaAuthProvider.test.ts
@@ -1,0 +1,28 @@
+import nock from 'nock';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import config from '~/infra/config';
+
+import { authenticate } from './ceremaAuthProvider';
+
+beforeEach(() => {
+  nock.cleanAll();
+  nock.disableNetConnect();
+});
+
+afterEach(() => {
+  nock.cleanAll();
+  nock.enableNetConnect();
+});
+
+describe('authenticate', () => {
+  it('rejects an authentication response without an access token', async () => {
+    nock(config.cerema.api)
+      .post('/api/token/')
+      .reply(200, { refresh: 'refresh-token' });
+
+    await expect(authenticate()).rejects.toThrow(
+      'Cerema authentication response has no access token'
+    );
+  });
+});

--- a/server/src/services/ceremaService/ceremaAuthProvider.ts
+++ b/server/src/services/ceremaService/ceremaAuthProvider.ts
@@ -5,90 +5,33 @@ import { createLogger } from '~/infra/logger';
 
 const logger = createLogger('ceremaAuthProvider');
 
-/**
- * Represents an authentication token for Cerema API.
- */
-export interface AuthResult {
-  /** The token to use in Authorization header */
-  token: string;
-  /** The Authorization header prefix (Token for V1, Bearer for V2) */
-  authPrefix: 'Token' | 'Bearer';
-  /** The base API URL to use for subsequent requests */
+export interface CeremaAuth {
   apiUrl: string;
+  authorization: string;
 }
 
-/**
- * Interface for Cerema authentication providers.
- */
-export interface CeremaAuthProvider {
-  /**
-   * Authenticates with the Cerema API and returns an auth result.
-   */
-  authenticate(): Promise<AuthResult>;
-}
-
-/**
- * V1 authentication provider for the legacy Portail DF API.
- * Uses POST /api/api-token-auth/ and returns { token }.
- */
-class CeremaAuthProviderV1 implements CeremaAuthProvider {
-  async authenticate(): Promise<AuthResult> {
-    try {
-      const { data } = await axios.post<{ token: string }>(
-        `${config.cerema.api}/api/api-token-auth/`,
-        { username: config.cerema.username, password: config.cerema.password }
-      );
-      return {
-        token: data.token,
-        authPrefix: 'Token',
-        apiUrl: config.cerema.api
-      };
-    } catch (error) {
-      const status = axios.isAxiosError(error)
-        ? error.response?.status
-        : undefined;
-      const message = axios.isAxiosError(error) ? error.message : String(error);
-      logger.error('V1 authentication failed', { status, error: message });
-      throw new Error(`Cerema V1 authentication failed: ${status}`);
-    }
+export async function authenticate(): Promise<CeremaAuth> {
+  let data: { access?: string; refresh?: string };
+  try {
+    ({ data } = await axios.post<{ access?: string; refresh?: string }>(
+      `${config.cerema.api}/api/token/`,
+      { username: config.cerema.username, password: config.cerema.password }
+    ));
+  } catch (error) {
+    const status = axios.isAxiosError(error)
+      ? error.response?.status
+      : undefined;
+    const message = axios.isAxiosError(error) ? error.message : String(error);
+    logger.error('Authentication failed', { status, error: message });
+    throw new Error(`Cerema authentication failed: ${status}`);
   }
-}
 
-/**
- * V2 authentication provider for the new DataFoncier API.
- * Uses POST /api/token/ and returns { access, refresh }.
- */
-class CeremaAuthProviderV2 implements CeremaAuthProvider {
-  async authenticate(): Promise<AuthResult> {
-    try {
-      const { data } = await axios.post<{ access: string; refresh: string }>(
-        `${config.cerema.apiV2}/api/token/`,
-        { username: config.cerema.username, password: config.cerema.password }
-      );
-      return {
-        token: data.access,
-        authPrefix: 'Bearer',
-        apiUrl: config.cerema.apiV2
-      };
-    } catch (error) {
-      const status = axios.isAxiosError(error)
-        ? error.response?.status
-        : undefined;
-      const message = axios.isAxiosError(error) ? error.message : String(error);
-      logger.error('V2 authentication failed', { status, error: message });
-      throw new Error(`Cerema V2 authentication failed: ${status}`);
-    }
+  if (!data.access) {
+    throw new Error('Cerema authentication response has no access token');
   }
-}
 
-/**
- * Creates an auth provider based on the configured auth version.
- */
-export function createAuthProvider(): CeremaAuthProvider {
-  const version = config.cerema.authVersion;
-  logger.debug(`Using Cerema auth version: ${version}`);
-
-  return version === 'v2'
-    ? new CeremaAuthProviderV2()
-    : new CeremaAuthProviderV1();
+  return {
+    apiUrl: config.cerema.api,
+    authorization: `Bearer ${data.access}`
+  };
 }

--- a/server/src/services/ceremaService/ceremaService.test.ts
+++ b/server/src/services/ceremaService/ceremaService.test.ts
@@ -6,8 +6,7 @@ import config from '~/infra/config';
 import { CeremaService } from './ceremaService';
 import type { CeremaGroup, CeremaPerimeter } from './consultUserService';
 
-const BASE_URL =
-  config.cerema.authVersion === 'v2' ? config.cerema.apiV2 : config.cerema.api;
+const BASE_URL = config.cerema.api;
 const TOKEN = 'test-token';
 
 const lovacGroup: CeremaGroup = {
@@ -37,23 +36,13 @@ const pastDate = new Date(Date.now() - 86_400_000).toISOString();
 const structure = { siret: '12345678900001', acces_lovac: futureDate };
 
 function interceptAuth() {
-  if (config.cerema.authVersion === 'v2') {
-    nock(BASE_URL)
-      .post('/api/token/')
-      .reply(200, { access: TOKEN, refresh: 'refresh-token' });
-    return;
-  }
-
-  nock(BASE_URL).post('/api/api-token-auth/').reply(200, { token: TOKEN });
+  nock(BASE_URL)
+    .post('/api/token/')
+    .reply(200, { access: TOKEN, refresh: 'refresh-token' });
 }
 
 function interceptAuthFailure() {
-  if (config.cerema.authVersion === 'v2') {
-    nock(BASE_URL).post('/api/token/').reply(401, 'Unauthorized');
-    return;
-  }
-
-  nock(BASE_URL).post('/api/api-token-auth/').reply(401, 'Unauthorized');
+  nock(BASE_URL).post('/api/token/').reply(401, 'Unauthorized');
 }
 
 function interceptUsers(email: string, users: object[]) {
@@ -87,6 +76,28 @@ afterEach(() => {
 
 describe('CeremaService', () => {
   describe('consultUsers', () => {
+    it('authenticates with JWT and uses the Bearer access token', async () => {
+      const email = 'user@test.fr';
+      const authScope = nock(BASE_URL)
+        .post('/api/token/', {
+          username: config.cerema.username,
+          password: config.cerema.password
+        })
+        .reply(200, { access: TOKEN, refresh: 'refresh-token' });
+      const usersScope = nock(BASE_URL)
+        .matchHeader('Authorization', `Bearer ${TOKEN}`)
+        .get('/api/utilisateurs')
+        .query({ email })
+        .reply(200, { results: [] });
+      const service = new CeremaService();
+
+      const result = await service.consultUsers(email);
+
+      expect(result).toEqual([]);
+      expect(authScope.isDone()).toBe(true);
+      expect(usersScope.isDone()).toBe(true);
+    });
+
     it('returns [] when auth fails', async () => {
       interceptAuthFailure();
       const service = new CeremaService();

--- a/server/src/services/ceremaService/ceremaService.ts
+++ b/server/src/services/ceremaService/ceremaService.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 
 import { logger } from '~/infra/logger';
 
-import { createAuthProvider, AuthResult } from './ceremaAuthProvider';
+import { authenticate, type CeremaAuth } from './ceremaAuthProvider';
 import {
   CeremaGroup,
   CeremaPerimeter,
@@ -37,9 +37,9 @@ function hasGroupLovacAccess(group: CeremaGroup): boolean {
   return group.niveau_acces === 'lovac' || group.lovac === true;
 }
 
-function authHeaders(auth: AuthResult) {
+function authHeaders(auth: CeremaAuth) {
   return {
-    Authorization: `${auth.authPrefix} ${auth.token}`,
+    Authorization: auth.authorization,
     'Content-Type': 'application/json'
   };
 }
@@ -48,7 +48,7 @@ function authHeaders(auth: AuthResult) {
  * Make an authenticated API call to Portail DF
  */
 async function fetchPortailDF<T>(
-  auth: AuthResult,
+  auth: CeremaAuth,
   endpoint: string
 ): Promise<T | null> {
   try {
@@ -63,11 +63,9 @@ async function fetchPortailDF<T>(
 }
 
 export class CeremaService implements ConsultUserService {
-  private authProvider = createAuthProvider();
-
   async consultUsers(email: string): Promise<CeremaUser[]> {
     try {
-      const auth = await this.authProvider.authenticate();
+      const auth = await authenticate();
 
       const { data: userContent } = await axios.get<{
         results: Array<{

--- a/server/src/services/ceremaService/userKindService.test.ts
+++ b/server/src/services/ceremaService/userKindService.test.ts
@@ -1,0 +1,63 @@
+import nock from 'nock';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import config from '~/infra/config';
+
+import { fetchUserKind } from './userKindService';
+
+const ACCESS_TOKEN = 'access-token';
+const originalCeremaEnabled = config.cerema.enabled;
+
+beforeEach(() => {
+  config.cerema.enabled = true;
+  nock.cleanAll();
+  nock.disableNetConnect();
+});
+
+afterEach(() => {
+  config.cerema.enabled = originalCeremaEnabled;
+  nock.cleanAll();
+  nock.enableNetConnect();
+  vi.unstubAllGlobals();
+});
+
+describe('fetchUserKind', () => {
+  it('uses the JWT access token as a Bearer credential', async () => {
+    const email = 'user+test@example.com';
+    const authScope = nock(config.cerema.api)
+      .post('/api/token/')
+      .reply(200, { access: ACCESS_TOKEN, refresh: 'refresh-token' });
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          count: 1,
+          next: null,
+          previous: null,
+          results: [
+            {
+              id_user: 1,
+              email,
+              exterieur: false,
+              gestionnaire: true
+            }
+          ]
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await fetchUserKind(email);
+
+    expect(result).toBe('gestionnaire');
+    expect(authScope.isDone()).toBe(true);
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${config.cerema.api}/api/utilisateurs?email=user%2Btest%40example.com`,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: `Bearer ${ACCESS_TOKEN}`
+        })
+      })
+    );
+  });
+});

--- a/server/src/services/ceremaService/userKindService.ts
+++ b/server/src/services/ceremaService/userKindService.ts
@@ -1,7 +1,7 @@
 import config from '~/infra/config';
 import { logger } from '~/infra/logger';
 
-import { createAuthProvider } from './ceremaAuthProvider';
+import { authenticate } from './ceremaAuthProvider';
 
 export interface PortailDFUser {
   id_user: number;
@@ -45,8 +45,6 @@ export function determineUserKind(
   }
 }
 
-const authProvider = createAuthProvider();
-
 /**
  * Fetch user kind from Portail DF API.
  *
@@ -63,7 +61,7 @@ export async function fetchUserKind(email: string): Promise<string | null> {
   }
 
   try {
-    const { token, authPrefix, apiUrl } = await authProvider.authenticate();
+    const { apiUrl, authorization } = await authenticate();
 
     // Fetch user data from Portail DF
     const userResponse = await fetch(
@@ -71,7 +69,7 @@ export async function fetchUserKind(email: string): Promise<string | null> {
       {
         method: 'GET',
         headers: {
-          Authorization: `${authPrefix} ${token}`,
+          Authorization: authorization,
           'Content-Type': 'application/json'
         }
       }


### PR DESCRIPTION
## Summary

- remove the legacy Portail DF token authentication path from the Node.js server
- use JWT Bearer authentication consistently in the server and Python scripts
- remove the transitional CEREMA_AUTH_VERSION and CEREMA_API_V2 configuration
- update operational and architecture documentation
- add focused TypeScript and Python tests, and run the Python tests in CI

## Why

The Portail DF JWT authentication flow is now the supported production path. Keeping both modes left legacy behavior available, made the old mode the default in some contexts, and allowed standalone scripts to keep targeting the retired authentication endpoint.

## Scope

- Node.js authentication provider and consumers
- Portail DF and user-kind Python scripts
- environment examples and Clever Cloud setup documentation
- architecture and installation documentation
- Python scripts CI coverage

Terraform and review-app definitions contained no remaining references to the transitional authentication variables, so no source change was required there.

## Deployment notes

- CEREMA_API is now the single Portail DF API base URL used by the server
- the target environment must expose the JWT token endpoint before deployment
- CEREMA_AUTH_VERSION and CEREMA_API_V2 can be removed from deployed environment variables after rollout
- staging must be validated against JWT authentication before this change is deployed there

## Validation

- 23 focused Vitest tests across authentication, service consumers, and configuration
- 2 focused pytest tests for the migrated Python authentication flows
- yarn nx typecheck server
- yarn nx build server
- yarn lint (passes with six pre-existing frontend warnings)
- oxfmt check on all changed supported files
- git diff --check
- GitHub Actions workflow YAML parse

## Related tickets

- [Decommission legacy Portail DF authentication](https://app.notion.com/p/Tech-D-commissionner-ancien-mode-de-connexion-portail-DF-31a9ec2a056c80d9a18ddd725b81c83b?pvs=21)
- [Portail DF access-token migration](https://app.notion.com/p/Portail-DF-Modifier-token-d-acc-s-Portail-DF-3199ec2a056c8042be14cc6b844eec71?pvs=21)