### PR TITLE
fix: preserve database password for Dagster reconnects

### DIFF
--- a/analytics/dagster/src/assets/lovac/owner_housing_locations.py
+++ b/analytics/dagster/src/assets/lovac/owner_housing_locations.py
@@ -18,6 +18,7 @@ from dagster import (
     String,
     asset,
 )
+from psycopg2.extensions import make_dsn
 
 from ...owner_housing_locations import (
     LocationComputationError,
@@ -281,10 +282,12 @@ def lovac_owner_housing_locations(
             ),
         )
     limit = config["limit"] or None
+    connection = context.resources.psycopg2_connection
+    db_url = make_dsn(connection.dsn, password=connection.info.password)
 
     try:
         report = calculate_owner_housing_locations(
-            db_url=context.resources.psycopg2_connection.dsn,
+            db_url=db_url,
             data_file_year=config["data_file_year"],
             establishment_id=establishment_id,
             geo_codes=geo_codes,

--- a/analytics/dagster/tests/test_lovac_owner_housing_locations.py
+++ b/analytics/dagster/tests/test_lovac_owner_housing_locations.py
@@ -5,6 +5,7 @@ from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock, Mock
 
 import pytest
+from psycopg2.extensions import parse_dsn
 
 PROJECT_ROOT = Path(__file__).parent.parent
 ESTABLISHMENT_ID = "00000000-0000-0000-0000-000000000001"
@@ -75,7 +76,10 @@ def _location_context(*, dry_run: bool = False):
         },
         log=SimpleNamespace(info=Mock()),
         resources=SimpleNamespace(
-            psycopg2_connection=SimpleNamespace(dsn="postgresql://configured/test")
+            psycopg2_connection=SimpleNamespace(
+                dsn="dbname=test user=writer password=xxx",
+                info=SimpleNamespace(password="configured-secret"),
+            )
         ),
     )
 
@@ -232,19 +236,27 @@ def test_location_asset_rejects_a_different_backfill_scope(monkeypatch):
     calculate.assert_not_called()
 
 
-def test_location_asset_uses_the_configured_database_resource(monkeypatch):
+def test_location_asset_passes_a_reconnectable_database_dsn(monkeypatch):
     calculate = Mock(return_value=_report())
     monkeypatch.setattr(asset_module, "calculate_owner_housing_locations", calculate)
     compute = _compute(asset_module.lovac_owner_housing_locations)
     context = _location_context()
     context.resources = SimpleNamespace(
-        psycopg2_connection=SimpleNamespace(dsn="postgresql://configured/test")
+        psycopg2_connection=SimpleNamespace(
+            dsn="dbname=zlv user=writer password=xxx",
+            info=SimpleNamespace(password="secret with spaces"),
+        )
     )
     backfill_report = {"scope": _report().to_dict()["scope"]}
 
     compute(context, backfill_report)
 
-    assert calculate.call_args.kwargs["db_url"] == "postgresql://configured/test"
+    forwarded_dsn = parse_dsn(calculate.call_args.kwargs["db_url"])
+    assert forwarded_dsn == {
+        "dbname": "zlv",
+        "user": "writer",
+        "password": "secret with spaces",
+    }
 
 
 def test_location_asset_forwards_explicit_full_year_opt_in(monkeypatch):


### PR DESCRIPTION
## Context

The first production run of `lovac_post_import_enrichment` failed before selecting any owner-housing pair. The Dagster PostgreSQL resource initialized successfully, but the location calculator then failed to open its own connection with `password authentication failed`. No production data was written (`candidate_count = 0`, `processed_pairs = 0`, `updated_pairs = 0`).

## Root cause

The regression was introduced during the July 22 scope-cleanup refactor (`6107a60b`). The owner-location asset started reusing the shared Dagster PostgreSQL resource and forwarded `connection.dsn` to the calculator.

Psycopg intentionally obscures the password in `connection.dsn`. This is harmless for existing Dagster assets that use the already-open connection directly, but the owner-location calculator creates fresh connections for processing and batched writes. Those reconnections therefore received the obscured password instead of the configured one.

The PostgreSQL role and Clever Cloud configuration were not the cause: the initial resource connection succeeded and the same credentials were verified against the production database.

## Why existing validation missed it

The production-clone dry run exercised the calculator directly with an explicit database URL, so it validated the queries, classifications, writes and trigger behavior without crossing the Dagster-resource-to-calculator seam.

The previous asset test used a simple fake `dsn` and only asserted that the string was forwarded. It did not reproduce Psycopg's password-obscuring behavior.

## Fix

- Rebuild a reconnectable DSN with `psycopg2.extensions.make_dsn()`.
- Restore the password from `connection.info.password`, which is already loaded by the Dagster resource.
- Keep the reconstructed DSN in memory only; it is not logged or added to Dagster metadata.
- Replace the previous pass-through assertion with a regression test that starts from an obscured password and verifies the forwarded DSN remains reconnectable, including a password containing spaces.

## Validation

- Regression test observed failing before the implementation and passing afterwards.
- `130` Dagster tests passed.
- `31` targeted owner-location tests passed.
- Black formatting check passed.
- `git diff --check` passed.

## Deployment

Merging this PR into `main` is sufficient. The data-stack workflow deploys Dagster production directly from `main`; no release to the `prod` branch, database migration or Clever Cloud configuration change is required.
