### PR TITLE
fix(frontend): recover from stale Vite chunks

### DIFF
--- a/frontend/public/.htaccess
+++ b/frontend/public/.htaccess
@@ -3,10 +3,9 @@
     Header set Cache-Control "no-cache"
   </Files>
 
-  # Vite assets include an eight-character content hash in their filename.
-  <FilesMatch "-[A-Za-z0-9_-]{8}\.[^.]+$">
+  <If "%{REQUEST_URI} =~ m#^/assets/#">
     Header set Cache-Control "public, max-age=31536000, immutable"
-  </FilesMatch>
+  </If>
 </IfModule>
 
 RewriteEngine On

--- a/frontend/public/.htaccess
+++ b/frontend/public/.htaccess
@@ -1,9 +1,23 @@
+<IfModule mod_headers.c>
+  <Files "index.html">
+    Header set Cache-Control "no-cache"
+  </Files>
+
+  # Vite assets include an eight-character content hash in their filename.
+  <FilesMatch "-[A-Za-z0-9_-]{8}\.[^.]+$">
+    Header set Cache-Control "public, max-age=31536000, immutable"
+  </FilesMatch>
+</IfModule>
+
 RewriteEngine On
 
 # If an existing asset or directory is requested, serve it
-RewriteCond %{DOCUMENT_ROOT}%{REQUEST_URI} -f [OR]
-RewriteCond %{DOCUMENT_ROOT}%{REQUEST_URI} -d
+RewriteCond %{REQUEST_FILENAME} -f [OR]
+RewriteCond %{REQUEST_FILENAME} -d
 RewriteRule ^ - [L]
 
+# Missing Vite assets must return an error instead of the SPA HTML fallback
+RewriteRule ^assets(?:/|$) - [R=404,L]
+
 # If the requested resource doesn't exist, use index.html
-RewriteRule ^ /index.html
+RewriteRule ^ /index.html [L]

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -7,6 +7,8 @@ import { MapProvider } from 'react-map-gl/maplibre';
 import { Provider as StoreProvider } from 'react-redux';
 import { Link } from 'react-router';
 
+import { registerPreloadErrorRecovery } from '~/utils/preloadError';
+
 import App from './App';
 import Notification from './components/Notification/Notification';
 import { store } from './store/store';
@@ -14,6 +16,7 @@ import ThemeProvider from './theme';
 import config from './utils/config';
 import sentry from './utils/sentry';
 
