### PR TITLE
fix(auth): harden the password reset flow

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -82,6 +82,7 @@
       name="description"
       content="Zéro Logement Vacant est un service public qui aide les propriétaires de logement vacant à rentrer en contact avec les collectivités afin de bénéficier d’accompagnements et d’aides pour la remise sur le marché"
     />
+    <script src="/crisp-bootstrap.js"></script>
     <title>Zéro Logement Vacant</title>
   </head>
   <body>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -82,17 +82,6 @@
       name="description"
       content="Zéro Logement Vacant est un service public qui aide les propriétaires de logement vacant à rentrer en contact avec les collectivités afin de bénéficier d’accompagnements et d’aides pour la remise sur le marché"
     />
-    <script type="text/javascript">
-      window.$crisp = [];
-      window.CRISP_WEBSITE_ID = '65781ccb-c386-4dbf-b614-5581c3a1ff7e';
-      (function () {
-        d = document;
-        s = d.createElement('script');
-        s.src = 'https://client.crisp.chat/l.js';
-        s.async = 1;
-        d.getElementsByTagName('head')[0].appendChild(s);
-      })();
-    </script>
     <title>Zéro Logement Vacant</title>
   </head>
   <body>

--- a/frontend/public/crisp-bootstrap.js
+++ b/frontend/public/crisp-bootstrap.js
@@ -1,0 +1,21 @@
+(function () {
+  const hasVisiblePasswordResetToken =
+    window.location.pathname === '/mot-de-passe/nouveau' &&
+    window.location.hash.length > 1;
+  if (hasVisiblePasswordResetToken) {
+    return;
+  }
+
+  const clientUrl = 'https://client.crisp.chat/l.js';
+  if (document.querySelector(`script[src="${clientUrl}"]`)) {
+    return;
+  }
+
+  window.$crisp = window.$crisp || [];
+  window.CRISP_WEBSITE_ID = '65781ccb-c386-4dbf-b614-5581c3a1ff7e';
+
+  const script = document.createElement('script');
+  script.src = clientUrl;
+  script.async = true;
+  document.head.appendChild(script);
+})();

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import {
   RouterProvider
 } from 'react-router';
 
+import TelemetryInitializer from '~/components/TelemetryInitializer';
 import { AuthProvider } from '~/contexts/AuthContext';
 import { useAppDispatch, useAppSelector } from '~/hooks/useStore';
 import AuthenticatedLayout from '~/layouts/AuthenticatedLayout';
