### PR TITLE
test: stabilize flaky CI tests

### DIFF
--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -1,4 +1,5 @@
 import '@testing-library/jest-dom';
+import { configure } from '@testing-library/react';
 import * as extended from 'jest-extended';
 import 'jest-sorted';
 import { afterAll, afterEach, beforeAll, expect, vi } from 'vitest';
@@ -6,6 +7,10 @@ import { afterAll, afterEach, beforeAll, expect, vi } from 'vitest';
 import data from './src/mocks/handlers/data';
 import { mockAPI } from './src/mocks/mock-api';
 import EventSourceMock from './src/test/event-source-mock';
+
+// Heavy views can take longer than Testing Library's default one-second
+// async query timeout to render on loaded CI runners.
+configure({ asyncUtilTimeout: 10_000 });
 
 expect.extend(extended);
 // expect.extend(sorted);

--- a/server/src/repositories/test/housingRepository.test.ts
+++ b/server/src/repositories/test/housingRepository.test.ts
@@ -2606,10 +2606,12 @@ describe('Housing repository', () => {
 
       describe('by beneficiary count', () => {
         const geoCode = oneOf(establishment.geoCodes);
+        let housingIds: string[];
 
         beforeEach(async () => {
           const housingWith2 = genHousingApi(geoCode);
           const housingWith1 = genHousingApi(geoCode);
+          housingIds = [housingWith2.id, housingWith1.id];
           const owners = faker.helpers.multiple(() => genOwnerApi(), {
             count: 3
           });
@@ -2627,6 +2629,7 @@ describe('Housing repository', () => {
           const result = await housingRepository.count({
             establishmentIds: [establishment.id],
             beneficiaryCounts: ['2'],
+            housingIds,
             localities: [geoCode]
           });
 


### PR DESCRIPTION
## What

- Increase Testing Library's asynchronous query timeout to 10 seconds for heavy frontend views on loaded CI runners.
- Scope the beneficiary-count repository test to the housing fixtures it creates.

## Why

The `Main` workflow failed nondeterministically twice on commit `e19624e`:

- a frontend `findBy*` query failed after 1.099 seconds, matching Testing Library's default one-second async timeout;
- the beneficiary-count repository test returned 2 instead of 1 because it queried a shared test database without limiting the count to its own fixtures.

Both failures moved or disappeared when the exact same commit was rerun, confirming test-suite instability rather than a product regression.

## Impact

Test infrastructure only. There is no production-code, API, database-schema, or user-interface behavior change.

## Validation

- `yarn nx test frontend -- src/views/Housing/test/HousingOwnersView.test.tsx` — 15/15 passed
- `yarn nx test frontend -- src/views/HousingList/test/HousingListView.campaignFlows.test.tsx` — 4/4 passed
- `yarn nx test server -- src/repositories/test/housingRepository.test.ts` — 169/169 passed against an isolated PostgreSQL database
- `yarn typecheck` — 10/10 projects passed
- `yarn lint` — passed with pre-existing warnings only
- `yarn format` — passed
- `git diff --check` — passed

## Residual risk

A genuinely missing element queried with `findBy*` can now take up to 10 seconds to report a failure. The complete coverage suite was not run locally; GitHub Actions remains the full-suite validation.