+registerPreloadErrorRecovery();
 sentry.init();
 
 startReactDsfr({

--- a/frontend/src/utils/preloadError.ts
+++ b/frontend/src/utils/preloadError.ts
@@ -51,15 +51,17 @@ export function registerPreloadErrorRecovery(
   const showRecovery = options.showRecovery ?? showDefaultRecovery;
   let recoveryPending = false;
 
-  const onPreloadError = () => {
+  const onPreloadError = (event: Event) => {
     if (recoveryPending) {
+      event.preventDefault();
       return;
     }
 
     const currentTime = now();
+    let storage: Pick<Storage, 'getItem' | 'setItem'>;
 
     try {
-      const storage = getStorage();
+      storage = getStorage();
       const storedReloadAt = storage.getItem(PRELOAD_ERROR_RELOAD_KEY);
       const lastReloadAt = storedReloadAt ? Number(storedReloadAt) : null;
 
@@ -70,8 +72,6 @@ export function registerPreloadErrorRecovery(
           return;
         }
       }
-
-      storage.setItem(PRELOAD_ERROR_RELOAD_KEY, currentTime.toString());
     } catch {
       return;
     }
@@ -82,7 +82,15 @@ export function registerPreloadErrorRecovery(
       return;
     }
 
+    try {
+      storage.setItem(PRELOAD_ERROR_RELOAD_KEY, currentTime.toString());
+    } catch {
+      // Recovery is already visible. A missing cooldown is preferable to
+      // hiding the only action that can restore a stale application.
+    }
+
     recoveryPending = true;
+    event.preventDefault();
   };
 
   eventTarget.addEventListener('vite:preloadError', onPreloadError);

--- a/frontend/src/utils/preloadError.ts
+++ b/frontend/src/utils/preloadError.ts
@@ -19,7 +19,7 @@ function showDefaultRecovery(reload: () => void): void {
 
   title.id = `${PRELOAD_ERROR_RECOVERY_ID}-title`;
   title.className = 'fr-alert__title';
-  title.textContent = 'L’application a été mise à jour';
+  title.textContent = 'Une ressource n’a pas pu être chargée';
 
   description.textContent =
     'Rechargez la page pour continuer. Vous retrouverez la page en cours.';
@@ -31,7 +31,6 @@ function showDefaultRecovery(reload: () => void): void {
 
   alert.append(title, description, button);
   document.body.prepend(alert);
-  button.focus();
 }
 
 interface PreloadErrorRecoveryOptions {

--- a/frontend/src/utils/preloadError.ts
+++ b/frontend/src/utils/preloadError.ts
@@ -1,0 +1,94 @@
+const PRELOAD_ERROR_RELOAD_KEY = 'zlv:preload-error-reload-at';
+const PRELOAD_ERROR_RELOAD_COOLDOWN = 60_000;
+const PRELOAD_ERROR_RECOVERY_ID = 'vite-preload-error-recovery';
+
+function showDefaultRecovery(reload: () => void): void {
+  if (document.getElementById(PRELOAD_ERROR_RECOVERY_ID)) {
+    return;
+  }
+
+  const alert = document.createElement('section');
+  const title = document.createElement('p');
+  const description = document.createElement('p');
+  const button = document.createElement('button');
+
+  alert.id = PRELOAD_ERROR_RECOVERY_ID;
+  alert.className = 'fr-alert fr-alert--warning fr-m-2w';
+  alert.setAttribute('role', 'alert');
+  alert.setAttribute('aria-labelledby', `${PRELOAD_ERROR_RECOVERY_ID}-title`);
+
+  title.id = `${PRELOAD_ERROR_RECOVERY_ID}-title`;
+  title.className = 'fr-alert__title';
+  title.textContent = 'L’application a été mise à jour';
+
+  description.textContent =
+    'Rechargez la page pour continuer. Vous retrouverez la page en cours.';
+
+  button.type = 'button';
+  button.className = 'fr-btn fr-mt-2w';
+  button.textContent = 'Recharger l’application';
+  button.addEventListener('click', reload, { once: true });
+
+  alert.append(title, description, button);
+  document.body.prepend(alert);
+  button.focus();
+}
+
+interface PreloadErrorRecoveryOptions {
+  eventTarget?: Pick<EventTarget, 'addEventListener' | 'removeEventListener'>;
+  getStorage?: () => Pick<Storage, 'getItem' | 'setItem'>;
+  now?: () => number;
+  reload?: () => void;
+  showRecovery?: (reload: () => void) => void;
+}
+
+export function registerPreloadErrorRecovery(
+  options: PreloadErrorRecoveryOptions = {}
+): () => void {
+  const eventTarget = options.eventTarget ?? window;
+  const getStorage = options.getStorage ?? (() => window.sessionStorage);
+  const now = options.now ?? Date.now;
+  const reload = options.reload ?? (() => window.location.reload());
+  const showRecovery = options.showRecovery ?? showDefaultRecovery;
+  let recoveryPending = false;
+
+  const onPreloadError = () => {
+    if (recoveryPending) {
+      return;
+    }
+
+    const currentTime = now();
+
+    try {
+      const storage = getStorage();
+      const storedReloadAt = storage.getItem(PRELOAD_ERROR_RELOAD_KEY);
+      const lastReloadAt = storedReloadAt ? Number(storedReloadAt) : null;
+
+      if (lastReloadAt !== null && Number.isFinite(lastReloadAt)) {
+        const elapsed = currentTime - lastReloadAt;
+
+        if (elapsed >= 0 && elapsed < PRELOAD_ERROR_RELOAD_COOLDOWN) {
+          return;
+        }
+      }
+
+      storage.setItem(PRELOAD_ERROR_RELOAD_KEY, currentTime.toString());
+    } catch {
+      return;
+    }
+
+    try {
+      showRecovery(reload);
+    } catch {
+      return;
+    }
+
+    recoveryPending = true;
+  };
+
+  eventTarget.addEventListener('vite:preloadError', onPreloadError);
+
+  return () => {
+    eventTarget.removeEventListener('vite:preloadError', onPreloadError);
+  };
+}

--- a/frontend/src/utils/test/preloadError.test.ts
+++ b/frontend/src/utils/test/preloadError.test.ts
@@ -25,8 +25,8 @@ describe('Preload error recovery', () => {
     window.dispatchEvent(firstEvent);
     window.dispatchEvent(secondEvent);
 
-    expect(firstEvent.defaultPrevented).toBeFalse();
-    expect(secondEvent.defaultPrevented).toBeFalse();
+    expect(firstEvent.defaultPrevented).toBeTrue();
+    expect(secondEvent.defaultPrevented).toBeTrue();
     expect(showRecovery).toHaveBeenCalledOnce();
     expect(reload).not.toHaveBeenCalled();
 
@@ -80,7 +80,7 @@ describe('Preload error recovery', () => {
     const secondEvent = new Event('vite:preloadError', { cancelable: true });
     window.dispatchEvent(secondEvent);
 
-    expect(secondEvent.defaultPrevented).toBeFalse();
+    expect(secondEvent.defaultPrevented).toBeTrue();
     expect(firstShowRecovery).toHaveBeenCalledOnce();
     expect(secondShowRecovery).toHaveBeenCalledOnce();
     expect(reload).not.toHaveBeenCalled();
@@ -102,7 +102,7 @@ describe('Preload error recovery', () => {
     expect(reload).not.toHaveBeenCalled();
   });
 
-  it('should keep the error visible if the reload guard cannot be written', () => {
+  it('should offer recovery if the reload guard cannot be written', () => {
     const reload = vi.fn();
     const showRecovery = vi.fn();
     unregister = registerPreloadErrorRecovery({
@@ -119,9 +119,29 @@ describe('Preload error recovery', () => {
 
     window.dispatchEvent(event);
 
-    expect(event.defaultPrevented).toBeFalse();
-    expect(showRecovery).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBeTrue();
+    expect(showRecovery).toHaveBeenCalledOnce();
     expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('should retry showing recovery when a previous attempt failed', () => {
+    const showRecovery = vi.fn(() => {
+      throw new Error('Recovery rendering failed');
+    });
+    unregister = registerPreloadErrorRecovery({
+      showRecovery,
+      now: () => 100_000
+    });
+    const firstEvent = new Event('vite:preloadError', { cancelable: true });
+    const secondEvent = new Event('vite:preloadError', { cancelable: true });
+
+    window.dispatchEvent(firstEvent);
+    window.dispatchEvent(secondEvent);
+
+    expect(showRecovery).toHaveBeenCalledTimes(2);
+    expect(firstEvent.defaultPrevented).toBeFalse();
+    expect(secondEvent.defaultPrevented).toBeFalse();
+    expect(sessionStorage.getItem('zlv:preload-error-reload-at')).toBeNull();
   });
 
   it('should recover when the stored reload timestamp is corrupted', () => {
@@ -137,7 +157,7 @@ describe('Preload error recovery', () => {
 
     window.dispatchEvent(event);
 
-    expect(event.defaultPrevented).toBeFalse();
+    expect(event.defaultPrevented).toBeTrue();
     expect(showRecovery).toHaveBeenCalledOnce();
     expect(reload).not.toHaveBeenCalled();
   });
@@ -155,7 +175,7 @@ describe('Preload error recovery', () => {
 
     window.dispatchEvent(event);
 
-    expect(event.defaultPrevented).toBeFalse();
+    expect(event.defaultPrevented).toBeTrue();
     expect(showRecovery).toHaveBeenCalledOnce();
     expect(reload).not.toHaveBeenCalled();
   });

--- a/frontend/src/utils/test/preloadError.test.ts
+++ b/frontend/src/utils/test/preloadError.test.ts
@@ -8,6 +8,7 @@ describe('Preload error recovery', () => {
     unregister = undefined;
     sessionStorage.clear();
     document.getElementById('vite-preload-error-recovery')?.remove();
+    document.getElementById('preload-error-existing-control')?.remove();
   });
 
   it('should offer recovery only once when a stale dynamic import fails', () => {
@@ -159,8 +160,12 @@ describe('Preload error recovery', () => {
     expect(reload).not.toHaveBeenCalled();
   });
 
-  it('should show an accessible reload action and wait for its activation', () => {
+  it('should show an accessible reload action without moving the focus', () => {
     const reload = vi.fn();
+    const existingControl = document.createElement('button');
+    existingControl.id = 'preload-error-existing-control';
+    document.body.append(existingControl);
+    existingControl.focus();
     unregister = registerPreloadErrorRecovery({
       reload,
       now: () => 100_000
@@ -171,13 +176,13 @@ describe('Preload error recovery', () => {
 
     const alert = document.querySelector('[role="alert"]');
     const button = alert?.querySelector('button');
-    expect(alert).toHaveAccessibleName('L’application a été mise à jour');
-    expect(alert).toHaveTextContent('L’application a été mise à jour');
+    expect(alert).toHaveAccessibleName('Une ressource n’a pas pu être chargée');
+    expect(alert).toHaveTextContent('Une ressource n’a pas pu être chargée');
     expect(alert).toHaveTextContent(
       'Rechargez la page pour continuer. Vous retrouverez la page en cours.'
     );
     expect(button).toHaveAccessibleName('Recharger l’application');
-    expect(button).toHaveFocus();
+    expect(existingControl).toHaveFocus();
     expect(alert?.querySelector('h1, h2, h3, h4, h5, h6')).toBeNull();
     expect(reload).not.toHaveBeenCalled();
 

--- a/frontend/src/utils/test/preloadError.test.ts
+++ b/frontend/src/utils/test/preloadError.test.ts
@@ -1,0 +1,188 @@
+import { registerPreloadErrorRecovery } from '../preloadError';
+
+describe('Preload error recovery', () => {
+  let unregister: (() => void) | undefined;
+
+  afterEach(() => {
+    unregister?.();
+    unregister = undefined;
+    sessionStorage.clear();
+    document.getElementById('vite-preload-error-recovery')?.remove();
+  });
+
+  it('should offer recovery only once when a stale dynamic import fails', () => {
+    const reload = vi.fn();
+    const showRecovery = vi.fn();
+    unregister = registerPreloadErrorRecovery({
+      reload,
+      showRecovery,
+      now: () => 100_000
+    });
+    const firstEvent = new Event('vite:preloadError', { cancelable: true });
+    const secondEvent = new Event('vite:preloadError', { cancelable: true });
+
+    window.dispatchEvent(firstEvent);
+    window.dispatchEvent(secondEvent);
+
+    expect(firstEvent.defaultPrevented).toBeFalse();
+    expect(secondEvent.defaultPrevented).toBeFalse();
+    expect(showRecovery).toHaveBeenCalledOnce();
+    expect(reload).not.toHaveBeenCalled();
+
+    showRecovery.mock.calls[0]?.[0]();
+
+    expect(reload).toHaveBeenCalledOnce();
+  });
+
+  it('should expose the normal error after a recovery attempt within the cooldown', () => {
+    const firstShowRecovery = vi.fn();
+    unregister = registerPreloadErrorRecovery({
+      showRecovery: firstShowRecovery,
+      now: () => 100_000
+    });
+    window.dispatchEvent(new Event('vite:preloadError', { cancelable: true }));
+    unregister();
+
+    const secondShowRecovery = vi.fn();
+    unregister = registerPreloadErrorRecovery({
+      showRecovery: secondShowRecovery,
+      now: () => 100_000
+    });
+    const secondEvent = new Event('vite:preloadError', { cancelable: true });
+    window.dispatchEvent(secondEvent);
+
+    expect(firstShowRecovery).toHaveBeenCalledOnce();
+    expect(secondShowRecovery).not.toHaveBeenCalled();
+    expect(secondEvent.defaultPrevented).toBeFalse();
+  });
+
+  it('should allow a new recovery attempt after the cooldown', () => {
+    const reload = vi.fn();
+    const firstShowRecovery = vi.fn();
+    let currentTime = 100_000;
+    unregister = registerPreloadErrorRecovery({
+      reload,
+      showRecovery: firstShowRecovery,
+      now: () => currentTime
+    });
+    const firstEvent = new Event('vite:preloadError', { cancelable: true });
+    window.dispatchEvent(firstEvent);
+    unregister();
+
+    currentTime += 60_001;
+    const secondShowRecovery = vi.fn();
+    unregister = registerPreloadErrorRecovery({
+      reload,
+      showRecovery: secondShowRecovery,
+      now: () => currentTime
+    });
+    const secondEvent = new Event('vite:preloadError', { cancelable: true });
+    window.dispatchEvent(secondEvent);
+
+    expect(secondEvent.defaultPrevented).toBeFalse();
+    expect(firstShowRecovery).toHaveBeenCalledOnce();
+    expect(secondShowRecovery).toHaveBeenCalledOnce();
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('should keep the error visible if the reload guard cannot be persisted', () => {
+    const reload = vi.fn();
+    unregister = registerPreloadErrorRecovery({
+      reload,
+      getStorage: () => {
+        throw new DOMException('Storage is unavailable');
+      }
+    });
+    const event = new Event('vite:preloadError', { cancelable: true });
+
+    window.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBeFalse();
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('should keep the error visible if the reload guard cannot be written', () => {
+    const reload = vi.fn();
+    const showRecovery = vi.fn();
+    unregister = registerPreloadErrorRecovery({
+      reload,
+      showRecovery,
+      getStorage: () => ({
+        getItem: () => null,
+        setItem: () => {
+          throw new DOMException('Storage is read-only');
+        }
+      })
+    });
+    const event = new Event('vite:preloadError', { cancelable: true });
+
+    window.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBeFalse();
+    expect(showRecovery).not.toHaveBeenCalled();
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('should recover when the stored reload timestamp is corrupted', () => {
+    const reload = vi.fn();
+    const showRecovery = vi.fn();
+    sessionStorage.setItem('zlv:preload-error-reload-at', '100000-corrupted');
+    unregister = registerPreloadErrorRecovery({
+      reload,
+      showRecovery,
+      now: () => 100_000
+    });
+    const event = new Event('vite:preloadError', { cancelable: true });
+
+    window.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBeFalse();
+    expect(showRecovery).toHaveBeenCalledOnce();
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('should recover when the stored reload timestamp is in the future', () => {
+    const reload = vi.fn();
+    const showRecovery = vi.fn();
+    sessionStorage.setItem('zlv:preload-error-reload-at', '200000');
+    unregister = registerPreloadErrorRecovery({
+      reload,
+      showRecovery,
+      now: () => 100_000
+    });
+    const event = new Event('vite:preloadError', { cancelable: true });
+
+    window.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBeFalse();
+    expect(showRecovery).toHaveBeenCalledOnce();
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('should show an accessible reload action and wait for its activation', () => {
+    const reload = vi.fn();
+    unregister = registerPreloadErrorRecovery({
+      reload,
+      now: () => 100_000
+    });
+    const event = new Event('vite:preloadError', { cancelable: true });
+
+    window.dispatchEvent(event);
+
+    const alert = document.querySelector('[role="alert"]');
+    const button = alert?.querySelector('button');
+    expect(alert).toHaveAccessibleName('L’application a été mise à jour');
+    expect(alert).toHaveTextContent('L’application a été mise à jour');
+    expect(alert).toHaveTextContent(
+      'Rechargez la page pour continuer. Vous retrouverez la page en cours.'
+    );
+    expect(button).toHaveAccessibleName('Recharger l’application');
+    expect(button).toHaveFocus();
+    expect(alert?.querySelector('h1, h2, h3, h4, h5, h6')).toBeNull();
+    expect(reload).not.toHaveBeenCalled();
+
+    button?.click();
+
+    expect(reload).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## What

- Configure Apache to serve `index.html` and SPA route fallbacks with `Cache-Control: no-cache`.
- Cache content-hashed Vite assets as immutable for one year.
- Return a real `404` for missing `/assets/*` files instead of rewriting them to the SPA HTML document.
- Handle Vite's `vite:preloadError` event with an accessible DSFR warning and an explicit reload action.
- Prevent repeated recovery prompts with a guarded 60-second `sessionStorage` cooldown.

## Why

After the production deployment, tabs that were already open still referenced an old `CampaignListView` chunk that had been removed by the new build. Apache rewrote that missing JavaScript URL to `index.html` and returned it as `200 text/html`, so the browser could not load the dynamic import and React Router displayed an unexpected application error.

This change addresses both sides of the incident: browsers revalidate the application shell after deployments, missing chunks no longer masquerade as JavaScript, and stale sessions receive a clear recovery action.

## Impact

- Fresh sessions keep long-lived caching for fingerprinted assets.
- Stale sessions can reload the current route to pick up the latest asset manifest.
- Reloading remains under the user's control; no automatic context change is triggered.
- No API, database, or domain-model change.

## Accessibility

- The recovery message uses `role="alert"`, an accessible name, and a native button.
- The alert is announced without moving the user's current focus.
- The alert title is not a heading, preserving each page's existing heading hierarchy.
- The page reload occurs only after user activation, in line with RGAA 7.4.

## Validation

- `yarn nx test frontend -- src/utils/test/preloadError.test.ts` — 8/8 passed
- `yarn nx typecheck frontend` — passed
- `yarn oxlint frontend/src/utils/preloadError.ts frontend/src/utils/test/preloadError.test.ts` — passed
- `yarn oxfmt --check frontend/src/utils/preloadError.ts frontend/src/utils/test/preloadError.test.ts` — passed
- `yarn nx build frontend` — passed
- `git diff --check` — passed
- Apache 2.4 smoke test against the production build:
  - `/` and `/campagnes` return `200 text/html` with `Cache-Control: no-cache`
  - an existing fingerprinted campaign chunk returns `200 text/javascript` with `Cache-Control: public, max-age=31536000, immutable`
  - a missing campaign chunk returns `404` and is not rewritten to the SPA document

## Post-deployment checks

- Verify the production response headers for `/` and a client-side route.
- Verify an existing hashed JS asset is immutable.
- Verify a deliberately missing `/assets/*.js` URL returns `404`, never `200 text/html`.
- Reproduce from a pre-deployment tab and confirm the recovery alert reloads the current route successfully.

## Residual risk

The full frontend test suite was not run locally; GitHub Actions remains the complete regression gate. Until the user activates the reload action, the original React Router error boundary remains visible below the recovery alert so Vite keeps the real import error instead of resolving the lazy module as `undefined`. If `sessionStorage` is unavailable, the original error remains visible without a recovery prompt rather than risking a repeated flow.
