### PR TITLE
fix(analytics): resolve event author establishment for deleted users

### DIFF
--- a/analytics/dbt/models/intermediate/production/int_production_events.sql
+++ b/analytics/dbt/models/intermediate/production/int_production_events.sql
@@ -1,4 +1,28 @@
-WITH all_events AS (
+-- Résolution de l'auteur d'un événement.
+--
+-- On lit `stg_production_users` (tous les utilisateurs) et NON
+-- `int_production_users` (qui filtre `deleted_at IS NULL`). Sinon tout
+-- événement créé par un utilisateur depuis supprimé perd son
+-- `establishment_id` (NULL) et n'est plus attribuable à aucun établissement:
+-- ~25 000 logements orphelins, dont 19 000 récupérables ici.
+--
+-- Même raison pour `user_type`: il était calculé dans `int_production_users`,
+-- donc NULL pour un utilisateur supprimé, puis ramené à 'user' par le
+-- COALESCE ci-dessous. Un administrateur ZLV supprimé était ainsi compté
+-- comme un utilisateur de collectivité.
+WITH event_authors AS (
+    SELECT
+        id,
+        establishment_id,
+        deleted_at,
+        CASE
+            WHEN email LIKE '%beta.gouv.fr' THEN 'zlv'
+            ELSE 'user'
+        END AS user_type
+    FROM {{ ref ('stg_production_users') }}
+),
+
+all_events AS (
     SELECT
         id,
         created_at,
@@ -48,9 +72,12 @@ SELECT
     s.new AS new_status_refined,
     s.new AS event_status_label,
     version as event_version,
-    coalesce(user_type, 'user') AS user_source,
-    CAST(u.establishment_id AS VARCHAR) AS establishment_id
+    coalesce(u.user_type, 'user') AS user_source,
+    CAST(u.establishment_id AS VARCHAR) AS establishment_id,
+    -- TRUE si l'auteur a depuis été supprimé: l'événement reste attribué à son
+    -- établissement, mais l'utilisateur n'apparaît plus dans les effectifs.
+    u.deleted_at IS NOT NULL AS created_by_deleted_user
 FROM
     all_events ae
-LEFT JOIN {{ ref ('int_production_users') }} u ON ae.created_by = u.id
+LEFT JOIN event_authors u ON ae.created_by = u.id
 LEFT JOIN {{ ref ('status') }} s ON s.status = ae.new_status

--- a/analytics/dbt/models/intermediate/production/schema.yml
+++ b/analytics/dbt/models/intermediate/production/schema.yml
@@ -14,7 +14,21 @@ models:
       - name: type
         description: "Type d'événement (housing:status-updated, housing:occupancy-updated, etc.)"
       - name: user_source
-        description: "Source de l'événement (zlv=automatique, user=utilisateur)"
+        description: |
+          Source de l'événement (zlv=automatique, user=utilisateur). Déduit de
+          l'email de l'auteur, y compris pour les utilisateurs supprimés.
+      - name: establishment_id
+        description: |
+          Établissement de l'utilisateur ayant créé l'événement. Résolu depuis
+          stg_production_users (utilisateurs supprimés inclus), ce qui rend
+          l'événement attribuable même après suppression du compte. NULL
+          uniquement lorsque created_by est absent de la table users (~2% des
+          événements utilisateurs).
+      - name: created_by_deleted_user
+        description: |
+          TRUE si l'auteur de l'événement a depuis été supprimé. L'événement
+          reste attribué à son établissement, mais l'utilisateur n'apparaît plus
+          dans les effectifs (user_number).
       - name: version
         description: "Version du format (old=texte, new=JSON)"
         tests:

--- a/analytics/dbt/tests/production/events/test_events_establishment_resolution_rate.sql
+++ b/analytics/dbt/tests/production/events/test_events_establishment_resolution_rate.sql
@@ -1,0 +1,33 @@
+-- Test: la quasi-totalité des événements utilisateurs doit être rattachable à un
+-- établissement.
+--
+-- Bug historique: int_production_events résolvait l'auteur via
+-- int_production_users, qui filtre `deleted_at IS NULL`. Tout événement créé par
+-- un utilisateur depuis supprimé perdait donc son establishment_id, et
+-- disparaissait de tous les compteurs par établissement (~14% des logements mis
+-- à jour, soit ~25 000 logements, dont 19 000 récupérables).
+--
+-- Depuis la résolution via stg_production_users, seuls restent orphelins les
+-- événements dont le created_by est absent de la table users (~6 300 logements,
+-- ~3,6%). Le seuil de 6% laisse de la marge sans laisser repasser la régression.
+
+{{ config(severity='error') }}
+
+WITH user_events AS (
+    SELECT
+        COUNT(*) AS total_events,
+        COUNT(*) FILTER (WHERE establishment_id IS NULL) AS unresolved_events
+    FROM {{ ref('int_production_events') }}
+    WHERE user_source = 'user'
+      AND type IN ('housing:status-updated', 'housing:occupancy-updated')
+      AND housing_id IS NOT NULL
+)
+
+SELECT
+    total_events,
+    unresolved_events,
+    ROUND(unresolved_events::FLOAT / total_events * 100, 2) AS unresolved_pct,
+    'Trop d''événements utilisateurs sans établissement rattaché' AS issue
+FROM user_events
+WHERE total_events > 0
+  AND unresolved_events::FLOAT / total_events > 0.06


### PR DESCRIPTION
## Problem

`int_production_events` resolved the event author through `int_production_users`, which filters `deleted_at IS NULL`. Any event created by a user whose account was later deleted lost its `establishment_id`, so it vanished from every per-establishment counter in the warehouse.

Same root cause for `user_source`: `user_type` was computed inside `int_production_users`, so it was `NULL` for deleted users and silently fell back to `'user'` via the `COALESCE`. Deleted ZLV admin accounts (`@beta.gouv.fr`) were counted as local-authority users.

## Fix

Resolve the author from `stg_production_users` (deleted users included) in a dedicated `event_authors` CTE, and derive `user_type` from the email there.

## Measured impact

On `housing:status-updated` / `housing:occupancy-updated` events with `user_source = 'user'`:

| Metric | Before | After |
|---|---|---|
| Events with no establishment | 16.71% | **2.08%** |
| Distinct housing attributed to an establishment | 155 699 | **176 839** |
| Events reclassified `user` → `zlv` | — | 4 944 |

The residual 2.08% are events whose `created_by` is absent from the users table altogether (~6 300 housing) — not recoverable from the warehouse.

## Also included

- `created_by_deleted_user` boolean, so downstream models can still tell that the author is gone from the establishment's headcount.
- Regression test `test_events_establishment_resolution_rate` asserting the unresolved rate stays under 6%.
- `schema.yml` documentation for `establishment_id`, `user_source` and the new column.

## Downstream figures that move (upward)

`marts_production_housing`, `marts_production_establishments_activation`, `marts_production_establishments_category_pro_activity`, `marts_bi_housing_*`, `marts_zlv_usage`.

This is PR 1 of 2. PR 2 reworks `marts_zlv_usage` itself (single attribution rule, distinct counting, échelons, yearly breakdown).

## Verification

`dbt compile` passes. The compiled SQL was executed read-only against `dwh` to produce the figures above; `dbt run --target prod` was deliberately not executed from this branch.