### PR TITLE
fix(establishments): use administrative kind for intercommunality filter

### DIFF
--- a/frontend/src/hooks/test/HousingFiltersContext.test.tsx
+++ b/frontend/src/hooks/test/HousingFiltersContext.test.tsx
@@ -9,11 +9,14 @@ import {
   genEstablishmentDTO,
   genUserDTO
 } from '@zerologementvacant/models/fixtures';
+import { http, HttpResponse } from 'msw';
 import type { PropsWithChildren } from 'react';
 import { Provider as StoreProvider } from 'react-redux';
 
 import data from '~/mocks/handlers/data';
+import { mockAPI } from '~/mocks/mock-api';
 import { MockAuthProvider, type MockAuthOptions } from '~/test/auth';
+import config from '~/utils/config';
 
 import configureTestStore from '../../utils/storeUtils';
 import {
@@ -203,6 +206,33 @@ describe('HousingFiltersContext', () => {
         intercommunalities: [intercommunality.id]
       });
       expect(result.current.filters.filters.localities).toBeUndefined();
+    });
+
+    it('loads intercommunalities by administrative kind', async () => {
+      const department: EstablishmentDTO = {
+        ...genEstablishmentDTO(),
+        kind: 'DEP',
+        geoCodes: ['06004', '06012', '06088']
+      };
+      let requestedKind: string | null = null;
+      let requestedKindAdmin: string | null = null;
+      mockAPI.use(
+        http.get(`${config.apiEndpoint}/establishments`, ({ request }) => {
+          const url = new URL(request.url);
+          requestedKind = url.searchParams.get('kind');
+          requestedKindAdmin = url.searchParams.get('kindAdmin');
+          return HttpResponse.json([]);
+        })
+      );
+
+      renderHook(() => useIntercommunalities(), {
+        wrapper: createWrapper(undefined, createAuthOptions(department))
+      });
+
+      await waitFor(() => {
+        expect(requestedKindAdmin).toBe('CA,CC,CU,METRO,EPT');
+      });
+      expect(requestedKind).toBeNull();
     });
   });
 

--- a/frontend/src/hooks/useIntercommunalities.ts
+++ b/frontend/src/hooks/useIntercommunalities.ts
@@ -1,4 +1,5 @@
 import {
+  INTERCOMMUNALITY_KIND_ADMIN_VALUES,
   isChild,
   isDepartmentalEstablishment
 } from '@zerologementvacant/models';
