### PR TITLE
fix(frontend): keep stale preload recovery reachable in modals

### DIFF
--- a/frontend/src/utils/preloadError.ts
+++ b/frontend/src/utils/preloadError.ts
@@ -30,7 +30,14 @@ function showDefaultRecovery(reload: () => void): void {
   button.addEventListener('click', reload, { once: true });
 
   alert.append(title, description, button);
-  document.body.prepend(alert);
+  const openedModal = document.querySelector<HTMLDialogElement>(
+    'dialog.fr-modal[open]'
+  );
+  const recoveryContainer =
+    openedModal?.querySelector<HTMLElement>('.fr-modal__content') ??
+    openedModal ??
+    document.body;
+  recoveryContainer.prepend(alert);
 }
 
 interface PreloadErrorRecoveryOptions {

--- a/frontend/src/utils/test/preloadError.test.ts
+++ b/frontend/src/utils/test/preloadError.test.ts
@@ -1,14 +1,20 @@
+import userEvent from '@testing-library/user-event';
+
 import { registerPreloadErrorRecovery } from '../preloadError';
 
 describe('Preload error recovery', () => {
   let unregister: (() => void) | undefined;
+  let releaseModalFocusTrap: (() => void) | undefined;
 
   afterEach(() => {
     unregister?.();
     unregister = undefined;
+    releaseModalFocusTrap?.();
+    releaseModalFocusTrap = undefined;
     sessionStorage.clear();
     document.getElementById('vite-preload-error-recovery')?.remove();
     document.getElementById('preload-error-existing-control')?.remove();
+    document.getElementById('preload-error-modal')?.remove();
   });
 
   it('should offer recovery only once when a stale dynamic import fails', () => {
@@ -209,5 +215,56 @@ describe('Preload error recovery', () => {
     button?.click();
 
     expect(reload).toHaveBeenCalledOnce();
+  });
+
+  it('should keep the reload action keyboard-reachable when a DSFR modal is open', async () => {
+    const user = userEvent.setup();
+    const modal = document.createElement('dialog');
+    const modalContent = document.createElement('div');
+    const modalControl = document.createElement('button');
+    modal.id = 'preload-error-modal';
+    modal.className = 'fr-modal';
+    modal.setAttribute('open', 'true');
+    modalContent.className = 'fr-modal__content';
+    modalControl.type = 'button';
+    modalControl.textContent = 'Action de la modale';
+    modalContent.append(modalControl);
+    modal.append(modalContent);
+    document.body.append(modal);
+    const trapTabulation = (event: KeyboardEvent) => {
+      if (event.key !== 'Tab') return;
+
+      const focusables = Array.from(
+        modal.querySelectorAll<HTMLButtonElement>('button:not([disabled])')
+      );
+      const first = focusables[0];
+      const last = focusables.at(-1);
+
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last?.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first?.focus();
+      }
+    };
+    window.addEventListener('keydown', trapTabulation);
+    releaseModalFocusTrap = () => {
+      window.removeEventListener('keydown', trapTabulation);
+    };
+    unregister = registerPreloadErrorRecovery({ now: () => 100_000 });
+    modalControl.focus();
+
+    window.dispatchEvent(new Event('vite:preloadError', { cancelable: true }));
+    await user.tab();
+
+    const reloadButton = document.querySelector<HTMLButtonElement>(
+      '#vite-preload-error-recovery button'
+    );
+    expect(reloadButton).toHaveFocus();
+
+    await user.tab({ shift: true });
+
+    expect(modalControl).toHaveFocus();
   });
 });


### PR DESCRIPTION
## Contexte

La PR #1942 a été fusionnée avant traitement du retour RGAA concernant l’action de rechargement affichée lors d’une erreur de préchargement Vite.

Lorsqu’une modale DSFR était ouverte, cette action était ajoutée au `body`, en dehors du focus trap de la modale. Elle pouvait donc ne pas être atteignable au clavier.

## Correction

Cette PR déplace l’action de rechargement dans le contenu de la modale DSFR ouverte, avec un repli vers la modale elle-même puis vers le `body` lorsqu’aucune modale n’est ouverte.

Aucun autre changement fonctionnel n’est inclus.

## Validation

- 10 tests ciblés ;
- typecheck frontend ;
- build frontend ;
- lint ;
- format ;
- `git diff --check`.

## RGAA

Les critères suivants ont été vérifiés :

- 7.3 : l’action reste contrôlable au clavier ;
- 7.5 : le message d’erreur conserve son annonce via `role="alert"` ;
- 12.8 : l’ordre de tabulation reste cohérent dans la modale ;
- 12.9 : l’action n’est plus située hors du focus trap DSFR.