@@ -60,7 +61,7 @@ const SiteMapView = lazy(() => import('~/views/SiteMapView'));
 
 const router = sentry.createBrowserRouter(
   createRoutesFromElements(
-    <Route>
+    <Route element={<TelemetryInitializer />}>
       <Route element={<AuthenticatedLayout />}>
         <Route path="/" element={<Navigate to="/parc-de-logements" />} />
         <Route path="/plan-du-site" element={<SiteMapView />} />

--- a/frontend/src/components/TelemetryInitializer.tsx
+++ b/frontend/src/components/TelemetryInitializer.tsx
@@ -1,0 +1,14 @@
+import { useEffect } from 'react';
+import { Outlet, useLocation } from 'react-router';
+
+import { startTelemetryWhenSafe } from '~/utils/telemetry';
+
+export default function TelemetryInitializer() {
+  const { hash, pathname } = useLocation();
+
+  useEffect(() => {
+    startTelemetryWhenSafe({ hash, pathname });
+  }, [hash, pathname]);
+
+  return <Outlet />;
+}

--- a/frontend/src/components/modals/GeoPerimeterUploadingModal/PerimeterUploadModal.tsx
+++ b/frontend/src/components/modals/GeoPerimeterUploadingModal/PerimeterUploadModal.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react';
 import * as yup from 'yup';
 
 import { createConfirmationModal } from '~/components/modals/ConfirmationModal/ConfirmationModalNext';
-import { fileValidator, useForm } from '~/hooks/useForm';
+import { fileValidator } from '~/hooks/useForm';
 
 import styles from './geo-perimeter-uploading-modal.module.scss';
 
@@ -28,6 +28,7 @@ function createPerimeterUploadModal() {
       const { onClose, onSubmit, ...rest } = props;
       const FileTypes = ['application/zip', 'application/x-zip-compressed'];
       const [file, setFile] = useState<File | undefined>();
+      const [fileError, setFileError] = useState('');
       const [validationError, setValidationError] = useState('');
 
       const schema = yup
@@ -35,24 +36,28 @@ function createPerimeterUploadModal() {
         .shape({ file: fileValidator(FileTypes).default(undefined) })
         .required();
 
-      const { message, validate } = useForm(schema as any, {
-        file
-      });
-
       const selectFile = (event: any) => {
+        setFileError('');
         setValidationError('');
         setFile(event.target?.files?.[0]);
       };
 
       const submitFile = async () => {
+        setFileError('');
         setValidationError('');
         try {
-          await validate(() => onSubmit(file!));
-        } catch {
+          await schema.validate({ file }, { abortEarly: false });
+        } catch (error) {
+          if (error instanceof yup.ValidationError) {
+            setFileError(error.message);
+            return;
+          }
           setValidationError(
             'Le fichier n’a pas pu être validé. Veuillez réessayer.'
           );
+          return;
         }
+        onSubmit(file!);
       };
 
       const displayedError = props.error || validationError;
@@ -83,14 +88,15 @@ function createPerimeterUploadModal() {
               <Upload
                 nativeInputProps={{
                   onChange: (event: any) => selectFile(event),
-                  accept: '.zip,application/zip,application/x-zip-compressed'
+                  accept: '.zip,application/zip,application/x-zip-compressed',
+                  'aria-invalid': isFileTooLarge || fileError ? true : undefined
                 }}
                 multiple={false}
                 label="Ajouter un fichier"
                 hint="Format : fichier géographique (SIG) au format .zip comprenant l'ensemble des extensions qui constituent le fichier (.cpg, .dbf, .shp, etc.)."
-                state={isFileTooLarge ? 'error' : 'default'}
+                state={isFileTooLarge || fileError ? 'error' : 'default'}
                 stateRelatedMessage={
-                  isFileTooLarge ? displayedError : message('file')
+                  isFileTooLarge ? displayedError : fileError
                 }
                 className={styles.upload}
               />

--- a/frontend/src/components/modals/GeoPerimeterUploadingModal/PerimeterUploadModal.tsx
+++ b/frontend/src/components/modals/GeoPerimeterUploadingModal/PerimeterUploadModal.tsx
@@ -28,31 +28,37 @@ function createPerimeterUploadModal() {
       const { onClose, onSubmit, ...rest } = props;
       const FileTypes = ['application/zip', 'application/x-zip-compressed'];
       const [file, setFile] = useState<File | undefined>();
+      const [validationError, setValidationError] = useState('');
 
       const schema = yup
         .object()
         .shape({ file: fileValidator(FileTypes).default(undefined) })
         .required();
 
-      const { isValid, message, validate } = useForm(schema as any, {
+      const { message, validate } = useForm(schema as any, {
         file
       });
 
       const selectFile = (event: any) => {
+        setValidationError('');
         setFile(event.target?.files?.[0]);
       };
 
-      const submitFile = () => {
-        validate().then(() => {
-          if (isValid()) {
-            onSubmit(file!);
-          }
-        });
+      const submitFile = async () => {
+        setValidationError('');
+        try {
+          await validate(() => onSubmit(file!));
+        } catch {
+          setValidationError(
+            'Le fichier n’a pas pu être validé. Veuillez réessayer.'
+          );
+        }
       };
 
+      const displayedError = props.error || validationError;
       // Check if error is file_too_large to display it differently
-      const isFileTooLarge = props.error?.includes('trop volumineux');
-      const shouldShowAlert = !!props.error && !isFileTooLarge;
+      const isFileTooLarge = displayedError.includes('trop volumineux');
+      const shouldShowAlert = !!displayedError && !isFileTooLarge;
 
       return (
         <modal.Component
@@ -63,11 +69,11 @@ function createPerimeterUploadModal() {
           {...rest}
         >
           <Grid container spacing={2}>
-            {shouldShowAlert && props.error && (
+            {shouldShowAlert && (
               <Grid size={12}>
                 <Alert
                   severity="error"
-                  description={props.error}
+                  description={displayedError}
                   closable={false}
                   small
                 />
@@ -84,7 +90,7 @@ function createPerimeterUploadModal() {
                 hint="Format : fichier géographique (SIG) au format .zip comprenant l'ensemble des extensions qui constituent le fichier (.cpg, .dbf, .shp, etc.)."
                 state={isFileTooLarge ? 'error' : 'default'}
                 stateRelatedMessage={
-                  isFileTooLarge ? props.error : message('file')
+                  isFileTooLarge ? displayedError : message('file')
                 }
                 className={styles.upload}
               />

--- a/frontend/src/components/modals/GeoPerimeterUploadingModal/test/PerimeterUploadModal.test.tsx
+++ b/frontend/src/components/modals/GeoPerimeterUploadingModal/test/PerimeterUploadModal.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import createPerimeterUploadModal from '../PerimeterUploadModal';
+
+const modal = createPerimeterUploadModal();
+
+describe('PerimeterUploadModal', () => {
+  it('should surface an unexpected validation failure without submitting', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<modal.Component onClose={vi.fn()} onSubmit={onSubmit} />);
+    modal.open();
+    const dialog = await screen.findByRole('dialog');
+    const input = within(dialog).getByLabelText(/^Ajouter un fichier/);
+    const file = new File(['perimeter'], 'perimeter.zip', {
+      type: 'application/zip'
+    });
+    await user.upload(input, file);
+    Object.defineProperty(file, 'type', {
+      configurable: true,
+      get() {
+        throw new Error('Validation failure containing a private filename');
+      }
+    });
+
+    await user.click(within(dialog).getByRole('button', { name: 'Confirmer' }));
+
+    expect(await within(dialog).findByRole('alert')).toHaveTextContent(
+      'Le fichier n’a pas pu être validé. Veuillez réessayer.'
+    );
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/modals/GeoPerimeterUploadingModal/test/PerimeterUploadModal.test.tsx
+++ b/frontend/src/components/modals/GeoPerimeterUploadingModal/test/PerimeterUploadModal.test.tsx
@@ -6,6 +6,23 @@ import createPerimeterUploadModal from '../PerimeterUploadModal';
 const modal = createPerimeterUploadModal();
 
 describe('PerimeterUploadModal', () => {
+  it('should associate a missing-file error with the upload field', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<modal.Component onClose={vi.fn()} onSubmit={onSubmit} />);
+    modal.open();
+    const dialog = await screen.findByRole('dialog');
+
+    await user.click(within(dialog).getByRole('button', { name: 'Confirmer' }));
+
+    const input = within(dialog).getByLabelText(/^Ajouter un fichier/);
+    expect(
+      await within(dialog).findByText('Veuillez sélectionner un fichier')
+    ).toBeVisible();
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
   it('should surface an unexpected validation failure without submitting', async () => {
     const user = userEvent.setup();
     const onSubmit = vi.fn();

--- a/frontend/src/hooks/useEmailLink.tsx
+++ b/frontend/src/hooks/useEmailLink.tsx
@@ -15,7 +15,9 @@ interface EmailLinkOptions<T> {
 
 export function useEmailLink<T>(options: EmailLinkOptions<T>) {
   const location = useLocation();
-  const hash = readPasswordResetToken(location.pathname, location.hash);
+  const [hash] = useState(() =>
+    readPasswordResetToken(location.pathname, location.hash)
+  );
   const dispatch = useAppDispatch();
   const [loading, setLoading] = useState(false);
   const [link, setLink] = useState<T>();

--- a/frontend/src/hooks/useEmailLink.tsx
+++ b/frontend/src/hooks/useEmailLink.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { hideLoading, showLoading } from 'react-redux-loading-bar';
 import { useLocation } from 'react-router';
 
+import { readPasswordResetToken } from '../utils/password-reset-token';
 import { useAppDispatch } from './useStore';
 
 interface LinkService<T> {
@@ -13,8 +14,8 @@ interface EmailLinkOptions<T> {
 }
 
 export function useEmailLink<T>(options: EmailLinkOptions<T>) {
-  // Get the hash value without "#"
-  const hash = useLocation().hash.slice(1);
+  const location = useLocation();
+  const hash = readPasswordResetToken(location.pathname, location.hash);
   const dispatch = useAppDispatch();
   const [loading, setLoading] = useState(false);
   const [link, setLink] = useState<T>();

--- a/frontend/src/hooks/useForm.tsx
+++ b/frontend/src/hooks/useForm.tsx
@@ -204,14 +204,6 @@ export function useForm<
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [...Object.values(input)]);
 
-  useEffect(() => {
-    const validations = (fullValidationKeys ?? []).map((key) =>
-      validateAt(key)
-    );
-    (async () => await Promise.all(validations))();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, fullValidationKeys);
-
   return {
     isDirty,
     isTouched,

--- a/frontend/src/hooks/useForm.tsx
+++ b/frontend/src/hooks/useForm.tsx
@@ -1,3 +1,4 @@
+import schemas from '@zerologementvacant/schemas';
 import { isDate } from 'date-fns';
 import { Array, pipe, Predicate, Record } from 'effect';
 import { useEffect, useRef, useState } from 'react';
@@ -14,26 +15,9 @@ export const emailValidator = yup
     'L’adresse doit être un email valide. Exemple de format valide : exemple@gmail.com'
   );
 
-export const passwordFormatValidator = yup
-  .string()
-  .min(12, 'Au moins 12 caractères.')
-  .matches(/[A-Z]/g, {
-    name: 'uppercase',
-    message: 'Au moins une majuscule.'
-  })
-  .matches(/[a-z]/g, {
-    name: 'lowercase',
-    message: 'Au moins une minuscule.'
-  })
-  .matches(/[0-9]/g, {
-    name: 'number',
-    message: 'Au moins un chiffre.'
-  });
+export const passwordFormatValidator = schemas.password;
 
-export const passwordConfirmationValidator = yup
-  .string()
-  .required('Veuillez confirmer votre mot de passe.')
-  .oneOf([yup.ref('password')], 'Les mots de passe doivent être identiques.');
+export const passwordConfirmationValidator = schemas.passwordConfirmation();
 
 export const campaignTitleValidator = yup
   .string()
@@ -95,6 +79,10 @@ export function useForm<
   const previousInput = useRef<U>();
 
   const isDirty = touchedKeys.size > 0;
+
+  function isTouched<K extends keyof U>(key: K): boolean {
+    return touchedKeys.has(key);
+  }
 
   function error<K extends keyof U>(key?: K): yup.ValidationError | undefined {
     return key && touchedKeys.has(key)
@@ -174,8 +162,12 @@ export function useForm<
       await schema.validate(input, { abortEarly: false });
       setErrors(undefined);
       await onValid?.();
-    } catch (errors) {
-      setErrors((errors as yup.ValidationError).inner);
+    } catch (error) {
+      if (error instanceof yup.ValidationError) {
+        setErrors(error.inner);
+        return;
+      }
+      throw error;
     }
   }
 
@@ -222,6 +214,7 @@ export function useForm<
 
   return {
     isDirty,
+    isTouched,
     isValid,
     hasError,
     messageList,

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -18,10 +18,12 @@ import { initCrisp } from './utils/crisp';
 import { protectPasswordResetToken } from './utils/password-reset-token';
 import sentry from './utils/sentry';
 
-protectPasswordResetToken();
+const canStartTelemetry = protectPasswordResetToken();
 registerPreloadErrorRecovery();
-initCrisp();
-sentry.init();
+if (canStartTelemetry) {
+  initCrisp();
+  sentry.init();
+}
 
 startReactDsfr({
   defaultColorScheme: 'light',
@@ -34,7 +36,7 @@ declare module '@codegouvfr/react-dsfr/spa' {
   }
 }
 
-if (config.posthog.enabled) {
+if (config.posthog.enabled && canStartTelemetry) {
   posthog.init(config.posthog.apiKey, {
     api_host: 'https://eu.i.posthog.com',
     person_profiles: 'identified_only'

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -14,9 +14,13 @@ import Notification from './components/Notification/Notification';
 import { store } from './store/store';
 import ThemeProvider from './theme';
 import config from './utils/config';
+import { initCrisp } from './utils/crisp';
+import { protectPasswordResetToken } from './utils/password-reset-token';
 import sentry from './utils/sentry';
 
+protectPasswordResetToken();
 registerPreloadErrorRecovery();
+initCrisp();
 sentry.init();
 
 startReactDsfr({

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -13,17 +13,13 @@ import App from './App';
 import Notification from './components/Notification/Notification';
 import { store } from './store/store';
 import ThemeProvider from './theme';
-import config from './utils/config';
-import { initCrisp } from './utils/crisp';
 import { protectPasswordResetToken } from './utils/password-reset-token';
 import sentry from './utils/sentry';
+import { startTelemetryWhenSafe } from './utils/telemetry';
 
-const canStartTelemetry = protectPasswordResetToken();
+protectPasswordResetToken();
 registerPreloadErrorRecovery();
-if (canStartTelemetry) {
-  initCrisp();
-  sentry.init();
-}
+startTelemetryWhenSafe(window.location);
 
 startReactDsfr({
   defaultColorScheme: 'light',
@@ -34,13 +30,6 @@ declare module '@codegouvfr/react-dsfr/spa' {
   interface RegisterLink {
     Link: typeof Link;
   }
-}
-
-if (config.posthog.enabled && canStartTelemetry) {
-  posthog.init(config.posthog.apiKey, {
-    api_host: 'https://eu.i.posthog.com',
-    person_profiles: 'identified_only'
-  });
 }
 
 const container = document.getElementById('root');

--- a/frontend/src/models/ResetLink.tsx
+++ b/frontend/src/models/ResetLink.tsx
@@ -1,1 +1,0 @@
-export type { ResetLinkDTO as ResetLink } from '@zerologementvacant/models';

--- a/frontend/src/services/reset-link.service.ts
+++ b/frontend/src/services/reset-link.service.ts
@@ -1,5 +1,8 @@
-import { type ResetLink } from '../models/ResetLink';
 import config from '../utils/config';
+
+interface ResetLinkValidation {
+  valid: true;
+}
 
 const sendResetEmail = async (email: string): Promise<void> => {
   const { status } = await fetch(`${config.apiEndpoint}/reset-links`, {
@@ -12,7 +15,7 @@ const sendResetEmail = async (email: string): Promise<void> => {
   }
 };
 
-const get = async (id: string): Promise<ResetLink> => {
+const get = async (id: string): Promise<ResetLinkValidation> => {
   const response = await fetch(`${config.apiEndpoint}/reset-links/${id}`, {
     method: 'GET',
     headers: { 'Content-Type': 'application/json' }
@@ -30,7 +33,14 @@ const resetPassword = async (key: string, password: string): Promise<void> => {
     body: JSON.stringify({ key, password })
   });
   if (!response.ok) {
-    throw new Error('Password reset failed');
+    if (response.status === 404 || response.status === 410) {
+      throw new Error(
+        'Ce lien de réinitialisation n’est plus valide. Demandez un nouveau lien.'
+      );
+    }
+    throw new Error(
+      'Votre mot de passe n’a pas pu être enregistré. Veuillez réessayer. Si le problème persiste, demandez un nouveau lien de réinitialisation.'
+    );
   }
 };
 

--- a/frontend/src/utils/crisp.ts
+++ b/frontend/src/utils/crisp.ts
@@ -5,12 +5,18 @@ declare global {
   }
 }
 
+const CRISP_CLIENT_URL = 'https://client.crisp.chat/l.js';
+
 export function initCrisp(): void {
-  window.$crisp = [];
+  if (document.querySelector(`script[src="${CRISP_CLIENT_URL}"]`)) {
+    return;
+  }
+
+  window.$crisp ??= [];
   window.CRISP_WEBSITE_ID = '65781ccb-c386-4dbf-b614-5581c3a1ff7e';
 
   const script = document.createElement('script');
-  script.src = 'https://client.crisp.chat/l.js';
+  script.src = CRISP_CLIENT_URL;
   script.async = true;
   document.head.appendChild(script);
 }

--- a/frontend/src/utils/crisp.ts
+++ b/frontend/src/utils/crisp.ts
@@ -1,0 +1,16 @@
+declare global {
+  interface Window {
+    $crisp: unknown[];
+    CRISP_WEBSITE_ID: string;
+  }
+}
+
+export function initCrisp(): void {
+  window.$crisp = [];
+  window.CRISP_WEBSITE_ID = '65781ccb-c386-4dbf-b614-5581c3a1ff7e';
+
+  const script = document.createElement('script');
+  script.src = 'https://client.crisp.chat/l.js';
+  script.async = true;
+  document.head.appendChild(script);
+}

--- a/frontend/src/utils/password-reset-token.ts
+++ b/frontend/src/utils/password-reset-token.ts
@@ -1,0 +1,72 @@
+export const PASSWORD_RESET_PATH = '/mot-de-passe/nouveau';
+export const PASSWORD_RESET_TOKEN_STORAGE_KEY = 'zlv.password-reset-token';
+
+let protectedPasswordResetToken = '';
+
+type PasswordResetLocation = Pick<Location, 'hash' | 'pathname' | 'search'>;
+type PasswordResetHistory = Pick<History, 'replaceState' | 'state'>;
+type PasswordResetStorage = Pick<Storage, 'getItem' | 'removeItem' | 'setItem'>;
+type PasswordResetStorageProvider<T extends keyof PasswordResetStorage> =
+  () => Pick<PasswordResetStorage, T>;
+
+function browserSessionStorage(): PasswordResetStorage {
+  return window.sessionStorage;
+}
+
+export function protectPasswordResetToken(
+  location: PasswordResetLocation = window.location,
+  history: PasswordResetHistory = window.history,
+  storage: PasswordResetStorageProvider<'setItem'> = browserSessionStorage
+): void {
+  if (location.pathname !== PASSWORD_RESET_PATH || !location.hash) {
+    return;
+  }
+
+  protectedPasswordResetToken = location.hash.slice(1);
+  try {
+    storage().setItem(
+      PASSWORD_RESET_TOKEN_STORAGE_KEY,
+      protectedPasswordResetToken
+    );
+  } catch {
+    // Some privacy modes disable storage. The in-memory fallback still lets the
+    // current page consume the token after it has been removed from the URL.
+  }
+  history.replaceState(
+    history.state,
+    '',
+    `${location.pathname}${location.search}`
+  );
+}
+
+export function readPasswordResetToken(
+  pathname: string,
+  hash: string,
+  storage: PasswordResetStorageProvider<'getItem'> = browserSessionStorage
+): string {
+  if (hash) {
+    return hash.slice(1);
+  }
+  if (pathname !== PASSWORD_RESET_PATH) {
+    return '';
+  }
+  try {
+    return (
+      storage().getItem(PASSWORD_RESET_TOKEN_STORAGE_KEY) ??
+      protectedPasswordResetToken
+    );
+  } catch {
+    return protectedPasswordResetToken;
+  }
+}
+
+export function clearPasswordResetToken(
+  storage: PasswordResetStorageProvider<'removeItem'> = browserSessionStorage
+): void {
+  protectedPasswordResetToken = '';
+  try {
+    storage().removeItem(PASSWORD_RESET_TOKEN_STORAGE_KEY);
+  } catch {
+    // Storage can be unavailable in privacy modes; the in-memory token is clear.
+  }
+}

--- a/frontend/src/utils/password-reset-token.ts
+++ b/frontend/src/utils/password-reset-token.ts
@@ -1,72 +1,89 @@
 export const PASSWORD_RESET_PATH = '/mot-de-passe/nouveau';
-export const PASSWORD_RESET_TOKEN_STORAGE_KEY = 'zlv.password-reset-token';
+
+const PASSWORD_RESET_TOKEN_HISTORY_STATE_KEY = 'zlv.password-reset-token';
 
 let protectedPasswordResetToken = '';
 
 type PasswordResetLocation = Pick<Location, 'hash' | 'pathname' | 'search'>;
 type PasswordResetHistory = Pick<History, 'replaceState' | 'state'>;
-type PasswordResetStorage = Pick<Storage, 'getItem' | 'removeItem' | 'setItem'>;
-type PasswordResetStorageProvider<T extends keyof PasswordResetStorage> =
-  () => Pick<PasswordResetStorage, T>;
 
-function browserSessionStorage(): PasswordResetStorage {
-  return window.sessionStorage;
+function isHistoryState(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
 export function protectPasswordResetToken(
   location: PasswordResetLocation = window.location,
-  history: PasswordResetHistory = window.history,
-  storage: PasswordResetStorageProvider<'setItem'> = browserSessionStorage
-): void {
+  history: PasswordResetHistory = window.history
+): boolean {
   if (location.pathname !== PASSWORD_RESET_PATH || !location.hash) {
-    return;
+    return true;
   }
 
   protectedPasswordResetToken = location.hash.slice(1);
   try {
-    storage().setItem(
-      PASSWORD_RESET_TOKEN_STORAGE_KEY,
-      protectedPasswordResetToken
+    const currentState = history.state;
+    const nextState = {
+      ...(isHistoryState(currentState) ? currentState : {}),
+      [PASSWORD_RESET_TOKEN_HISTORY_STATE_KEY]: protectedPasswordResetToken
+    };
+    history.replaceState(
+      nextState,
+      '',
+      `${location.pathname}${location.search}`
     );
+    return true;
   } catch {
-    // Some privacy modes disable storage. The in-memory fallback still lets the
-    // current page consume the token after it has been removed from the URL.
+    // The URL fragment and the one-shot in-memory fallback keep the flow
+    // usable, but callers must not start third-party telemetry while the secret
+    // remains visible in the URL.
+    return false;
   }
-  history.replaceState(
-    history.state,
-    '',
-    `${location.pathname}${location.search}`
-  );
 }
 
 export function readPasswordResetToken(
   pathname: string,
   hash: string,
-  storage: PasswordResetStorageProvider<'getItem'> = browserSessionStorage
+  history: Pick<History, 'state'> = window.history
 ): string {
+  if (pathname !== PASSWORD_RESET_PATH) {
+    protectedPasswordResetToken = '';
+    return '';
+  }
+
+  const fallbackToken = protectedPasswordResetToken;
+  protectedPasswordResetToken = '';
+
   if (hash) {
     return hash.slice(1);
   }
-  if (pathname !== PASSWORD_RESET_PATH) {
-    return '';
-  }
   try {
-    return (
-      storage().getItem(PASSWORD_RESET_TOKEN_STORAGE_KEY) ??
-      protectedPasswordResetToken
-    );
+    const state = history.state;
+    const token = isHistoryState(state)
+      ? state[PASSWORD_RESET_TOKEN_HISTORY_STATE_KEY]
+      : undefined;
+    return typeof token === 'string' ? token : fallbackToken;
   } catch {
-    return protectedPasswordResetToken;
+    return fallbackToken;
   }
 }
 
 export function clearPasswordResetToken(
-  storage: PasswordResetStorageProvider<'removeItem'> = browserSessionStorage
+  history: PasswordResetHistory = window.history
 ): void {
   protectedPasswordResetToken = '';
   try {
-    storage().removeItem(PASSWORD_RESET_TOKEN_STORAGE_KEY);
+    const state = history.state;
+    if (
+      !isHistoryState(state) ||
+      !(PASSWORD_RESET_TOKEN_HISTORY_STATE_KEY in state)
+    ) {
+      return;
+    }
+
+    const nextState = { ...state };
+    delete nextState[PASSWORD_RESET_TOKEN_HISTORY_STATE_KEY];
+    history.replaceState(nextState, '');
   } catch {
-    // Storage can be unavailable in privacy modes; the in-memory token is clear.
+    // History can be unavailable in privacy modes; the in-memory token is clear.
   }
 }

--- a/frontend/src/utils/sentry.ts
+++ b/frontend/src/utils/sentry.ts
@@ -1,4 +1,5 @@
 import * as Sentry from '@sentry/react';
+import { redactSensitiveData } from '@zerologementvacant/utils';
 import { useEffect } from 'react';
 import {
   createBrowserRouter,
@@ -9,6 +10,16 @@ import {
 } from 'react-router';
 
 import config from './config';
+
+export function sanitizeEvent<T extends Sentry.Event>(event: T): T {
+  return redactSensitiveData(event);
+}
+
+export function sanitizeBreadcrumb<T extends Sentry.Breadcrumb>(
+  breadcrumb: T
+): T {
+  return redactSensitiveData(breadcrumb);
+}
 
 function init(): void {
   if (config.sentry.enabled) {
@@ -39,8 +50,14 @@ function init(): void {
         Sentry.browserProfilingIntegration(),
         // Replay for debugging
         Sentry.replayIntegration({
+          maskAllInputs: true,
           maskAllText: false,
-          blockAllMedia: false
+          blockAllMedia: false,
+          networkDetailDenyUrls: [
+            /\/reset-links(?:\/|$)/,
+            /\/account\/reset-password(?:\/|$)/
+          ],
+          beforeAddRecordingEvent: redactSensitiveData
         })
       ],
       sampleRate: config.sentry.sampleRate,
@@ -54,9 +71,10 @@ function init(): void {
 
       // Enhanced error handling
       beforeSend(event) {
+        const sanitized = sanitizeEvent(event);
         // Add custom tags for better organization
-        event.tags = {
-          ...event.tags,
+        sanitized.tags = {
+          ...sanitized.tags,
           component: 'frontend',
           framework: 'react',
           bundler: 'vite'
@@ -64,29 +82,31 @@ function init(): void {
 
         // Log errors to console in development
         if (config.sentry.env === 'development') {
-          console.error('Sentry error:', event);
+          console.error('Sentry error:', sanitized);
         }
-        return event;
+        return sanitized;
       },
 
       // Enhanced transaction processing
       beforeSendTransaction(event) {
+        const sanitized = sanitizeEvent(event);
         // Add performance context
-        event.tags = {
-          ...event.tags,
+        sanitized.tags = {
+          ...sanitized.tags,
           component: 'frontend',
           framework: 'react'
         };
-        return event;
+        return sanitized;
       },
 
       // Auto-capture console errors
       beforeBreadcrumb(breadcrumb) {
+        const sanitized = sanitizeBreadcrumb(breadcrumb);
         if (breadcrumb.category === 'console' && breadcrumb.level === 'error') {
           // This will help track console errors
-          return breadcrumb;
+          return sanitized;
         }
-        return breadcrumb;
+        return sanitized;
       }
     });
 

--- a/frontend/src/utils/sentry.ts
+++ b/frontend/src/utils/sentry.ts
@@ -21,6 +21,14 @@ export function sanitizeBreadcrumb<T extends Sentry.Breadcrumb>(
   return redactSensitiveData(breadcrumb);
 }
 
+function describeException(
+  exception: unknown
+): Readonly<Record<string, string>> {
+  return exception instanceof Error
+    ? { name: exception.name }
+    : { type: typeof exception };
+}
+
 function init(): void {
   if (config.sentry.enabled) {
     console.log('Initializing Sentry with:', {
@@ -51,7 +59,7 @@ function init(): void {
         // Replay for debugging
         Sentry.replayIntegration({
           maskAllInputs: true,
-          maskAllText: false,
+          maskAllText: true,
           blockAllMedia: false,
           networkDetailDenyUrls: [
             /\/reset-links(?:\/|$)/,
@@ -112,12 +120,15 @@ function init(): void {
 
     // Global error handlers for uncaught errors
     window.addEventListener('error', (event) => {
-      console.error('Global error:', event.error);
+      console.error('Global error:', describeException(event.error));
       Sentry.captureException(event.error);
     });
 
     window.addEventListener('unhandledrejection', (event) => {
-      console.error('Unhandled promise rejection:', event.reason);
+      console.error(
+        'Unhandled promise rejection:',
+        describeException(event.reason)
+      );
       Sentry.captureException(event.reason);
     });
 

--- a/frontend/src/utils/telemetry.ts
+++ b/frontend/src/utils/telemetry.ts
@@ -1,0 +1,41 @@
+import posthog from 'posthog-js';
+
+import config from './config';
+import { initCrisp } from './crisp';
+import { PASSWORD_RESET_PATH } from './password-reset-token';
+import sentry from './sentry';
+
+type TelemetryLocation = Pick<Location, 'hash' | 'pathname'>;
+
+export function createTelemetryStarter(initialize: () => void) {
+  let started = false;
+
+  return (location: TelemetryLocation): boolean => {
+    if (
+      !started &&
+      location.pathname === PASSWORD_RESET_PATH &&
+      location.hash
+    ) {
+      return false;
+    }
+    if (!started) {
+      started = true;
+      initialize();
+    }
+    return true;
+  };
+}
+
+function initializeTelemetry(): void {
+  initCrisp();
+  sentry.init();
+  if (config.posthog.enabled) {
+    posthog.init(config.posthog.apiKey, {
+      api_host: 'https://eu.i.posthog.com',
+      person_profiles: 'identified_only'
+    });
+  }
+}
+
+export const startTelemetryWhenSafe =
+  createTelemetryStarter(initializeTelemetry);

--- a/frontend/src/utils/test/crisp.test.ts
+++ b/frontend/src/utils/test/crisp.test.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { initCrisp } from '../crisp';
@@ -22,5 +25,53 @@ describe('Crisp', () => {
       async: true,
       src: 'https://client.crisp.chat/l.js'
     });
+  });
+
+  it('should bootstrap the chat independently before the application bundle', () => {
+    const html = readFileSync(resolve(process.cwd(), 'index.html'), 'utf8');
+    const bootstrap = readFileSync(
+      resolve(process.cwd(), 'public/crisp-bootstrap.js'),
+      'utf8'
+    );
+
+    expect(html).toContain('<script src="/crisp-bootstrap.js"></script>');
+    expect(html.indexOf('/crisp-bootstrap.js')).toBeLessThan(
+      html.indexOf('src/index.tsx')
+    );
+    expect(bootstrap).toContain(
+      "const clientUrl = 'https://client.crisp.chat/l.js'"
+    );
+    expect(bootstrap).toContain('document.head.appendChild(script)');
+  });
+
+  it('should guard the independent bootstrap while a reset token is visible', () => {
+    const bootstrap = readFileSync(
+      resolve(process.cwd(), 'public/crisp-bootstrap.js'),
+      'utf8'
+    );
+
+    expect(bootstrap).toContain(
+      "window.location.pathname === '/mot-de-passe/nouveau'"
+    );
+    expect(bootstrap).toContain('window.location.hash.length > 1');
+    expect(bootstrap.indexOf('return;')).toBeLessThan(
+      bootstrap.indexOf('document.head.appendChild(script)')
+    );
+  });
+
+  it('should not initialize the chat twice when the independent bootstrap already loaded it', () => {
+    const queue = [['set', 'session:segments', [['authenticated']]]];
+    const existingScript = document.createElement('script');
+    existingScript.src = 'https://client.crisp.chat/l.js';
+    window.$crisp = queue;
+    vi.spyOn(document, 'querySelector').mockReturnValue(existingScript);
+    const appendChild = vi
+      .spyOn(document.head, 'appendChild')
+      .mockImplementation((node) => node);
+
+    initCrisp();
+
+    expect(appendChild).not.toHaveBeenCalled();
+    expect(window.$crisp).toBe(queue);
   });
 });

--- a/frontend/src/utils/test/crisp.test.ts
+++ b/frontend/src/utils/test/crisp.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { initCrisp } from '../crisp';
+
+describe('Crisp', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should load the chat client when initialized by the application', () => {
+    const appendChild = vi
+      .spyOn(document.head, 'appendChild')
+      .mockImplementation((node) => node);
+
+    initCrisp();
+
+    expect(window.CRISP_WEBSITE_ID).toBe(
+      '65781ccb-c386-4dbf-b614-5581c3a1ff7e'
+    );
+    expect(appendChild).toHaveBeenCalledOnce();
+    expect(appendChild.mock.calls[0][0]).toMatchObject({
+      async: true,
+      src: 'https://client.crisp.chat/l.js'
+    });
+  });
+});

--- a/frontend/src/utils/test/password-reset-token.test.ts
+++ b/frontend/src/utils/test/password-reset-token.test.ts
@@ -1,16 +1,24 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import {
-  PASSWORD_RESET_TOKEN_STORAGE_KEY,
+  clearPasswordResetToken,
   protectPasswordResetToken,
   readPasswordResetToken
 } from '../password-reset-token';
 
 describe('Password reset token', () => {
-  it('should move the token from the URL fragment to session storage', () => {
+  it('should move the token from the URL fragment to the current history entry', () => {
     const token = 'A'.repeat(100);
-    const setItem = vi.fn();
-    const replaceState = vi.fn();
+    let state: unknown = { navigation: true };
+    const replaceState = vi.fn((nextState: unknown) => {
+      state = nextState;
+    });
+    const history = {
+      get state() {
+        return state;
+      },
+      replaceState
+    };
 
     protectPasswordResetToken(
       {
@@ -18,51 +26,102 @@ describe('Password reset token', () => {
         search: '?source=email',
         hash: `#${token}`
       },
-      { state: { navigation: true }, replaceState },
-      () => ({ setItem })
+      history
     );
 
-    expect(setItem).toHaveBeenCalledWith(
-      PASSWORD_RESET_TOKEN_STORAGE_KEY,
-      token
-    );
     expect(replaceState).toHaveBeenCalledWith(
-      { navigation: true },
+      expect.objectContaining({ navigation: true }),
       '',
       '/mot-de-passe/nouveau?source=email'
     );
+    expect(readPasswordResetToken('/mot-de-passe/nouveau', '', history)).toBe(
+      token
+    );
   });
 
-  it('should read the protected token when the URL fragment has been cleared', () => {
+  it('should retain the token on reload of the current history entry', () => {
     const token = 'B'.repeat(100);
+    let state: unknown = null;
+    const history = {
+      get state() {
+        return state;
+      },
+      replaceState: vi.fn((nextState: unknown) => {
+        state = nextState;
+      })
+    };
 
-    expect(
-      readPasswordResetToken('/mot-de-passe/nouveau', '', () => ({
-        getItem: () => token
-      }))
-    ).toBe(token);
+    protectPasswordResetToken(
+      {
+        pathname: '/mot-de-passe/nouveau',
+        search: '',
+        hash: `#${token}`
+      },
+      history
+    );
+
+    expect(readPasswordResetToken('/mot-de-passe/nouveau', '', history)).toBe(
+      token
+    );
+    expect(readPasswordResetToken('/mot-de-passe/nouveau', '', history)).toBe(
+      token
+    );
   });
 
-  it('should keep the token in memory when session storage is unavailable', () => {
+  it('should keep a one-shot fallback and report an unprotected URL when history is unavailable', () => {
     const token = 'C'.repeat(100);
+    const history = {
+      get state(): unknown {
+        throw new DOMException('History unavailable', 'SecurityError');
+      },
+      replaceState: vi.fn()
+    };
 
-    expect(() =>
-      protectPasswordResetToken(
-        {
-          pathname: '/mot-de-passe/nouveau',
-          search: '',
-          hash: `#${token}`
-        },
-        { state: null, replaceState: vi.fn() },
-        () => {
-          throw new DOMException('Storage unavailable', 'SecurityError');
-        }
-      )
-    ).not.toThrow();
-    expect(
-      readPasswordResetToken('/mot-de-passe/nouveau', '', () => {
-        throw new DOMException('Storage unavailable', 'SecurityError');
-      })
-    ).toBe(token);
+    const protectedUrl = protectPasswordResetToken(
+      {
+        pathname: '/mot-de-passe/nouveau',
+        search: '',
+        hash: `#${token}`
+      },
+      history
+    );
+
+    expect(protectedUrl).toBe(false);
+    expect(readPasswordResetToken('/mot-de-passe/nouveau', '', history)).toBe(
+      token
+    );
+  });
+
+  it('should not reuse a token when the reset route is opened in a new history entry', () => {
+    const token = 'D'.repeat(100);
+    const originalState = window.history.state;
+    const originalUrl = window.location.href;
+
+    try {
+      window.history.replaceState(
+        { entry: 'reset' },
+        '',
+        `/mot-de-passe/nouveau#${token}`
+      );
+      protectPasswordResetToken();
+
+      expect(
+        readPasswordResetToken(window.location.pathname, window.location.hash)
+      ).toBe(token);
+
+      window.history.pushState({ entry: 'elsewhere' }, '', '/connexion');
+      window.history.pushState(
+        { entry: 'new-reset' },
+        '',
+        '/mot-de-passe/nouveau'
+      );
+
+      expect(
+        readPasswordResetToken(window.location.pathname, window.location.hash)
+      ).toBe('');
+    } finally {
+      clearPasswordResetToken();
+      window.history.replaceState(originalState, '', originalUrl);
+    }
   });
 });

--- a/frontend/src/utils/test/password-reset-token.test.ts
+++ b/frontend/src/utils/test/password-reset-token.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  PASSWORD_RESET_TOKEN_STORAGE_KEY,
+  protectPasswordResetToken,
+  readPasswordResetToken
+} from '../password-reset-token';
+
+describe('Password reset token', () => {
+  it('should move the token from the URL fragment to session storage', () => {
+    const token = 'A'.repeat(100);
+    const setItem = vi.fn();
+    const replaceState = vi.fn();
+
+    protectPasswordResetToken(
+      {
+        pathname: '/mot-de-passe/nouveau',
+        search: '?source=email',
+        hash: `#${token}`
+      },
+      { state: { navigation: true }, replaceState },
+      () => ({ setItem })
+    );
+
+    expect(setItem).toHaveBeenCalledWith(
+      PASSWORD_RESET_TOKEN_STORAGE_KEY,
+      token
+    );
+    expect(replaceState).toHaveBeenCalledWith(
+      { navigation: true },
+      '',
+      '/mot-de-passe/nouveau?source=email'
+    );
+  });
+
+  it('should read the protected token when the URL fragment has been cleared', () => {
+    const token = 'B'.repeat(100);
+
+    expect(
+      readPasswordResetToken('/mot-de-passe/nouveau', '', () => ({
+        getItem: () => token
+      }))
+    ).toBe(token);
+  });
+
+  it('should keep the token in memory when session storage is unavailable', () => {
+    const token = 'C'.repeat(100);
+
+    expect(() =>
+      protectPasswordResetToken(
+        {
+          pathname: '/mot-de-passe/nouveau',
+          search: '',
+          hash: `#${token}`
+        },
+        { state: null, replaceState: vi.fn() },
+        () => {
+          throw new DOMException('Storage unavailable', 'SecurityError');
+        }
+      )
+    ).not.toThrow();
+    expect(
+      readPasswordResetToken('/mot-de-passe/nouveau', '', () => {
+        throw new DOMException('Storage unavailable', 'SecurityError');
+      })
+    ).toBe(token);
+  });
+});

--- a/frontend/src/utils/test/sentry.test.ts
+++ b/frontend/src/utils/test/sentry.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const sentryMocks = vi.hoisted(() => ({
+  captureException: vi.fn(),
+  init: vi.fn(),
+  replayIntegration: vi.fn(() => ({}))
+}));
+
+vi.mock('@sentry/react', () => ({
+  ErrorBoundary: () => null,
+  addBreadcrumb: vi.fn(),
+  browserProfilingIntegration: vi.fn(() => ({})),
+  browserTracingIntegration: vi.fn(() => ({})),
+  captureException: sentryMocks.captureException,
+  captureMessage: vi.fn(),
+  init: sentryMocks.init,
+  reactRouterV7BrowserTracingIntegration: vi.fn(() => ({})),
+  replayIntegration: sentryMocks.replayIntegration,
+  reportingObserverIntegration: vi.fn(() => ({})),
+  setContext: vi.fn(),
+  setTag: vi.fn(),
+  setUser: vi.fn(),
+  withErrorBoundary: vi.fn(),
+  wrapCreateBrowserRouterV7: vi.fn((createRouter) => createRouter)
+}));
+
+vi.mock('../config', () => ({
+  default: {
+    apiEndpoint: 'http://localhost:3001/api',
+    sentry: {
+      dsn: 'https://sentry.example.test/1',
+      enabled: true,
+      env: 'test',
+      sampleRate: 1,
+      tracesSampleRate: 1
+    }
+  }
+}));
+
+import sentry from '../sentry';
+
+describe('Sentry', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  it('should not log raw errors or rejection reasons from global handlers', () => {
+    const token = 'A'.repeat(100);
+    const error = new Error(`Request failed: /reset-links/${token}`);
+    const rejectionReason = { password: 'MotDePasse123' };
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    sentry.init();
+
+    window.dispatchEvent(new ErrorEvent('error', { error }));
+    const rejectionEvent = new Event('unhandledrejection');
+    Object.defineProperty(rejectionEvent, 'reason', { value: rejectionReason });
+    window.dispatchEvent(rejectionEvent);
+
+    expect(consoleError.mock.calls.flat()).not.toContain(error);
+    expect(consoleError.mock.calls.flat()).not.toContain(rejectionReason);
+    expect(sentryMocks.captureException).toHaveBeenCalledWith(error);
+    expect(sentryMocks.captureException).toHaveBeenCalledWith(rejectionReason);
+  });
+
+  it('should mask DOM text in session replays', () => {
+    sentry.init();
+
+    expect(sentryMocks.replayIntegration).toHaveBeenCalledWith(
+      expect.objectContaining({
+        maskAllInputs: true,
+        maskAllText: true
+      })
+    );
+  });
+});

--- a/frontend/src/utils/test/telemetry.test.ts
+++ b/frontend/src/utils/test/telemetry.test.ts
@@ -1,0 +1,20 @@
+import { createTelemetryStarter } from '../telemetry';
+
+describe('Telemetry lifecycle', () => {
+  it('should start once navigation leaves an unprotected password-reset URL', () => {
+    const initialize = vi.fn();
+    const startWhenSafe = createTelemetryStarter(initialize);
+
+    expect(
+      startWhenSafe({
+        pathname: '/mot-de-passe/nouveau',
+        hash: '#private-reset-token'
+      })
+    ).toBe(false);
+    expect(initialize).not.toHaveBeenCalled();
+
+    expect(startWhenSafe({ pathname: '/connexion', hash: '' })).toBe(true);
+    expect(startWhenSafe({ pathname: '/', hash: '' })).toBe(true);
+    expect(initialize).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/views/Account/ResetPasswordView.tsx
+++ b/frontend/src/views/Account/ResetPasswordView.tsx
@@ -143,6 +143,7 @@ function ResetPasswordView() {
               title="Erreur"
               description={error}
               className="fr-my-3w"
+              closable
               severity="error"
             />
           )}

--- a/frontend/src/views/Account/ResetPasswordView.tsx
+++ b/frontend/src/views/Account/ResetPasswordView.tsx
@@ -5,7 +5,7 @@ import Grid from '@mui/material/Grid';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import { type FormEvent, useState } from 'react';
-import { object, string } from 'yup';
+import { object } from 'yup';
 
 import building from '../../assets/images/building.svg';
 import AppTextInput from '../../components/_app/AppTextInput/AppTextInput';
@@ -17,6 +17,9 @@ import {
   useForm
 } from '../../hooks/useForm';
 import resetLinkService from '../../services/reset-link.service';
+import { clearPasswordResetToken } from '../../utils/password-reset-token';
+
+const PASSWORD_REQUIRED_MESSAGE = 'Veuillez renseigner votre mot de passe.';
 
 function ResetPasswordView() {
   useDocumentTitle('Nouveau mot de passe');
@@ -29,23 +32,27 @@ function ResetPasswordView() {
   });
 
   const shape = {
-    password: string().required('Veuillez renseigner votre mot de passe.'),
-    passwordFormat: passwordFormatValidator,
+    password: passwordFormatValidator.required(PASSWORD_REQUIRED_MESSAGE),
     passwordConfirmation: passwordConfirmationValidator
   };
   type FormShape = typeof shape;
 
-  const form = useForm(object().shape(shape) as any, {
-    password,
-    passwordFormat: password,
-    passwordConfirmation
-  });
+  const form = useForm(
+    object().shape(shape) as any,
+    {
+      password,
+      passwordConfirmation
+    },
+    ['password']
+  );
 
   async function submit(e: FormEvent<HTMLFormElement>) {
     try {
       e.preventDefault();
+      setError('');
       await form.validate(async () => {
         await resetLinkService.resetPassword(resetLink.hash, password);
+        clearPasswordResetToken();
         setPasswordReset(true);
       });
     } catch (err) {
@@ -97,12 +104,15 @@ function ResetPasswordView() {
       >
         <Grid container spacing={2} alignItems="center">
           <Grid size="grow">
-            <Typography component="h1" variant="h4" mb={3}>
-              Votre mot de passe a été réinitialisé !
-            </Typography>
-            <Typography component="p" variant="body1">
-              Essayez de vous connecter en utilisant votre nouveau mot de passe.
-            </Typography>
+            <div role="status">
+              <Typography component="h1" variant="h4" mb={3}>
+                Votre mot de passe a été réinitialisé !
+              </Typography>
+              <Typography component="p" variant="body1">
+                Essayez de vous connecter en utilisant votre nouveau mot de
+                passe.
+              </Typography>
+            </div>
             <Stack direction="row" sx={{ justifyContent: 'flex-end' }}>
               <Button linkProps={{ to: '/connexion' }}>Se connecter</Button>
             </Stack>
@@ -131,9 +141,8 @@ function ResetPasswordView() {
           {error && (
             <Alert
               title="Erreur"
-              description="Erreur lors de la mise à jour du mot de passe."
+              description={error}
               className="fr-my-3w"
-              closable
               severity="error"
             />
           )}
@@ -151,11 +160,31 @@ function ResetPasswordView() {
               label="Créer votre mot de passe (obligatoire)"
               required
             />
-            {form.messageList('passwordFormat')?.map((message, i) => (
-              <p className={`fr-${message.type}-text`} key={i}>
-                {message.text}
-              </p>
-            ))}
+            {form
+              .messageList('password')
+              .filter((message) => message.text !== PASSWORD_REQUIRED_MESSAGE)
+              .map((message, i) => {
+                const status = form.isTouched('password')
+                  ? message.type
+                  : 'default';
+                return (
+                  <p
+                    className={
+                      status === 'default' ? undefined : `fr-${status}-text`
+                    }
+                    key={i}
+                  >
+                    <span className="fr-sr-only">
+                      {status === 'error'
+                        ? 'Critère non respecté : '
+                        : status === 'valid'
+                          ? 'Critère respecté : '
+                          : 'Critère à respecter : '}
+                    </span>
+                    {message.text}
+                  </p>
+                );
+              })}
             <AppTextInput<FormShape>
               value={passwordConfirmation}
               type="password"

--- a/frontend/src/views/Account/test/ResetPasswordView.test.tsx
+++ b/frontend/src/views/Account/test/ResetPasswordView.test.tsx
@@ -16,12 +16,8 @@ describe('ResetPasswordView', () => {
 
   function setup() {
     mockAPI.use(
-      http.get(`${config.apiEndpoint}/reset-links/:id`, ({ params }) =>
-        HttpResponse.json({
-          id: params.id,
-          createdAt: new Date().toJSON(),
-          expiresAt: new Date(Date.now() + 60 * 60 * 1000).toJSON()
-        })
+      http.get(`${config.apiEndpoint}/reset-links/:id`, () =>
+        HttpResponse.json({ valid: true })
       ),
       http.post(`${config.apiEndpoint}/account/reset-password`, () =>
         HttpResponse.json(null, { status: 200 })
@@ -55,7 +51,7 @@ describe('ResetPasswordView', () => {
     // Both fields must be non-empty to pass native HTML `required` validation
     // (this legacy form has no `noValidate`) and reach the custom yup check.
     const password = await screen.findByLabelText(/^Créer votre mot de passe/);
-    await user.type(password, 'Abcdefghij1');
+    await user.type(password, 'MotDePasse123');
     const passwordConfirmation = screen.getByLabelText(
       /^Confirmer votre mot de passe/
     );
@@ -78,7 +74,7 @@ describe('ResetPasswordView', () => {
     setup();
 
     const password = await screen.findByLabelText(/^Créer votre mot de passe/);
-    await user.type(password, 'Abcdefghij1');
+    await user.type(password, 'MotDePasse123');
     const passwordConfirmation = screen.getByLabelText(
       /^Confirmer votre mot de passe/
     );
@@ -93,9 +89,106 @@ describe('ResetPasswordView', () => {
     expect(passwordConfirmation).toHaveAttribute('aria-invalid', 'true');
 
     await user.clear(passwordConfirmation);
-    await user.type(passwordConfirmation, 'Abcdefghij1');
+    await user.type(passwordConfirmation, 'MotDePasse123');
     await user.click(submit);
 
     expect(passwordConfirmation).not.toHaveAttribute('aria-invalid');
+  });
+
+  it('should associate password policy errors with the field and not submit (RGAA 11.10)', async () => {
+    setup();
+    const resetPassword = vi.fn();
+    mockAPI.use(
+      http.post(`${config.apiEndpoint}/account/reset-password`, () => {
+        resetPassword();
+        return new HttpResponse(null, { status: 200 });
+      })
+    );
+
+    const password = await screen.findByLabelText(/^Créer votre mot de passe/);
+    await user.type(password, 'motdepasse123');
+    await user.type(
+      screen.getByLabelText(/^Confirmer votre mot de passe/),
+      'motdepasse123'
+    );
+    await user.click(
+      screen.getByRole('button', {
+        name: /Enregistrer le nouveau mot de passe/i
+      })
+    );
+
+    expect(password).toHaveAttribute('aria-invalid', 'true');
+    expect(password).toHaveAccessibleDescription(/Au moins une majuscule/);
+    const uppercaseCriterion = screen
+      .getAllByText('Au moins une majuscule.')
+      .find((element) => element.textContent?.includes('Critère non respecté'));
+    expect(uppercaseCriterion).toBeVisible();
+    expect(uppercaseCriterion).toHaveTextContent(
+      'Critère non respecté : Au moins une majuscule.'
+    );
+    expect(resetPassword).not.toHaveBeenCalled();
+  });
+
+  it('should announce an actionable error when the password cannot be reset', async () => {
+    setup();
+    mockAPI.use(
+      http.post(`${config.apiEndpoint}/account/reset-password`, () =>
+        HttpResponse.json(
+          { name: 'InternalServerError', message: 'Internal Server Error' },
+          { status: 500 }
+        )
+      )
+    );
+
+    const password = await screen.findByLabelText(/^Créer votre mot de passe/);
+    await user.type(password, 'MotDePasse123');
+    const passwordConfirmation = screen.getByLabelText(
+      /^Confirmer votre mot de passe/
+    );
+    await user.type(passwordConfirmation, 'MotDePasse123');
+    await user.click(
+      screen.getByRole('button', {
+        name: /Enregistrer le nouveau mot de passe/i
+      })
+    );
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent(
+      'Votre mot de passe n’a pas pu être enregistré. Veuillez réessayer.'
+    );
+    expect(password).toHaveValue('MotDePasse123');
+  });
+
+  it('should reset a password without special characters and announce success', async () => {
+    setup();
+    let requestBody: unknown;
+    mockAPI.use(
+      http.post(
+        `${config.apiEndpoint}/account/reset-password`,
+        async ({ request }) => {
+          requestBody = await request.json();
+          return new HttpResponse(null, { status: 200 });
+        }
+      )
+    );
+
+    const password = await screen.findByLabelText(/^Créer votre mot de passe/);
+    await user.type(password, 'MotDePasse123');
+    await user.type(
+      screen.getByLabelText(/^Confirmer votre mot de passe/),
+      'MotDePasse123'
+    );
+    await user.click(
+      screen.getByRole('button', {
+        name: /Enregistrer le nouveau mot de passe/i
+      })
+    );
+
+    const status = await screen.findByRole('status');
+    expect(status).toHaveTextContent('Votre mot de passe a été réinitialisé');
+    expect(requestBody).toEqual({
+      key: linkId,
+      password: 'MotDePasse123'
+    });
   });
 });

--- a/frontend/src/views/Account/test/ResetPasswordView.test.tsx
+++ b/frontend/src/views/Account/test/ResetPasswordView.test.tsx
@@ -45,6 +45,22 @@ describe('ResetPasswordView', () => {
     );
   }
 
+  it('should keep the password policy neutral before the user interacts with the form', async () => {
+    setup();
+
+    const password = await screen.findByLabelText(/^Créer votre mot de passe/);
+    const uppercaseCriterion = screen
+      .getAllByText('Au moins une majuscule.')
+      .find((element) => element.textContent?.includes('Critère'));
+
+    expect(password).not.toHaveAttribute('aria-invalid');
+    expect(uppercaseCriterion).toHaveTextContent(
+      'Critère à respecter : Au moins une majuscule.'
+    );
+    expect(uppercaseCriterion).not.toHaveClass('fr-error-text');
+    expect(uppercaseCriterion).not.toHaveClass('fr-valid-text');
+  });
+
   it('should mark a mismatched password confirmation as invalid and associate the error to the field (RGAA 11.10)', async () => {
     setup();
 

--- a/frontend/src/views/Account/test/ResetPasswordView.test.tsx
+++ b/frontend/src/views/Account/test/ResetPasswordView.test.tsx
@@ -1,11 +1,16 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
+import { StrictMode } from 'react';
 import { Provider } from 'react-redux';
 import { createMemoryRouter, RouterProvider } from 'react-router';
 
 import { mockAPI } from '~/mocks/mock-api';
 import config from '~/utils/config';
+import {
+  clearPasswordResetToken,
+  protectPasswordResetToken
+} from '~/utils/password-reset-token';
 
 import configureTestStore from '../../../utils/storeUtils';
 import ResetPasswordView from '../ResetPasswordView';
@@ -59,6 +64,54 @@ describe('ResetPasswordView', () => {
     );
     expect(uppercaseCriterion).not.toHaveClass('fr-error-text');
     expect(uppercaseCriterion).not.toHaveClass('fr-valid-text');
+  });
+
+  it('should retain the protected reset token through the StrictMode remount', async () => {
+    const requestedIds: string[] = [];
+    mockAPI.use(
+      http.get(`${config.apiEndpoint}/reset-links/:id`, ({ params }) => {
+        requestedIds.push(String(params.id));
+        return HttpResponse.json({ valid: true });
+      })
+    );
+    const originalState = window.history.state;
+    const originalUrl = window.location.href;
+
+    try {
+      window.history.replaceState(
+        originalState,
+        '',
+        `/mot-de-passe/nouveau#${linkId}`
+      );
+      expect(protectPasswordResetToken()).toBe(true);
+      expect(window.location.hash).toBe('');
+
+      const router = createMemoryRouter(
+        [
+          {
+            path: '/mot-de-passe/nouveau',
+            element: <ResetPasswordView />
+          }
+        ],
+        { initialEntries: ['/mot-de-passe/nouveau'] }
+      );
+      render(
+        <StrictMode>
+          <Provider store={configureTestStore()}>
+            <RouterProvider router={router} />
+          </Provider>
+        </StrictMode>
+      );
+
+      expect(
+        await screen.findByLabelText(/^Créer votre mot de passe/)
+      ).toBeVisible();
+      expect(requestedIds.length).toBeGreaterThan(0);
+      expect(new Set(requestedIds)).toEqual(new Set([linkId]));
+    } finally {
+      clearPasswordResetToken();
+      window.history.replaceState(originalState, '', originalUrl);
+    }
   });
 
   it('should mark a mismatched password confirmation as invalid and associate the error to the field (RGAA 11.10)', async () => {
@@ -173,6 +226,14 @@ describe('ResetPasswordView', () => {
       'Votre mot de passe n’a pas pu être enregistré. Veuillez réessayer.'
     );
     expect(password).toHaveValue('MotDePasse123');
+
+    const closeAlert = screen.getByRole('button', {
+      name: 'Masquer le message'
+    });
+    closeAlert.focus();
+    await user.keyboard('{Enter}');
+
+    expect(alert).not.toBeInTheDocument();
   });
 
   it('should reset a password without special characters and announce success', async () => {

--- a/packages/schemas/src/test/password.test.ts
+++ b/packages/schemas/src/test/password.test.ts
@@ -1,0 +1,30 @@
+import { fc, test } from '@fast-check/vitest';
+
+import { password } from '../password';
+
+const uppercase = fc.constantFrom(...'ABCDEFGHIJKLMNOPQRSTUVWXYZ');
+const lowercase = fc.constantFrom(...'abcdefghijklmnopqrstuvwxyz');
+const digit = fc.constantFrom(...'0123456789');
+const alphanumeric = fc.constantFrom(
+  ...'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
+);
+
+const validAlphanumericPassword = fc
+  .tuple(
+    uppercase,
+    lowercase,
+    digit,
+    fc.array(alphanumeric, { minLength: 9, maxLength: 50 })
+  )
+  .map(([upper, lower, number, rest]) =>
+    [upper, lower, number, ...rest].join('')
+  );
+
+describe('password', () => {
+  test.prop([validAlphanumericPassword])(
+    'should accept passwords without special characters',
+    (input) => {
+      expect(() => password.required().validateSync(input)).not.toThrow();
+    }
+  );
+});

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -4,4 +4,5 @@ export * from './log-level';
 export * from './logger';
 export * from './merger';
 export * from './object';
+export * from './redaction';
 export * from './string';

--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -1,6 +1,7 @@
 import pino, { LoggerOptions as PinoLoggerOptions } from 'pino';
 
 import { LogLevel } from './log-level';
+import { redactSensitiveData, redactSensitiveUrl } from './redaction';
 
 interface LoggerOptions {
   isProduction?: boolean;
@@ -41,20 +42,53 @@ export function createLogger(name: string, opts: LoggerOptions): Logger {
   // Provide a child logger to avoid overhead
   const logger = baseLogger.child({ name }, { level });
   return {
-    trace: toPinoLogFn(logger.trace.bind(logger)),
-    debug: toPinoLogFn(logger.debug.bind(logger)),
-    info: toPinoLogFn(logger.info.bind(logger)),
-    warn: toPinoLogFn(logger.warn.bind(logger)),
-    error: toPinoLogFn(logger.error.bind(logger))
+    trace: toPinoLogFn(logger.trace.bind(logger), () =>
+      logger.isLevelEnabled(LogLevel.TRACE)
+    ),
+    debug: toPinoLogFn(logger.debug.bind(logger), () =>
+      logger.isLevelEnabled(LogLevel.DEBUG)
+    ),
+    info: toPinoLogFn(logger.info.bind(logger), () =>
+      logger.isLevelEnabled(LogLevel.INFO)
+    ),
+    warn: toPinoLogFn(logger.warn.bind(logger), () =>
+      logger.isLevelEnabled(LogLevel.WARN)
+    ),
+    error: toPinoLogFn(logger.error.bind(logger), () =>
+      logger.isLevelEnabled(LogLevel.ERROR)
+    )
   };
 }
 
-function toPinoLogFn(log: pino.LogFn): LogFn {
+function toPinoLogFn(log: pino.LogFn, isEnabled: () => boolean): LogFn {
   return (messageOrData: string | object | unknown, data?: unknown) => {
-    if (typeof messageOrData === 'string') {
-      log(data, messageOrData);
-    } else {
-      log(messageOrData);
+    if (!isEnabled()) {
+      return;
     }
+    if (typeof messageOrData === 'string') {
+      log(redactLogData(data), redactSensitiveUrl(messageOrData));
+    } else {
+      log(redactLogData(messageOrData));
+    }
+  };
+}
+
+function redactLogData(value: unknown): unknown {
+  return redactSensitiveData(value, { transformError: redactError });
+}
+
+function redactError(error: Error): Record<string, unknown> {
+  const code = (error as Error & { code?: unknown }).code;
+  return {
+    name: error.name,
+    code:
+      typeof code === 'string' && /^[a-z0-9_.:-]{1,64}$/i.test(code)
+        ? code
+        : undefined,
+    stack:
+      error.stack
+        ?.split('\n')
+        .filter((line) => /^\s+at\s/.test(line))
+        .join('\n') || undefined
   };
 }

--- a/packages/utils/src/redaction.ts
+++ b/packages/utils/src/redaction.ts
@@ -7,16 +7,28 @@ export interface RedactionOptions {
 const RESET_LINK_TOKEN_PATTERN = /(\/reset-links\/)[^/?#]+/g;
 const SENSITIVE_FRAGMENT_URL_PATTERN =
   /\/(?:reset-links\/[^/?#]+|mot-de-passe\/nouveau)(?:[/?#]|$)/;
-const SENSITIVE_KEY_PATTERN =
-  /password|token|authorization|cookie|reset.?link|(^|[_-])secret($|[_-])|(?:api|session)[-_]?key|secret(?:[-_]?access)?[-_]?key|(^|[_-])key($|[_-])/i;
+
+function isSensitiveKey(key: string): boolean {
+  const segments = key.toLowerCase().split(/[-_]/);
+  const normalized = segments.join('');
+  return (
+    ['password', 'token', 'authorization', 'cookie', 'resetlink'].some(
+      (fragment) => normalized.includes(fragment)
+    ) ||
+    normalized.includes('secret') ||
+    segments.includes('key') ||
+    key.endsWith('Key')
+  );
+}
 
 export function redactSensitiveUrl(value: string): string {
   const redacted = value.replace(
     RESET_LINK_TOKEN_PATTERN,
     `$1${FILTERED_VALUE}`
   );
-  return SENSITIVE_FRAGMENT_URL_PATTERN.test(value)
-    ? redacted.replace(/#.*$/, '')
+  const fragmentIndex = redacted.indexOf('#');
+  return SENSITIVE_FRAGMENT_URL_PATTERN.test(value) && fragmentIndex >= 0
+    ? redacted.slice(0, fragmentIndex)
     : redacted;
 }
 
@@ -63,7 +75,7 @@ export function redactSensitiveData<T>(
       return;
     }
     Object.entries(current).forEach(([entryKey, entryValue]) => {
-      if (SENSITIVE_KEY_PATTERN.test(entryKey)) {
+      if (isSensitiveKey(entryKey)) {
         markSensitiveSubtree(entryValue);
       } else {
         findSensitiveObjects(entryValue);
@@ -74,7 +86,7 @@ export function redactSensitiveData<T>(
   findSensitiveObjects(value);
 
   function redact(current: unknown, key?: string): unknown {
-    if (key && SENSITIVE_KEY_PATTERN.test(key)) {
+    if (key && isSensitiveKey(key)) {
       return FILTERED_VALUE;
     }
     if (typeof current === 'string') {

--- a/packages/utils/src/redaction.ts
+++ b/packages/utils/src/redaction.ts
@@ -1,17 +1,77 @@
 export const FILTERED_VALUE = '[Filtered]';
 
-const RESET_LINK_TOKEN_PATTERN = /(\/reset-links\/)[^/?#]+/g;
-const SENSITIVE_KEY_PATTERN =
-  /password|token|authorization|cookie|reset.?link|(^|_)key($|_)/i;
-
-export function redactSensitiveUrl(value: string): string {
-  return value
-    .replace(RESET_LINK_TOKEN_PATTERN, `$1${FILTERED_VALUE}`)
-    .replace(/#.*$/, '');
+export interface RedactionOptions {
+  transformError?: (error: Error) => unknown;
 }
 
-export function redactSensitiveData<T>(value: T): T {
+const RESET_LINK_TOKEN_PATTERN = /(\/reset-links\/)[^/?#]+/g;
+const SENSITIVE_FRAGMENT_URL_PATTERN =
+  /\/(?:reset-links\/[^/?#]+|mot-de-passe\/nouveau)(?:[/?#]|$)/;
+const SENSITIVE_KEY_PATTERN =
+  /password|token|authorization|cookie|reset.?link|(^|[_-])secret($|[_-])|(?:api|session)[-_]?key|secret(?:[-_]?access)?[-_]?key|(^|[_-])key($|[_-])/i;
+
+export function redactSensitiveUrl(value: string): string {
+  const redacted = value.replace(
+    RESET_LINK_TOKEN_PATTERN,
+    `$1${FILTERED_VALUE}`
+  );
+  return SENSITIVE_FRAGMENT_URL_PATTERN.test(value)
+    ? redacted.replace(/#.*$/, '')
+    : redacted;
+}
+
+export function redactSensitiveData<T>(
+  value: T,
+  options: RedactionOptions = {}
+): T {
   const seen = new WeakMap<object, unknown>();
+  const sensitiveObjects = new WeakSet<object>();
+  const scanned = new WeakSet<object>();
+
+  function markSensitiveSubtree(current: unknown): void {
+    if (current === null || typeof current !== 'object') {
+      return;
+    }
+    if (sensitiveObjects.has(current)) {
+      return;
+    }
+    sensitiveObjects.add(current);
+    if (Array.isArray(current)) {
+      current.forEach(markSensitiveSubtree);
+      return;
+    }
+    const prototype = Object.getPrototypeOf(current);
+    if (prototype === Object.prototype || prototype === null) {
+      Object.values(current).forEach(markSensitiveSubtree);
+    }
+  }
+
+  function findSensitiveObjects(current: unknown): void {
+    if (current === null || typeof current !== 'object') {
+      return;
+    }
+    if (scanned.has(current)) {
+      return;
+    }
+    scanned.add(current);
+    if (Array.isArray(current)) {
+      current.forEach(findSensitiveObjects);
+      return;
+    }
+    const prototype = Object.getPrototypeOf(current);
+    if (prototype !== Object.prototype && prototype !== null) {
+      return;
+    }
+    Object.entries(current).forEach(([entryKey, entryValue]) => {
+      if (SENSITIVE_KEY_PATTERN.test(entryKey)) {
+        markSensitiveSubtree(entryValue);
+      } else {
+        findSensitiveObjects(entryValue);
+      }
+    });
+  }
+
+  findSensitiveObjects(value);
 
   function redact(current: unknown, key?: string): unknown {
     if (key && SENSITIVE_KEY_PATTERN.test(key)) {
@@ -22,6 +82,12 @@ export function redactSensitiveData<T>(value: T): T {
     }
     if (current === null || typeof current !== 'object') {
       return current;
+    }
+    if (sensitiveObjects.has(current)) {
+      return FILTERED_VALUE;
+    }
+    if (current instanceof Error) {
+      return options.transformError?.(current) ?? current;
     }
     if (current instanceof Date) {
       return current;
@@ -45,7 +111,12 @@ export function redactSensitiveData<T>(value: T): T {
     const clone: Record<string, unknown> = {};
     seen.set(current, clone);
     Object.entries(current).forEach(([entryKey, entryValue]) => {
-      clone[entryKey] = redact(entryValue, entryKey);
+      Object.defineProperty(clone, entryKey, {
+        configurable: true,
+        enumerable: true,
+        value: redact(entryValue, entryKey),
+        writable: true
+      });
     });
     return clone;
   }

--- a/packages/utils/src/redaction.ts
+++ b/packages/utils/src/redaction.ts
@@ -1,0 +1,54 @@
+export const FILTERED_VALUE = '[Filtered]';
+
+const RESET_LINK_TOKEN_PATTERN = /(\/reset-links\/)[^/?#]+/g;
+const SENSITIVE_KEY_PATTERN =
+  /password|token|authorization|cookie|reset.?link|(^|_)key($|_)/i;
+
+export function redactSensitiveUrl(value: string): string {
+  return value
+    .replace(RESET_LINK_TOKEN_PATTERN, `$1${FILTERED_VALUE}`)
+    .replace(/#.*$/, '');
+}
+
+export function redactSensitiveData<T>(value: T): T {
+  const seen = new WeakMap<object, unknown>();
+
+  function redact(current: unknown, key?: string): unknown {
+    if (key && SENSITIVE_KEY_PATTERN.test(key)) {
+      return FILTERED_VALUE;
+    }
+    if (typeof current === 'string') {
+      return redactSensitiveUrl(current);
+    }
+    if (current === null || typeof current !== 'object') {
+      return current;
+    }
+    if (current instanceof Date) {
+      return current;
+    }
+
+    const cached = seen.get(current);
+    if (cached) {
+      return cached;
+    }
+    if (Array.isArray(current)) {
+      const clone: unknown[] = [];
+      seen.set(current, clone);
+      current.forEach((item) => clone.push(redact(item)));
+      return clone;
+    }
+    const prototype = Object.getPrototypeOf(current);
+    if (prototype !== Object.prototype && prototype !== null) {
+      return current;
+    }
+
+    const clone: Record<string, unknown> = {};
+    seen.set(current, clone);
+    Object.entries(current).forEach(([entryKey, entryValue]) => {
+      clone[entryKey] = redact(entryValue, entryKey);
+    });
+    return clone;
+  }
+
+  return redact(value) as T;
+}

--- a/packages/utils/src/test/logger.test.ts
+++ b/packages/utils/src/test/logger.test.ts
@@ -1,0 +1,90 @@
+import { setImmediate } from 'node:timers/promises';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { LogLevel } from '../log-level';
+import { createLogger } from '../logger';
+
+describe('Logger', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('redacts structured secrets at the shared logger seam', async () => {
+    const secret = 'SharedLoggerSecret';
+    const chunks: string[] = [];
+    vi.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+      chunks.push(String(chunk));
+      return true;
+    });
+    const logger = createLogger('redaction-test', { isProduction: true });
+
+    logger.info('Sensitive request', {
+      apiKey: secret,
+      breadcrumb: 'main#content button#submit',
+      nested: { password: secret },
+      safe: 'visible'
+    });
+    await setImmediate();
+
+    const output = chunks.join('');
+    expect(output).not.toContain(secret);
+    expect(output).toContain('[Filtered]');
+    expect(output).toContain('main#content button#submit');
+    expect(output).toContain('visible');
+  });
+
+  it('does not serialize a raw Error message that may contain a secret', async () => {
+    const secret = 'RawErrorSecret';
+    const chunks: string[] = [];
+    vi.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+      chunks.push(String(chunk));
+      return true;
+    });
+    const logger = createLogger('error-redaction-test', { isProduction: true });
+
+    logger.error(new Error(`Authentication failed\n${secret}`));
+    await setImmediate();
+
+    const output = chunks.join('');
+    expect(output).not.toContain(secret);
+    expect(output).toContain('Error');
+  });
+
+  it('does not serialize secret messages from nested errors', async () => {
+    const secret = 'NestedErrorSecret';
+    const chunks: string[] = [];
+    vi.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+      chunks.push(String(chunk));
+      return true;
+    });
+    const logger = createLogger('nested-error-redaction-test', {
+      isProduction: true
+    });
+
+    logger.error('Nested failure', {
+      err: new Error(`Authentication failed\n${secret}`)
+    });
+    await setImmediate();
+
+    const output = chunks.join('');
+    expect(output).not.toContain(secret);
+    expect(output).toContain('Error');
+  });
+
+  it('does not traverse payloads for disabled log levels', () => {
+    const payload = {};
+    Object.defineProperty(payload, 'password', {
+      enumerable: true,
+      get() {
+        throw new Error('Disabled log payload should not be read');
+      }
+    });
+    const logger = createLogger('disabled-level-test', {
+      isProduction: true,
+      level: LogLevel.INFO
+    });
+
+    expect(() => logger.debug('Disabled debug log', payload)).not.toThrow();
+  });
+});

--- a/packages/utils/src/test/redaction.test.ts
+++ b/packages/utils/src/test/redaction.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  FILTERED_VALUE,
+  redactSensitiveData,
+  redactSensitiveUrl
+} from '../redaction';
+
+describe('Sensitive data redaction', () => {
+  it('should redact reset tokens and URL fragments', () => {
+    const token = 'A'.repeat(100);
+    const url = `https://example.test/reset-links/${token}?source=email#${token}`;
+
+    const redacted = redactSensitiveUrl(url);
+
+    expect(redacted).toBe(
+      `https://example.test/reset-links/${FILTERED_VALUE}?source=email`
+    );
+    expect(redacted).not.toContain(token);
+  });
+
+  it('should recursively redact secret-bearing fields and URLs', () => {
+    const token = 'B'.repeat(100);
+    const password = 'MotDePasse123';
+
+    const redacted = redactSensitiveData({
+      request: {
+        data: { key: token, password },
+        url: `https://example.test/reset-links/${token}`
+      },
+      breadcrumbs: [
+        {
+          data: { authorization: `Bearer ${token}` }
+        }
+      ]
+    });
+
+    expect(JSON.stringify(redacted)).not.toContain(token);
+    expect(JSON.stringify(redacted)).not.toContain(password);
+    expect(redacted.request.data).toEqual({
+      key: FILTERED_VALUE,
+      password: FILTERED_VALUE
+    });
+  });
+
+  it('should leave class instances untouched', () => {
+    const error = new Error('Diagnostic context');
+
+    expect(redactSensitiveData(error)).toBe(error);
+  });
+});

--- a/packages/utils/src/test/redaction.test.ts
+++ b/packages/utils/src/test/redaction.test.ts
@@ -19,6 +19,12 @@ describe('Sensitive data redaction', () => {
     expect(redacted).not.toContain(token);
   });
 
+  it('should preserve fragment-like text that is not a sensitive URL', () => {
+    const breadcrumb = 'main#content button#submit-password';
+
+    expect(redactSensitiveUrl(breadcrumb)).toBe(breadcrumb);
+  });
+
   it('should recursively redact secret-bearing fields and URLs', () => {
     const token = 'B'.repeat(100);
     const password = 'MotDePasse123';
@@ -41,6 +47,56 @@ describe('Sensitive data redaction', () => {
       key: FILTERED_VALUE,
       password: FILTERED_VALUE
     });
+  });
+
+  it('should redact common API and secret key field names', () => {
+    const value = 'SensitiveKeyValue';
+
+    const redacted = redactSensitiveData({
+      apiKey: value,
+      secret: value,
+      secretKey: value,
+      sessionKey: value,
+      'x-api-key': value
+    });
+
+    expect(redacted).toEqual({
+      apiKey: FILTERED_VALUE,
+      secret: FILTERED_VALUE,
+      secretKey: FILTERED_VALUE,
+      sessionKey: FILTERED_VALUE,
+      'x-api-key': FILTERED_VALUE
+    });
+    expect(JSON.stringify(redacted)).not.toContain(value);
+  });
+
+  it('should redact every alias of an object also referenced by a sensitive field', () => {
+    const value = 'AliasedSensitiveValue';
+    const credentials = { value };
+
+    const redacted = redactSensitiveData({
+      publicAlias: credentials,
+      password: credentials
+    });
+
+    expect(redacted).toEqual({
+      publicAlias: FILTERED_VALUE,
+      password: FILTERED_VALUE
+    });
+    expect(JSON.stringify(redacted)).not.toContain(value);
+  });
+
+  it('should preserve an own __proto__ key without mutating the clone prototype', () => {
+    const input = JSON.parse(
+      '{"__proto__":{"polluted":"yes"},"safe":"value"}'
+    ) as Record<string, unknown>;
+
+    const redacted = redactSensitiveData(input);
+
+    expect(Object.hasOwn(redacted, '__proto__')).toBe(true);
+    expect(Object.getPrototypeOf(redacted)).toBe(Object.prototype);
+    expect(redacted['__proto__']).toEqual({ polluted: 'yes' });
+    expect(({} as Record<string, unknown>)['polluted']).toBeUndefined();
   });
 
   it('should leave class instances untouched', () => {

--- a/server/src/controllers/auth-controller.ts
+++ b/server/src/controllers/auth-controller.ts
@@ -1,6 +1,7 @@
 import { constants } from 'http2';
 
 import { UserAccountDTO, UserRole } from '@zerologementvacant/models';
+import schemas from '@zerologementvacant/schemas';
 import { hashPassword } from 'better-auth/crypto';
 import { fromNodeHeaders } from 'better-auth/node';
 import { Request, Response } from 'express';
@@ -165,16 +166,7 @@ const resetPasswordSchema = object({
   key: string()
     .required()
     .matches(/^[a-zA-Z0-9]+$/),
-  password: string()
-    .required()
-    .min(12, 'Le mot de passe doit contenir au moins 12 caractères')
-    .matches(/[A-Z]/, 'Le mot de passe doit contenir au moins une majuscule')
-    .matches(/[a-z]/, 'Le mot de passe doit contenir au moins une minuscule')
-    .matches(/[0-9]/, 'Le mot de passe doit contenir au moins un chiffre')
-    .matches(
-      /[^A-Za-z0-9]/,
-      'Le mot de passe doit contenir au moins un caractère spécial'
-    )
+  password: schemas.password.required()
 });
 
 const resetPasswordValidators = {

--- a/server/src/controllers/resetLinkController.ts
+++ b/server/src/controllers/resetLinkController.ts
@@ -53,7 +53,7 @@ async function show(request: Request, response: Response) {
     throw new ResetLinkExpiredError();
   }
 
-  response.status(constants.HTTP_STATUS_OK).json(link);
+  response.status(constants.HTTP_STATUS_OK).json({ valid: true });
 }
 
 export default {

--- a/server/src/controllers/test/auth-controller.test.ts
+++ b/server/src/controllers/test/auth-controller.test.ts
@@ -87,10 +87,10 @@ describe('Account controller', () => {
   });
 
   describe('POST /account/reset-password', () => {
-    it('updates only the Better Auth credential password', async () => {
+    it('accepts the shared password policy and updates only the Better Auth credential password', async () => {
       const link = genResetLinkApi(user.id);
       await kysely.insertInto('resetLinks').values(link).execute();
-      const newPassword = '123QWEasd!@#';
+      const newPassword = '123QWEasdzxc';
 
       await kysely
         .insertInto('authUsers')

--- a/server/src/controllers/test/resetLink-api.test.ts
+++ b/server/src/controllers/test/resetLink-api.test.ts
@@ -140,9 +140,12 @@ describe('Reset link API', () => {
       const link = genResetLinkApi(user.id);
       await resetLinkRepository.insert(link);
 
-      const { status } = await request(url).get(testRoute(link.id));
+      const { body, status } = await request(url).get(testRoute(link.id));
 
       expect(status).toBe(constants.HTTP_STATUS_OK);
+      expect(body).toStrictEqual({ valid: true });
+      expect(JSON.stringify(body)).not.toContain(link.id);
+      expect(JSON.stringify(body)).not.toContain(user.id);
     });
   });
 });

--- a/server/src/errors/httpError.ts
+++ b/server/src/errors/httpError.ts
@@ -1,6 +1,13 @@
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface HttpError extends Error {
   status: number;
+  diagnostic?: ErrorDiagnostic;
+}
+
+export interface ErrorDiagnostic {
+  code?: string;
+  path?: string;
+  type?: string;
 }
 
 interface HttpErrorOptions {
@@ -9,6 +16,7 @@ interface HttpErrorOptions {
   status: number;
   data?: Record<string, unknown>;
   headers?: Readonly<Record<string, string>>;
+  diagnostic?: ErrorDiagnostic;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
@@ -16,6 +24,7 @@ export abstract class HttpError extends Error implements HttpError {
   status: number;
   data?: Record<string, unknown>;
   headers?: Readonly<Record<string, string>>;
+  diagnostic?: ErrorDiagnostic;
 
   protected constructor(options: HttpErrorOptions) {
     super(options.message);
@@ -23,6 +32,7 @@ export abstract class HttpError extends Error implements HttpError {
     this.status = options.status;
     this.data = options.data;
     this.headers = options.headers;
+    this.diagnostic = options.diagnostic;
   }
 
   toJSON(): Record<string, unknown> {

--- a/server/src/errors/httpError.ts
+++ b/server/src/errors/httpError.ts
@@ -40,7 +40,8 @@ export abstract class HttpError extends Error implements HttpError {
       name: this.name,
       message: this.message,
       status: this.status,
-      data: this.data
+      data: this.data,
+      diagnostic: this.diagnostic
     };
   }
 }

--- a/server/src/infra/openapi.yaml
+++ b/server/src/infra/openapi.yaml
@@ -1756,12 +1756,17 @@ paths:
                 password:
                   type: string
                   minLength: 12
-                  description: Min 12 chars, must include uppercase, lowercase, digit, and special character
+                  pattern: '^(?=.*[A-Z])(?=.*[a-z])(?=.*[0-9]).+$'
+                  description: Au moins 12 caractères, avec une majuscule, une minuscule et un chiffre
       responses:
         '200':
           description: Mot de passe réinitialisé avec succès
         '400':
-          description: Lien invalide ou expiré
+          description: Corps de requête invalide
+        '404':
+          description: Lien de réinitialisation introuvable
+        '410':
+          description: Lien de réinitialisation expiré ou déjà utilisé
 
   /reset-links:
     post:
@@ -1780,10 +1785,8 @@ paths:
                   type: string
                   format: email
       responses:
-        '201':
-          description: Lien de réinitialisation créé (email envoyé)
-        '404':
-          description: Email non trouvé
+        '200':
+          description: Demande prise en compte, que le compte existe ou non
 
   /reset-links/{id}:
     get:
@@ -1791,12 +1794,28 @@ paths:
       tags: [Authentication]
       security: []
       parameters:
-        - $ref: '#/components/parameters/IdParam'
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+            pattern: '^[a-zA-Z0-9]+$'
       responses:
         '200':
           description: Lien valide
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [valid]
+                properties:
+                  valid:
+                    type: boolean
+                    const: true
         '404':
-          description: Lien invalide ou expiré
+          description: Lien introuvable
+        '410':
+          description: Lien expiré ou déjà utilisé
 
   # ── Users (public) ───────────────────────────────────────────────────────────
   /users/creation:
@@ -1819,8 +1838,9 @@ paths:
                   example: nouveau@collectivite.fr
                 password:
                   type: string
-                  minLength: 8
-                  description: Mot de passe (min 8 caractères)
+                  minLength: 12
+                  pattern: '^(?=.*[A-Z])(?=.*[a-z])(?=.*[0-9]).+$'
+                  description: Au moins 12 caractères, avec une majuscule, une minuscule et un chiffre
                 firstName:
                   type: string
                   example: Jean

--- a/server/src/infra/sentry.ts
+++ b/server/src/infra/sentry.ts
@@ -1,8 +1,23 @@
 import * as Sentry from '@sentry/node';
+import { redactSensitiveData } from '@zerologementvacant/utils';
 import { Express } from 'express';
 
 import config from './config';
 import { logger } from './logger';
+
+export function sanitizeEvent<T extends Sentry.Event>(event: T): T {
+  const sanitized = redactSensitiveData({
+    ...event,
+    sdkProcessingMetadata: undefined
+  }) as T;
+  if (sanitized.request) {
+    delete sanitized.request.data;
+    delete sanitized.request.headers;
+    delete sanitized.request.cookies;
+    delete sanitized.request.query_string;
+  }
+  return sanitized;
+}
 
 function init(app: Express): void {
   if (config.sentry.enabled && !config.sentry.dsn) {
@@ -20,6 +35,8 @@ function init(app: Express): void {
       environment:
         config.app.env === 'production' ? 'production' : 'development',
       tracesSampleRate: 0.2,
+      beforeSend: sanitizeEvent,
+      beforeSendTransaction: sanitizeEvent,
       integrations: [
         new Sentry.Integrations.Http({
           tracing: true

--- a/server/src/infra/test/sentry.test.ts
+++ b/server/src/infra/test/sentry.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import { sanitizeEvent } from '../sentry';
+
+describe('Sentry', () => {
+  it('should remove authentication secrets from events', () => {
+    const token = 'C'.repeat(100);
+    const password = 'MotDePasse123';
+
+    const event = sanitizeEvent({
+      transaction: `GET /reset-links/${token}`,
+      request: {
+        url: `https://example.test/reset-links/${token}`,
+        data: { key: token, password },
+        headers: { authorization: `Bearer ${token}` },
+        cookies: { session: token },
+        query_string: `token=${token}`
+      },
+      breadcrumbs: [
+        {
+          category: 'fetch',
+          data: { url: `https://example.test/reset-links/${token}` }
+        }
+      ],
+      sdkProcessingMetadata: {
+        request: { body: { key: token, password } }
+      }
+    });
+
+    const serialized = JSON.stringify(event);
+    expect(serialized).not.toContain(token);
+    expect(serialized).not.toContain(password);
+    expect(event.request?.data).toBeUndefined();
+    expect(event.request?.headers).toBeUndefined();
+    expect(event.request?.cookies).toBeUndefined();
+    expect(event.request?.query_string).toBeUndefined();
+    expect(event.sdkProcessingMetadata).toBeUndefined();
+  });
+});

--- a/server/src/middlewares/error-handler.ts
+++ b/server/src/middlewares/error-handler.ts
@@ -11,7 +11,12 @@ import { createLogger } from '~/infra/logger';
 const logger = createLogger('error-handler');
 
 function stackFrames(error: Error): string | undefined {
-  return error.stack?.split('\n').slice(1).join('\n') || undefined;
+  return (
+    error.stack
+      ?.split('\n')
+      .filter((line) => /^\s+at\s/.test(line))
+      .join('\n') || undefined
+  );
 }
 
 function diagnosticId(error: Error): string {

--- a/server/src/middlewares/error-handler.ts
+++ b/server/src/middlewares/error-handler.ts
@@ -1,4 +1,5 @@
 import { constants } from 'http2';
+import { createHash } from 'node:crypto';
 
 import { errors as compose, ErrorHandler, Next } from 'compose-middleware';
 import { Request, Response } from 'express';
@@ -13,6 +14,14 @@ function stackFrames(error: Error): string | undefined {
   return error.stack?.split('\n').slice(1).join('\n') || undefined;
 }
 
+function diagnosticId(error: Error): string {
+  const firstStackFrame = stackFrames(error)?.split('\n')[0] ?? 'unknown';
+  return createHash('sha256')
+    .update(`${error.name}:${firstStackFrame}`)
+    .digest('hex')
+    .slice(0, 12);
+}
+
 function log(
   error: Error,
   request: Request,
@@ -22,6 +31,7 @@ function log(
   const status = isHttpError(error)
     ? error.status
     : constants.HTTP_STATUS_INTERNAL_SERVER_ERROR;
+  const isServerError = status >= constants.HTTP_STATUS_INTERNAL_SERVER_ERROR;
   logger.error({
     event: 'API Error',
     errorName: error.name,
@@ -29,10 +39,9 @@ function log(
     method: request.method,
     route: request.route?.path,
     errorId: (response as Response & { sentry?: string }).sentry,
-    stack:
-      status >= constants.HTTP_STATUS_INTERNAL_SERVER_ERROR
-        ? stackFrames(error)
-        : undefined
+    diagnosticId: isServerError ? diagnosticId(error) : undefined,
+    diagnostic: isHttpError(error) ? error.diagnostic : undefined,
+    stack: isServerError ? stackFrames(error) : undefined
   });
   next(error);
 }

--- a/server/src/middlewares/error-handler.ts
+++ b/server/src/middlewares/error-handler.ts
@@ -9,14 +9,31 @@ import { createLogger } from '~/infra/logger';
 
 const logger = createLogger('error-handler');
 
+function stackFrames(error: Error): string | undefined {
+  return error.stack?.split('\n').slice(1).join('\n') || undefined;
+}
+
 function log(
   error: Error,
   request: Request,
   response: Response,
   next: Next
 ): void {
-  // Should later be enhanced with relevant info like Request ID, user ID, etc.
-  logger.error('API Error', error);
+  const status = isHttpError(error)
+    ? error.status
+    : constants.HTTP_STATUS_INTERNAL_SERVER_ERROR;
+  logger.error({
+    event: 'API Error',
+    errorName: error.name,
+    status,
+    method: request.method,
+    route: request.route?.path,
+    errorId: (response as Response & { sentry?: string }).sentry,
+    stack:
+      status >= constants.HTTP_STATUS_INTERNAL_SERVER_ERROR
+        ? stackFrames(error)
+        : undefined
+  });
   next(error);
 }
 

--- a/server/src/middlewares/test/error-handler.test.ts
+++ b/server/src/middlewares/test/error-handler.test.ts
@@ -2,6 +2,21 @@ import { constants } from 'http2';
 
 import express, { NextFunction, Request, Response } from 'express';
 import request from 'supertest';
+import { beforeEach, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  error: vi.fn()
+}));
+
+vi.mock('~/infra/logger', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('~/infra/logger')>();
+  return {
+    ...actual,
+    createLogger: () => ({
+      error: mocks.error
+    })
+  };
+});
 
 import ExternalServiceUnavailableError from '~/errors/externalServiceUnavailableError';
 import TestAccountError from '~/errors/testAccountError';
@@ -10,10 +25,15 @@ import { genEmail } from '~/test/testFixtures';
 import errorHandler from '../error-handler';
 
 describe('Error handler', () => {
+  beforeEach(() => {
+    mocks.error.mockClear();
+  });
+
   describe('Integration test', () => {
     const expectedErrorRoute = '/fail';
     const retryableErrorRoute = '/retryable-fail';
     const unexpectedErrorRoute = '/unexpected-fail';
+    const sensitiveValue = 'SensitiveErrorValue123';
     const app = express();
 
     const email = genEmail();
@@ -37,7 +57,7 @@ describe('Error handler', () => {
     app.get(
       unexpectedErrorRoute,
       async (request: Request, response: Response, next: NextFunction) => {
-        const error = new Error('Unexpected error');
+        const error = new Error(sensitiveValue);
         next(error);
       }
     );
@@ -52,12 +72,25 @@ describe('Error handler', () => {
           message: `${email} is a test account. It cannot be used.`,
           status: constants.HTTP_STATUS_FORBIDDEN
         });
+
+      expect(mocks.error).toHaveBeenCalledWith(
+        expect.objectContaining({ stack: undefined })
+      );
     });
 
     it('should respond 500 Internal server error otherwise', async () => {
       await request(app)
         .get(unexpectedErrorRoute)
         .expect(constants.HTTP_STATUS_INTERNAL_SERVER_ERROR);
+
+      expect(JSON.stringify(mocks.error.mock.calls)).not.toContain(
+        sensitiveValue
+      );
+      expect(mocks.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          stack: expect.stringContaining('error-handler.test.ts')
+        })
+      );
     });
 
     it('returns Retry-After for a retryable upstream error', async () => {

--- a/server/src/middlewares/test/error-handler.test.ts
+++ b/server/src/middlewares/test/error-handler.test.ts
@@ -3,6 +3,7 @@ import { constants } from 'http2';
 import express, { NextFunction, Request, Response } from 'express';
 import request from 'supertest';
 import { beforeEach, vi } from 'vitest';
+import { object, string } from 'yup';
 
 const mocks = vi.hoisted(() => ({
   error: vi.fn()
@@ -23,6 +24,7 @@ import TestAccountError from '~/errors/testAccountError';
 import { genEmail } from '~/test/testFixtures';
 
 import errorHandler from '../error-handler';
+import validator from '../validator';
 
 describe('Error handler', () => {
   beforeEach(() => {
@@ -32,9 +34,12 @@ describe('Error handler', () => {
   describe('Integration test', () => {
     const expectedErrorRoute = '/fail';
     const retryableErrorRoute = '/retryable-fail';
+    const validationErrorRoute = '/validation-fail';
     const unexpectedErrorRoute = '/unexpected-fail';
     const sensitiveValue = 'SensitiveErrorValue123';
     const app = express();
+
+    app.use(express.json());
 
     const email = genEmail();
     app.get(
@@ -59,6 +64,17 @@ describe('Error handler', () => {
       async (request: Request, response: Response, next: NextFunction) => {
         const error = new Error(sensitiveValue);
         next(error);
+      }
+    );
+    app.post(
+      validationErrorRoute,
+      validator.validate({
+        body: object({
+          geoCode: string().length(5).required()
+        })
+      }),
+      (_request: Request, response: Response) => {
+        response.sendStatus(constants.HTTP_STATUS_OK);
       }
     );
     app.use(errorHandler());
@@ -88,7 +104,28 @@ describe('Error handler', () => {
       );
       expect(mocks.error).toHaveBeenCalledWith(
         expect.objectContaining({
+          diagnosticId: expect.stringMatching(/^[a-f0-9]{12}$/),
           stack: expect.stringContaining('error-handler.test.ts')
+        })
+      );
+    });
+
+    it('logs a safe structured validation diagnostic without the rejected value', async () => {
+      await request(app)
+        .post(validationErrorRoute)
+        .send({ geoCode: { secret: sensitiveValue } })
+        .expect(constants.HTTP_STATUS_BAD_REQUEST);
+
+      expect(JSON.stringify(mocks.error.mock.calls)).not.toContain(
+        sensitiveValue
+      );
+      expect(mocks.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          errorName: 'ValidationError',
+          diagnostic: {
+            path: 'body.geoCode',
+            type: 'typeError'
+          }
         })
       );
     });

--- a/server/src/middlewares/test/error-handler.test.ts
+++ b/server/src/middlewares/test/error-handler.test.ts
@@ -62,7 +62,7 @@ describe('Error handler', () => {
     app.get(
       unexpectedErrorRoute,
       async (request: Request, response: Response, next: NextFunction) => {
-        const error = new Error(sensitiveValue);
+        const error = new Error(`Safe diagnostic summary\n${sensitiveValue}`);
         next(error);
       }
     );

--- a/server/src/middlewares/test/validator.test.ts
+++ b/server/src/middlewares/test/validator.test.ts
@@ -54,6 +54,18 @@ describe('Validator middleware', () => {
       });
     });
 
+    it('should not expose invalid request values in the response', async () => {
+      const sensitiveValue = 'SensitiveValue123';
+
+      const { body, status } = await request(app)
+        .post(testRoute)
+        .send({ geoCode: { secret: sensitiveValue } })
+        .set('Content-Type', 'application/json');
+
+      expect(status).toBe(constants.HTTP_STATUS_BAD_REQUEST);
+      expect(JSON.stringify(body)).not.toContain(sensitiveValue);
+    });
+
     it('should strip unknown body keys', async () => {
       const { body, status } = await request(app)
         .post(testRoute)

--- a/server/src/middlewares/test/validator.test.ts
+++ b/server/src/middlewares/test/validator.test.ts
@@ -40,7 +40,7 @@ describe('Validator middleware', () => {
       });
     });
 
-    it('should validate wrong input', async () => {
+    it('should return safe diagnostics for invalid input', async () => {
       const { body, status } = await request(app)
         .post(testRoute)
         .send({
@@ -50,7 +50,11 @@ describe('Validator middleware', () => {
 
       expect(status).toBe(constants.HTTP_STATUS_BAD_REQUEST);
       expect(body).toMatchObject({
-        name: 'ValidationError'
+        name: 'ValidationError',
+        diagnostic: {
+          path: 'body.geoCode',
+          type: 'length'
+        }
       });
     });
 

--- a/server/src/middlewares/validator.ts
+++ b/server/src/middlewares/validator.ts
@@ -40,13 +40,14 @@ function validate(schema: RequestSchema) {
 
 class ValidationError extends HttpError implements HttpError {
   constructor(error: YupValidationError) {
+    const message =
+      error.type === 'typeError'
+        ? `Valeur invalide pour ${error.path ?? 'la requête'}.`
+        : error.message;
     super({
       name: error.name,
-      message: error.message,
-      status: constants.HTTP_STATUS_BAD_REQUEST,
-      data: {
-        ...error
-      }
+      message,
+      status: constants.HTTP_STATUS_BAD_REQUEST
     });
   }
 }

--- a/server/src/middlewares/validator.ts
+++ b/server/src/middlewares/validator.ts
@@ -47,7 +47,11 @@ class ValidationError extends HttpError implements HttpError {
     super({
       name: error.name,
       message,
-      status: constants.HTTP_STATUS_BAD_REQUEST
+      status: constants.HTTP_STATUS_BAD_REQUEST,
+      diagnostic: {
+        path: error.path,
+        type: error.type
+      }
     });
   }
 }

--- a/server/src/repositories/resetLinkRepository.ts
+++ b/server/src/repositories/resetLinkRepository.ts
@@ -11,7 +11,7 @@ async function insert(resetLinkApi: ResetLinkApi): Promise<void> {
 }
 
 async function get(id: string): Promise<ResetLinkApi | null> {
-  logger.info('Get resetLinkApi with id', id);
+  logger.info('Get reset link');
   const row = await kysely
     .selectFrom('resetLinks')
     .where('id', '=', id)
@@ -21,7 +21,7 @@ async function get(id: string): Promise<ResetLinkApi | null> {
 }
 
 async function used(id: string): Promise<void> {
-  logger.info(`Set resetLinkApi ${id} as used`);
+  logger.info('Mark reset link as used');
   await kysely
     .updateTable('resetLinks')
     .set({ usedAt: new Date() })

--- a/server/src/repositories/test/resetLinkRepository.test.ts
+++ b/server/src/repositories/test/resetLinkRepository.test.ts
@@ -1,7 +1,8 @@
 import { faker } from '@faker-js/faker/locale/fr';
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect, beforeAll, vi } from 'vitest';
 
 import { kysely } from '~/infra/database/kysely';
+import { logger } from '~/infra/logger';
 import { UserApi } from '~/models/UserApi';
 import resetLinkRepository from '~/repositories/resetLinkRepository';
 import { factories } from '~/test/factories';
@@ -69,5 +70,20 @@ describe('resetLinkRepository', () => {
         .executeTakeFirst();
       expect(row?.usedAt).not.toBeNull();
     });
+  });
+
+  it('should not write reset tokens to logs', async () => {
+    const link = genResetLinkApi(user.id);
+    await kysely.insertInto('resetLinks').values(link).execute();
+    const log = vi.spyOn(logger, 'info');
+
+    try {
+      await resetLinkRepository.get(link.id);
+      await resetLinkRepository.used(link.id);
+
+      expect(JSON.stringify(log.mock.calls)).not.toContain(link.id);
+    } finally {
+      log.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
## Summary

This PR fixes the password-reset bug reported in production:

- reset now uses the same shared password policy as account creation and password updates;
- API errors are no longer swallowed and are displayed through an accessible DSFR alert;
- password criteria remain neutral until the user interacts with the form;
- OpenAPI documents the actual password policy and reset-link responses.

## Root cause

The reset endpoint still required a special character, while the frontend and shared schema did not. When the API returned HTTP 400, the form hook treated the service error as a Yup validation error, so the submit button appeared to do nothing.

## Why the security changes are included

The investigation also showed that reset tokens, passwords or validation values could reach URLs, API responses, logs or monitoring data. These changes concern the same password-reset flow and avoid shipping it with known secret-exposure paths:

- the reset token is removed from the URL fragment before third-party tools start and is kept only in the current browser history entry;
- reset-link validation returns only `{ "valid": true }`, rather than data containing the token;
- passwords, tokens and authentication headers are redacted centrally from frontend/backend Sentry events and application logs;
- Sentry Replay masks inputs and rendered text;
- server errors retain only safe diagnostics such as validation `path`/`type`, a diagnostic ID and the Sentry correlation ID.

### Crisp and Sentry clarification

**Crisp is not newly introduced by this PR.** It keeps the same website ID and remote script. A small independent bootstrap now loads support even if the application bundle fails, except while a reset token is visible in the URL. The application initializer is idempotent and starts Crisp after the token becomes safe.

**Sentry was also already initialized.** This PR keeps the existing integration but adds input/text masking, sensitive-data redaction and exclusions for reset endpoints. If the browser prevents URL cleanup, Crisp, Sentry and PostHog remain suspended only while the token is visible, then start once navigation reaches a safe URL.

## Validation

Targeted frontend, server, schema and redaction tests pass, as do typecheck, lint and frontend/server builds. The affected form feedback was checked against the relevant RGAA validation and error-feedback criteria.

The branch history remains linear, with no merge commit.

## Deployment

Frontend and API should be deployed together. No migration, backfill or new environment variable is required.

After deployment, verify:

1. a reset with a password matching the displayed policy but without a special character;
2. an invalid or expired reset link;
3. an API failure displaying an actionable error.