@@ -10,7 +11,7 @@ export function useIntercommunalities() {
   const { establishment } = useUser();
   const query = useFindEstablishmentsQuery(
     {
-      kindAdmin: ['CA', 'CC', 'CU', 'METRO', 'EPT'] // Intercommunalities
+      kindAdmin: [...INTERCOMMUNALITY_KIND_ADMIN_VALUES]
     },
     {
       skip: establishment && !isDepartmentalEstablishment(establishment)

--- a/frontend/src/hooks/useIntercommunalities.ts
+++ b/frontend/src/hooks/useIntercommunalities.ts
@@ -10,7 +10,7 @@ export function useIntercommunalities() {
   const { establishment } = useUser();
   const query = useFindEstablishmentsQuery(
     {
-      kind: ['CA', 'CC', 'CU', 'METRO', 'EPT'] // Intercommunalities
+      kindAdmin: ['CA', 'CC', 'CU', 'METRO', 'EPT'] // Intercommunalities
     },
     {
       skip: establishment && !isDepartmentalEstablishment(establishment)

--- a/packages/models/src/EstablishmentDTO.ts
+++ b/packages/models/src/EstablishmentDTO.ts
@@ -38,16 +38,3 @@ export function isDepartmentalEstablishment(
   ];
   return departments.includes(establishment.kind);
 }
-
-export function isIntercommunalityEstablishment(
-  establishment: Pick<EstablishmentDTO, 'kind'>
-): boolean {
-  const intercommunalities: ReadonlyArray<EstablishmentKind> = [
-    'CA',
-    'CC',
-    'CU',
-    'METRO',
-    'EPT'
-  ];
-  return intercommunalities.includes(establishment.kind);
-}

--- a/packages/models/src/EstablishmentFiltersDTO.ts
+++ b/packages/models/src/EstablishmentFiltersDTO.ts
@@ -7,7 +7,11 @@ export type EstablishmentFiltersDTO = Partial<
   name?: EstablishmentDTO['name'];
   kind?: EstablishmentDTO['kind'][];
   /**
-   * Filter by the administrative kind imported from the Gold source.
+   * Filter by the raw administrative kind imported from the Gold source.
+   *
+   * This vocabulary is intentionally open because Gold administrative-service
+   * codes can evolve. Values are limited to 50 characters by the import and
+   * database column.
    */
   kindAdmin?: string[];
   siren?: EstablishmentDTO['siren'][];

--- a/packages/models/src/EstablishmentFiltersDTO.ts
+++ b/packages/models/src/EstablishmentFiltersDTO.ts
@@ -6,6 +6,10 @@ export type EstablishmentFiltersDTO = Partial<
   id?: EstablishmentDTO['id'][];
   name?: EstablishmentDTO['name'];
   kind?: EstablishmentDTO['kind'][];
+  /**
+   * Filter by the administrative kind imported from the Gold source.
+   */
+  kindAdmin?: string[];
   siren?: EstablishmentDTO['siren'][];
   /**
    * Filter on active establishments (having at least one user)

--- a/packages/models/src/EstablishmentKindAdmin.ts
+++ b/packages/models/src/EstablishmentKindAdmin.ts
@@ -1,0 +1,13 @@
+/**
+ * Administrative kinds from the Gold source that represent intercommunalities.
+ *
+ * The complete `kind_admin` vocabulary is intentionally not enumerated here:
+ * Gold also exposes extensible administrative-service codes.
+ */
+export const INTERCOMMUNALITY_KIND_ADMIN_VALUES = [
+  'CA',
+  'CC',
+  'CU',
+  'METRO',
+  'EPT'
+] as const;

--- a/packages/models/src/index.ts
+++ b/packages/models/src/index.ts
@@ -19,6 +19,7 @@ export * from './OwnerEntity';
 export * from './EstablishmentDTO';
 export * from './EstablishmentFiltersDTO';
 export * from './EstablishmentKind';
+export * from './EstablishmentKindAdmin';
 export * from './EstablishmentSource';
 export * from './EventDTO';
 export * from './EventPayloads';

--- a/packages/schemas/src/establishment-filters.ts
+++ b/packages/schemas/src/establishment-filters.ts
@@ -18,6 +18,9 @@ export const establishmentFilters: ObjectSchema<EstablishmentFiltersDTO> =
     kind: array()
       .transform(commaSeparatedString)
       .of(string().oneOf(ESTABLISHMENT_KIND_VALUES).required()),
+    kindAdmin: array()
+      .transform(commaSeparatedString)
+      .of(string().trim().max(50).required()),
     siren: array().transform(commaSeparatedString).of(siren.required()),
     query: string().trim(),
     related: string().uuid()

--- a/server/src/controllers/test/establishment-api.test.ts
+++ b/server/src/controllers/test/establishment-api.test.ts
@@ -116,7 +116,9 @@ describe('Establishment API', () => {
 
     it('should filter establishments by administrative kind', async () => {
       const [metropolis, otherIntercommunality] = await Promise.all([
-        factories.establishment.create({ geoCodes: ['06004', '06012', '06088'] }),
+        factories.establishment.create({
+          geoCodes: ['06004', '06012', '06088']
+        }),
         factories.establishment.create({
           geoCodes: ['06004', '06012'],
           kind: 'METRO'
@@ -147,7 +149,7 @@ describe('Establishment API', () => {
       expect(ids).not.toContain(otherIntercommunality.id);
     });
 
-    it('should fall back to legacy kind when administrative kind is missing', async () => {
+    it('should not mix legacy and administrative kinds', async () => {
       const legacyIntercommunality = await factories.establishment.create({
         geoCodes: ['06004', '06012'],
         kind: 'CA'
@@ -160,7 +162,7 @@ describe('Establishment API', () => {
       expect(status).toBe(constants.HTTP_STATUS_OK);
       expect(
         body.map((establishment: EstablishmentApi) => establishment.id)
-      ).toContain(legacyIntercommunality.id);
+      ).not.toContain(legacyIntercommunality.id);
     });
 
     it('should search establishments by query', async () => {

--- a/server/src/controllers/test/establishment-api.test.ts
+++ b/server/src/controllers/test/establishment-api.test.ts
@@ -11,6 +11,7 @@ import {
 import { GEO_CODE_REGEXP } from '@zerologementvacant/schemas';
 import request from 'supertest';
 
+import { kysely } from '~/infra/database/kysely';
 import { createServer } from '~/infra/server';
 import { EstablishmentApi } from '~/models/EstablishmentApi';
 import type { UserApi } from '~/models/UserApi';
@@ -46,6 +47,14 @@ describe('Establishment API', () => {
           nil: undefined
         }
       ),
+      kindAdmin: fc.option(
+        fc.array(fc.stringMatching(/^[A-Z][A-Z-]{0,49}$/), {
+          minLength: 1
+        }),
+        {
+          nil: undefined
+        }
+      ),
       name: fc.option(fc.string(), { nil: undefined }),
       geoCodes: fc.option(
         fc.array(fc.stringMatching(GEO_CODE_REGEXP), {
@@ -71,6 +80,7 @@ describe('Establishment API', () => {
           id: query.id?.join(','),
           available: query.available,
           kind: query.kind?.join(','),
+          kindAdmin: query.kindAdmin?.join(','),
           name: query.name,
           geoCodes: query.geoCodes?.join(','),
           siren: query.siren?.join(','),
@@ -102,6 +112,55 @@ describe('Establishment API', () => {
       expect(body).toSatisfyAll<EstablishmentApi>((establishment) => {
         return establishment.available;
       });
+    });
+
+    it('should filter establishments by administrative kind', async () => {
+      const [metropolis, otherIntercommunality] = await Promise.all([
+        factories.establishment.create({ geoCodes: ['06004', '06012', '06088'] }),
+        factories.establishment.create({
+          geoCodes: ['06004', '06012'],
+          kind: 'METRO'
+        })
+      ]);
+      await Promise.all([
+        kysely
+          .updateTable('establishments')
+          .set({ kind: 'ME', kindAdmin: 'METRO' })
+          .where('id', '=', metropolis.id)
+          .execute(),
+        kysely
+          .updateTable('establishments')
+          .set({ kindAdmin: 'CA' })
+          .where('id', '=', otherIntercommunality.id)
+          .execute()
+      ]);
+
+      const { body, status } = await request(url)
+        .get(testRoute)
+        .query({ kindAdmin: 'METRO' });
+
+      expect(status).toBe(constants.HTTP_STATUS_OK);
+      const ids = body.map(
+        (establishment: EstablishmentApi) => establishment.id
+      );
+      expect(ids).toContain(metropolis.id);
+      expect(ids).not.toContain(otherIntercommunality.id);
+    });
+
+    it('should fall back to legacy kind when administrative kind is missing', async () => {
+      const legacyIntercommunality = await factories.establishment.create({
+        geoCodes: ['06004', '06012'],
+        kind: 'CA'
+      });
+
+      const { body, status } = await request(url)
+        .get(testRoute)
+        .query({ kindAdmin: 'CA' });
+
+      expect(status).toBe(constants.HTTP_STATUS_OK);
+      expect(
+        body.map((establishment: EstablishmentApi) => establishment.id)
+      ).toContain(legacyIntercommunality.id);
     });
 
     it('should search establishments by query', async () => {

--- a/server/src/infra/openapi.yaml
+++ b/server/src/infra/openapi.yaml
@@ -1959,8 +1959,13 @@ paths:
             type: array
             items:
               type: string
+              minLength: 1
               maxLength: 50
-          description: Filtrer par nature administrative issue du référentiel Gold, avec repli sur le type historique si elle est absente
+            example: [CA, CC, CU, METRO, EPT]
+          description: >-
+            Filtrer par code administratif brut issu du référentiel Gold.
+            Le vocabulaire est extensible ; les codes d'intercommunalité
+            actuellement utilisés sont CA, CC, CU, METRO et EPT.
       responses:
         '200':
           description: Liste des établissements

--- a/server/src/infra/openapi.yaml
+++ b/server/src/infra/openapi.yaml
@@ -1951,6 +1951,16 @@ paths:
           schema:
             type: boolean
           description: Filtrer les établissements disponibles pour inscription
+        - in: query
+          name: kindAdmin
+          style: form
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+              maxLength: 50
+          description: Filtrer par nature administrative issue du référentiel Gold, avec repli sur le type historique si elle est absente
       responses:
         '200':
           description: Liste des établissements

--- a/server/src/repositories/establishmentRepository.ts
+++ b/server/src/repositories/establishmentRepository.ts
@@ -183,6 +183,21 @@ function listQuery(opts?: ListOptions) {
     .$if(!!filters?.kind, (query) =>
       query.where('establishments.kind', 'in', filters?.kind ?? [])
     )
+    .$if(!!filters?.kindAdmin, (query) =>
+      query.where((eb) =>
+        eb.or([
+          eb(
+            'establishments.kindAdmin',
+            'in',
+            filters?.kindAdmin ?? []
+          ),
+          eb.and([
+            eb('establishments.kindAdmin', 'is', null),
+            eb('establishments.kind', 'in', filters?.kindAdmin ?? [])
+          ])
+        ])
+      )
+    )
     .$if(!!filters?.name, (query) =>
       query.where(
         sql<boolean>`lower(unaccent(regexp_replace(regexp_replace(establishments.name, '''| [(].*[)]', '', 'g'), ' | - ', '-', 'g'))) like '%' || ${filters?.name}`

--- a/server/src/repositories/establishmentRepository.ts
+++ b/server/src/repositories/establishmentRepository.ts
@@ -184,19 +184,7 @@ function listQuery(opts?: ListOptions) {
       query.where('establishments.kind', 'in', filters?.kind ?? [])
     )
     .$if(!!filters?.kindAdmin, (query) =>
-      query.where((eb) =>
-        eb.or([
-          eb(
-            'establishments.kindAdmin',
-            'in',
-            filters?.kindAdmin ?? []
-          ),
-          eb.and([
-            eb('establishments.kindAdmin', 'is', null),
-            eb('establishments.kind', 'in', filters?.kindAdmin ?? [])
-          ])
-        ])
-      )
+      query.where('establishments.kindAdmin', 'in', filters?.kindAdmin ?? [])
     )
     .$if(!!filters?.name, (query) =>
       query.where(

--- a/server/src/repositories/test/localityRepository.test.ts
+++ b/server/src/repositories/test/localityRepository.test.ts
@@ -9,14 +9,15 @@ import localityRepository, { toLocalityInsert } from '../localityRepository';
 describe('Locality repository', () => {
   describe('find', () => {
     describe('geoCodes filter', () => {
-      const locality1 = genLocalityApi();
-      const locality2 = genLocalityApi();
+      const locality1 = genLocalityApi('01001');
+      const locality2 = genLocalityApi('01002');
 
       beforeAll(async () => {
         await factories.establishment.create();
         await kysely
           .insertInto('localities')
           .values([toLocalityInsert(locality1), toLocalityInsert(locality2)])
+          .onConflict((conflict) => conflict.column('geoCode').doNothing())
           .execute();
       });
 
@@ -49,11 +50,12 @@ describe('Locality repository', () => {
 
     describe('establishmentId filter', () => {
       it('should return only localities within the establishment geoCodes', async () => {
-        const locality1 = genLocalityApi();
-        const locality2 = genLocalityApi();
+        const locality1 = genLocalityApi('01003');
+        const locality2 = genLocalityApi('01004');
         await kysely
           .insertInto('localities')
           .values([toLocalityInsert(locality1), toLocalityInsert(locality2)])
+          .onConflict((conflict) => conflict.column('geoCode').doNothing())
           .execute();
         const establishment = await factories.establishment.create({
           geoCodes: [locality1.geoCode]


### PR DESCRIPTION
## What changed

- Add an additive `kindAdmin` filter to the establishments endpoint.
- Filter strictly on the Gold `kind_admin` column.
- Use this administrative filter when loading intercommunality options.
- Keep the existing legacy `kind` filter unchanged for compatibility.
- Centralize the five intercommunality codes: `CA`, `CC`, `CU`, `METRO` and `EPT`.
- Document the open Gold vocabulary and CSV query format in OpenAPI.

## Why

The intercommunality filter requested `METRO`, but the backend searched the legacy `kind` column. Métropole Nice Côte d’Azur has `kind = ME` and `kind_admin = METRO`, so it was excluded before the geographic filtering for Alpes-Maritimes.

`kind_admin` is maintained by the Gold establishment import and is the correct source for selecting intercommunalities.

## Data audit

The local production clone contains 36,791 establishments:

- 36,787 have a non-empty `kind_admin` (99.989%).
- All 36,787 Gold 2025 establishments have `kind_admin` populated.
- Only four rows are null: three seeds and one manual establishment.
- The five intercommunality codes select 1,266 Gold establishments: 230 CA, 989 CC, 14 CU, 22 METRO and 11 EPT.

The null rows do not justify a fallback to `kind`: the two fields use different taxonomies (`ME`/`METRO`, `SIVOM`/`EPT`, `SDED`/`DDT`, etc.). The endpoint therefore filters `kind_admin` strictly.

The generic `kindAdmin` parameter remains a string limited to 50 characters rather than a closed enum. Gold currently exposes 27 codes in the database and 29 in the source CSV files, and administrative-service codes can evolve. The five intercommunality values used by this feature are nevertheless defined as a closed typed constant.

## Validation

- Server establishment API tests: 12 passed
- Frontend housing filter tests: 15 passed
- Full Nx typecheck: 10 projects passed
- Formatting and lint checks passed
- OpenAPI YAML parsing passed
