### PR TITLE
fix(analytics): rework marts_zlv_usage on a single attribution rule

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,141 @@
+# Zéro Logement Vacant
+
+Service public français de lutte contre la vacance des logements. Les
+collectivités y suivent des logements vacants identifiés à partir des fichiers
+LOVAC, contactent leurs propriétaires et enregistrent l'évolution de
+l'occupation.
+
+Ce document est un **glossaire** : il fixe le vocabulaire du domaine et rien
+d'autre. Les choix techniques sont documentés dans [docs/decisions](./docs/decisions).
+
+## Language
+
+### Sources et millésimes
+
+**Millésime LOVAC** :
+Une livraison annuelle du fichier LOVAC, identifiée par son année de
+publication (2019 à 2026). Chaque millésime est un instantané complet et
+autonome, pas un delta par rapport au précédent.
+_Avoid_: année LOVAC, version LOVAC, cru
+
+**Local** :
+Une unité immobilière telle que le fichier LOVAC la décrit, quelle que soit sa
+nature (habitation, commerce, dépendance).
+_Avoid_: bien, unité, ligne LOVAC
+
+**Logement** :
+Un local à usage d'habitation, c'est-à-dire un appartement ou une maison
+effectivement affecté à l'habitation. Tout logement est un local ; l'inverse
+est faux. Un logement est identifié de façon unique par son identifiant local.
+_Avoid_: habitation, bien, local (quand on parle bien d'habitation)
+
+### Populations de logements
+
+La distinction suivante est la source de confusion la plus fréquente du projet :
+deux populations différentes portent le même nom courant de « logements
+vacants » et ne coïncident pas.
+
+**Stock LOVAC** :
+L'ensemble des logements qu'un millésime LOVAC déclare vacants sur un
+territoire donné. C'est une mesure de la vacance réelle telle que l'État
+l'observe, indépendante de ZLV. C'est ce que présente Analyses.
+_Avoid_: parc vacant, logements vacants (seul), stock de vacance
+
+**Parc ZLV importé** :
+L'ensemble des logements que ZLV a effectivement importés d'un millésime LOVAC
+donné, et qui existent donc dans l'application. C'est une mesure de ce que ZLV
+connaît et donne à suivre aux collectivités. C'est ce que présente Parc de
+logements.
+_Avoid_: parc de logements, logements ZLV, logements suivis
+
+**Millésime inclus** :
+Critère de provenance : « ZLV a importé ce logement depuis le millésime LOVAC
+de telle année ». C'est une propriété de traçabilité du Parc ZLV importé, et
+non une affirmation sur la présence du logement dans le fichier LOVAC de cette
+année-là. Un logement peut appartenir au Stock LOVAC d'un millésime sans porter
+le millésime inclus correspondant.
+_Avoid_: présence dans le millésime, année de vacance, millésime d'origine
+
+### Qualification de la vacance
+
+**Vacance FIL** :
+Vacance constatée depuis plus de deux ans au regard de la seule année de début
+de vacance déclarée dans le millésime. Critère retenu pour les millésimes 2025
+et suivants.
+_Avoid_: vacance longue, vacance structurelle
+
+**Vacance FIL+CCTHP** :
+Vacance FIL confirmée par le classement du local comme vacant dans les Fichiers
+Fonciers. Critère plus restrictif, retenu pour les millésimes 2019 à 2024.
+_Avoid_: vacance croisée, vacance confirmée
+
+**Parc privé** :
+Logements dont le propriétaire n'est ni une personne morale publique ni un
+bailleur social. C'est le périmètre d'action de ZLV.
+_Avoid_: hors bailleurs, non social
+
+### Territoires
+
+**Établissement** :
+Une collectivité utilisatrice de ZLV (commune, EPCI, département, région).
+_Avoid_: collectivité (dans le code), organisation, structure
+
+**Périmètre** :
+L'ensemble des communes qu'un établissement couvre, et donc l'assiette de tous
+ses chiffres.
+_Avoid_: territoire, ressort, zone
+
+**Échelon** :
+Le niveau administratif d'un établissement : commune, intercommunalité,
+département, région. Deux établissements d'échelons différents couvrent
+légitimement le même logement.
+_Avoid_: niveau, type, strate
+
+**Établissement inscrit** :
+Un établissement qui compte au moins un utilisateur. Mesure la présence d'une
+collectivité sur ZLV, indépendamment de son activité.
+_Avoid_: établissement actif, collectivité présente
+
+**Établissement ouvert** :
+Un établissement inscrit dont l'accès est par ailleurs ouvert. Sous-ensemble des
+établissements inscrits : les deux notions ne se substituent pas l'une à l'autre.
+_Avoid_: établissement disponible, compte actif
+
+### Usage de l'application
+
+**Attribution événementielle** :
+Rattacher une action à l'établissement de l'utilisateur qui l'a effectuée, et non
+aux établissements dont le périmètre couvre le logement concerné. C'est la règle
+de tous les compteurs d'activité.
+_Avoid_: attribution géographique, rattachement territorial
+
+**Logement mis à jour** :
+Un logement dont un utilisateur d'un établissement a modifié le suivi ou
+l'occupation. Se compte toujours en logements distincts par établissement.
+_Avoid_: logement traité, logement modifié, logement suivi
+
+**Logement contacté** :
+Un logement dont le propriétaire a reçu au moins un courrier d'une campagne
+envoyée. Un logement recontacté reste un seul logement contacté.
+_Avoid_: contact, envoi, logement ciblé
+
+**Enrichissement** :
+Toute amélioration de la connaissance d'un logement ou de son propriétaire par un
+utilisateur : coordonnées, identité, adresse, rang, note, document, DPE constaté.
+Distinct de la mise à jour de situation, qui porte sur le suivi et l'occupation.
+_Avoid_: complétion, qualification, fiabilisation
+
+**Acte** :
+Une intervention unitaire d'un utilisateur. Un même logement peut porter
+plusieurs actes, donc un comptage d'actes est toujours supérieur ou égal au
+comptage de logements distincts correspondant. Les deux mesures répondent à des
+questions différentes — effort fourni contre couverture atteinte — et ne doivent
+jamais être présentées l'une pour l'autre.
+_Avoid_: action, opération, mise à jour (au sens du décompte)
+
+**Logement distinct** :
+L'unité de tout compteur nommé « logements ». Deux conséquences : un logement
+touché plusieurs fois ne compte qu'une fois, et les compteurs de deux
+établissements ne s'additionnent pas, un logement pouvant être compté par
+chacun d'eux.
+_Avoid_: nombre de logements (sans qualificatif), volume

--- a/analytics/dbt/models/intermediate/analysis/int_analysis_establishments_zlv_usage.sql
+++ b/analytics/dbt/models/intermediate/analysis/int_analysis_establishments_zlv_usage.sql
@@ -243,78 +243,189 @@ housing_status_counts AS (
         ON COALESCE(f.establishment_id, o.establishment_id) = s.establishment_id
 ),
 
-owner_enrichment_events AS (
+-- =====================================================================
+-- ENRICHISSEMENT
+-- =====================================================================
+-- Même règle d'attribution que ci-dessus: l'événement est rattaché à
+-- l'établissement de son AUTEUR (via int_production_event_authors, utilisateurs
+-- supprimés inclus).
+--
+-- Particularité des événements 'owner:updated': ils portent sur un
+-- PROPRIÉTAIRE, pas sur un logement, et se déplient donc sur tous les logements
+-- de ce propriétaire — y compris ceux situés hors du territoire de
+-- l'établissement (57% des paires mesurées). On intersecte donc avec le
+-- périmètre de l'établissement: le géo n'est pas ici un mode d'attribution mais
+-- un filtre d'assiette. Sens retenu: "logements de mon territoire dont j'ai
+-- enrichi le propriétaire".
+
+owner_enrichment_pairs AS (
     SELECT
-        oeh.establishment_id,
-        COUNT(DISTINCT CASE
-            WHEN (oev.next_new ->> 'email') IS DISTINCT FROM (oev.next_old ->> 'email')
-            THEN ooh.housing_id
-        END) AS logements_maj_mails,
-        COUNT(DISTINCT CASE
-            WHEN (oev.next_new ->> 'phone') IS DISTINCT FROM (oev.next_old ->> 'phone')
-            THEN ooh.housing_id
-        END) AS logements_maj_phone,
-        COUNT(DISTINCT CASE
-            WHEN (oev.next_new ->> 'name') IS DISTINCT FROM (oev.next_old ->> 'name')
-            THEN ooh.housing_id
-        END) AS logements_maj_owners,
-        COUNT(DISTINCT CASE
-            WHEN (oev.next_new ->> 'address') IS DISTINCT FROM (oev.next_old ->> 'address')
-              OR (oev.next_new ->> 'additionalAddress') IS DISTINCT FROM (oev.next_old ->> 'additionalAddress')
-            THEN ooh.housing_id
-        END) AS logements_maj_owners_address,
-        MIN(oev.created_at) AS date_premiere_enrichissement_owner,
-        MAX(oev.created_at) AS date_derniere_enrichissement_owner
+        CAST(ou.establishment_id AS VARCHAR) AS establishment_id,
+        ooh.housing_id,
+        oev.created_at,
+        (oev.next_new ->> 'email') IS DISTINCT FROM (oev.next_old ->> 'email') AS mail_changed,
+        (oev.next_new ->> 'phone') IS DISTINCT FROM (oev.next_old ->> 'phone') AS phone_changed,
+        (oev.next_new ->> 'name') IS DISTINCT FROM (oev.next_old ->> 'name') AS name_changed,
+        (
+            (oev.next_new ->> 'address') IS DISTINCT FROM (oev.next_old ->> 'address')
+            OR (oev.next_new ->> 'additionalAddress') IS DISTINCT FROM (oev.next_old ->> 'additionalAddress')
+        ) AS address_changed
     FROM {{ ref('stg_production_owner_events') }} oe
     JOIN {{ ref('stg_production_events') }} oev ON oe.event_id = oev.id
     JOIN {{ ref('stg_production_owners_housing') }} ooh ON oe.owner_id = ooh.owner_id
-    JOIN {{ ref('int_production_establishments_housing') }} oeh ON ooh.housing_id = oeh.housing_id
-    JOIN {{ ref('int_production_users') }} ou ON oev.created_by = ou.id
+    JOIN {{ ref('int_production_event_authors') }} ou ON oev.created_by = ou.id
+    JOIN {{ ref('int_production_establishments_housing') }} oeh
+        ON ooh.housing_id = oeh.housing_id
+       AND CAST(oeh.establishment_id AS VARCHAR) = CAST(ou.establishment_id AS VARCHAR)
     WHERE oev.type = 'owner:updated'
-    GROUP BY oeh.establishment_id
+      AND ou.user_type = 'user'
+),
+
+owner_enrichment_events AS (
+    SELECT
+        establishment_id,
+        COUNT(DISTINCT CASE WHEN mail_changed THEN housing_id END) AS logements_maj_mails,
+        COUNT(DISTINCT CASE WHEN phone_changed THEN housing_id END) AS logements_maj_phone,
+        COUNT(DISTINCT CASE WHEN name_changed THEN housing_id END) AS logements_maj_owners,
+        COUNT(DISTINCT CASE WHEN address_changed THEN housing_id END) AS logements_maj_owners_address
+    FROM owner_enrichment_pairs
+    GROUP BY establishment_id
+),
+
+rank_change_pairs AS (
+    SELECT
+        CAST(ru.establishment_id AS VARCHAR) AS establishment_id,
+        rhe.housing_id,
+        rev.created_at
+    FROM {{ ref('stg_production_housing_events') }} rhe
+    JOIN {{ ref('stg_production_events') }} rev ON rhe.event_id = rev.id
+    JOIN {{ ref('int_production_event_authors') }} ru ON rev.created_by = ru.id
+    JOIN {{ ref('int_production_establishments_housing') }} reh
+        ON rhe.housing_id = reh.housing_id
+       AND CAST(reh.establishment_id AS VARCHAR) = CAST(ru.establishment_id AS VARCHAR)
+    WHERE rev.type = 'housing:owner-updated'
+      AND ru.user_type = 'user'
+      AND (rev.next_new ->> 'rank') IS DISTINCT FROM (rev.next_old ->> 'rank')
 ),
 
 rank_change_events AS (
     SELECT
-        reh.establishment_id,
-        COUNT(DISTINCT CASE
-            WHEN (rev.next_new ->> 'rank') IS DISTINCT FROM (rev.next_old ->> 'rank')
-            THEN rhe.housing_id
-        END) AS logements_maj_owners_rank
-    FROM {{ ref('stg_production_housing_events') }} rhe
-    JOIN {{ ref('stg_production_events') }} rev ON rhe.event_id = rev.id
-    JOIN {{ ref('int_production_establishments_housing') }} reh ON rhe.housing_id = reh.housing_id
-    JOIN {{ ref('int_production_users') }} ru ON rev.created_by = ru.id
-    WHERE rev.type = 'housing:owner-updated'
-    GROUP BY reh.establishment_id
+        establishment_id,
+        COUNT(DISTINCT housing_id) AS logements_maj_owners_rank
+    FROM rank_change_pairs
+    GROUP BY establishment_id
+),
+
+notes_pairs AS (
+    SELECT
+        CAST(n.establishment_id AS VARCHAR) AS establishment_id,
+        n.housing_id,
+        n.created_at
+    FROM {{ ref('int_production_notes') }} n
+    WHERE n.user_type = 'user'
+      AND n.deleted_at IS NULL
+      AND n.establishment_id IS NOT NULL
+      AND n.housing_id IS NOT NULL
 ),
 
 notes_stats AS (
     SELECT
-        n.establishment_id,
-        COUNT(DISTINCT n.housing_id) AS logements_maj_notes
-    FROM {{ ref('int_production_notes') }} n
-    WHERE n.user_type = 'user'
-    AND n.deleted_at IS NULL
-    GROUP BY n.establishment_id
+        establishment_id,
+        COUNT(DISTINCT housing_id) AS logements_maj_notes
+    FROM notes_pairs
+    GROUP BY establishment_id
+),
+
+document_pairs AS (
+    SELECT
+        CAST(du.establishment_id AS VARCHAR) AS establishment_id,
+        hde.housing_id,
+        dev.created_at
+    FROM {{ ref('stg_production_housing_document_events') }} hde
+    JOIN {{ ref('stg_production_events') }} dev ON hde.event_id = dev.id
+    JOIN {{ ref('int_production_event_authors') }} du ON dev.created_by = du.id
+    WHERE du.user_type = 'user'
+      AND du.establishment_id IS NOT NULL
 ),
 
 document_stats AS (
     SELECT
-        du.establishment_id,
-        COUNT(DISTINCT hde.housing_id) AS logements_maj_documents,
+        establishment_id,
+        COUNT(DISTINCT housing_id) AS logements_maj_documents,
         COUNT(*) AS documents_importes,
-        MAX(dev.created_at) AS date_dernier_document_importe
-    FROM {{ ref('stg_production_housing_document_events') }} hde
-    JOIN {{ ref('stg_production_events') }} dev ON hde.event_id = dev.id
-    JOIN {{ ref('int_production_users') }} du ON dev.created_by = du.id
-    GROUP BY du.establishment_id
+        MAX(created_at) AS date_dernier_document_importe
+    FROM document_pairs
+    GROUP BY establishment_id
 ),
+
+-- Mise à jour du DPE constaté par un utilisateur. La colonne
+-- `housing.actual_dpe` (migration de janvier 2026) ne porte ni date ni auteur:
+-- on part donc de l'événement 'housing:updated' qui trace la modification.
+-- Volumétrie faible et attendue: la fonctionnalité est récente et peu utilisée.
+dpe_pairs AS (
+    SELECT
+        CAST(pu.establishment_id AS VARCHAR) AS establishment_id,
+        phe.housing_id,
+        pev.created_at
+    FROM {{ ref('stg_production_housing_events') }} phe
+    JOIN {{ ref('stg_production_events') }} pev ON phe.event_id = pev.id
+    JOIN {{ ref('int_production_event_authors') }} pu ON pev.created_by = pu.id
+    WHERE pev.type = 'housing:updated'
+      AND (pev.next_new ->> 'actualEnergyConsumption')
+          IS DISTINCT FROM (pev.next_old ->> 'actualEnergyConsumption')
+      AND pu.user_type = 'user'
+      AND pu.establishment_id IS NOT NULL
+),
+
+dpe_stats AS (
+    SELECT
+        establishment_id,
+        COUNT(DISTINCT housing_id) AS logements_maj_dpe,
+        MAX(created_at) AS date_derniere_maj_dpe
+    FROM dpe_pairs
+    GROUP BY establishment_id
+),
+
+-- Agrégat d'enrichissement: logements DISTINCTS touchés par au moins une des
+-- familles d'enrichissement. À ne pas confondre avec la somme des familles, qui
+-- compte des ACTES (un logement dont le mail ET le téléphone ont été corrigés y
+-- compterait deux fois).
+enrichment_union AS (
+    SELECT establishment_id, housing_id, created_at FROM owner_enrichment_pairs
+    UNION
+    SELECT establishment_id, housing_id, created_at FROM rank_change_pairs
+    UNION
+    SELECT establishment_id, housing_id, created_at FROM notes_pairs
+    UNION
+    SELECT establishment_id, housing_id, created_at FROM document_pairs
+    UNION
+    SELECT establishment_id, housing_id, created_at FROM dpe_pairs
+),
+
+enrichment_counts AS (
+    SELECT
+        establishment_id,
+        COUNT(DISTINCT housing_id) AS logements_maj_enrichissement,
+        COUNT(*) AS actes_enrichissement,
+        MIN(created_at) AS date_premiere_maj_enrichissement,
+        MAX(created_at) AS date_derniere_maj_enrichissement
+    FROM enrichment_union
+    GROUP BY establishment_id
+),
+
+-- =====================================================================
+-- CAMPAGNES / GROUPES
+-- =====================================================================
+-- `logements_*` compte des logements DISTINCTS (un logement présent dans
+-- plusieurs campagnes ou plusieurs groupes ne compte qu'une fois).
+-- `contacts_campagnes` / `exports_groupes` gardent la volumétrie brute, utile
+-- comme mesure d'effort.
 
 campaign_housing_stats AS (
     SELECT
-        pc.establishment_id,
-        COUNT(pch.housing_id) AS logements_contactes_via_campagnes
+        CAST(pc.establishment_id AS VARCHAR) AS establishment_id,
+        COUNT(DISTINCT pch.housing_id) AS logements_contactes_via_campagnes,
+        COUNT(pch.housing_id) AS contacts_campagnes
     FROM {{ ref('int_production_campaigns') }} pc
     JOIN {{ ref('int_production_campaigns_housing') }} pch ON pc.campaign_id = pch.campaign_id
     WHERE pc.sent_at IS NOT NULL
@@ -323,24 +434,13 @@ campaign_housing_stats AS (
 
 group_housing_stats AS (
     SELECT
-        pg.establishment_id,
-        COUNT(phg.housing_id) AS logements_exportes_via_groupes
+        CAST(pg.establishment_id AS VARCHAR) AS establishment_id,
+        COUNT(DISTINCT phg.housing_id) AS logements_exportes_via_groupes,
+        COUNT(phg.housing_id) AS exports_groupes
     FROM {{ ref('stg_production_groups') }} pg
     JOIN {{ ref('stg_production_groups_housing') }} phg ON pg.id = phg.group_id
     WHERE pg.exported_at IS NOT NULL
     GROUP BY pg.establishment_id
-),
-
-dpe_stats AS (
-    SELECT
-        eh.establishment_id,
-        COUNT(DISTINCT CASE
-            WHEN h.actual_dpe IS NOT NULL
-            THEN eh.housing_id
-        END) AS logements_maj_dpe
-    FROM {{ ref('int_production_establishments_housing') }} eh
-    JOIN {{ ref('stg_production_housing') }} h ON CAST(h.id AS VARCHAR) = eh.housing_id
-    GROUP BY eh.establishment_id
 ),
 
 housing_park_counts AS (
@@ -365,35 +465,24 @@ geo_reference AS (
       AND mcm.region_label IS NOT NULL
 ),
 
-communes_with_commune_establishment AS (
-    SELECT DISTINCT cel.geo_code
-    FROM {{ ref('int_production_establishments_localities') }} cel
-    JOIN {{ ref('marts_production_establishments') }} ce
-        ON CAST(cel.establishment_id AS VARCHAR) = ce.establishment_id
-    WHERE ce.kind = 'Commune'
-      AND COALESCE(ce.user_number, 0) > 0
-),
+-- Millésimes exposés en colonnes larges: de la première campagne envoyée
+-- (2020) à l'année courante. Liste calculée à la compilation pour ne pas avoir
+-- à rouvrir le modèle chaque 1er janvier.
+{% set first_year = 2020 %}
+{% set last_year = modules.datetime.date.today().year %}
+{% set years = range(first_year, last_year + 1) | list %}
 
-echelons_inscrits AS (
+annual_pivot AS (
     SELECT
-        CAST(el.establishment_id AS VARCHAR) AS establishment_id,
-        COUNT(DISTINCT el.geo_code) AS total_communes_in_territory,
-        COUNT(DISTINCT cwce.geo_code) AS communes_inscrites,
-        CASE
-            WHEN COUNT(DISTINCT el.geo_code) > 0
-            THEN ROUND(
-                COUNT(DISTINCT cwce.geo_code)::FLOAT
-                / COUNT(DISTINCT el.geo_code) * 100, 0
-            )
-            ELSE NULL
-        END AS communes_inscrites_pct
-    FROM {{ ref('int_production_establishments_localities') }} el
-    JOIN {{ ref('marts_production_establishments') }} e
-        ON CAST(el.establishment_id AS VARCHAR) = e.establishment_id
-    LEFT JOIN communes_with_commune_establishment cwce
-        ON el.geo_code = cwce.geo_code
-    WHERE e.kind IN ('CA', 'CC', 'CU', 'ME')
-    GROUP BY el.establishment_id
+        establishment_id,
+        {% for year in years %}
+        COALESCE(SUM(CASE WHEN annee = {{ year }} THEN logements_contactes_via_campagnes END), 0)
+            AS logements_contactes_via_campagnes_{{ year }},
+        COALESCE(SUM(CASE WHEN annee = {{ year }} THEN logements_exportes_via_groupes END), 0)
+            AS logements_exportes_via_groupes_{{ year }}{{ "," if not loop.last }}
+        {% endfor %}
+    FROM {{ ref('int_analysis_establishments_zlv_usage_annuel') }}
+    GROUP BY establishment_id
 )
 
 SELECT
@@ -454,34 +543,26 @@ SELECT
     -- =====================================================
     -- LOGEMENTS MIS A JOUR - ENRICHISSEMENT
     -- =====================================================
-    (
-        COALESCE(oee.logements_maj_mails, 0) > 0
-        OR COALESCE(oee.logements_maj_phone, 0) > 0
-        OR COALESCE(oee.logements_maj_owners, 0) > 0
-        OR COALESCE(oee.logements_maj_owners_address, 0) > 0
-        OR COALESCE(ns.logements_maj_notes, 0) > 0
-        OR COALESCE(ds.logements_maj_documents, 0) > 0
-    ) AS a_1_logement_maj_enrichissement,
+    COALESCE(enc.logements_maj_enrichissement, 0) > 0 AS a_1_logement_maj_enrichissement,
 
-    (
-        COALESCE(oee.logements_maj_mails, 0)
-        + COALESCE(oee.logements_maj_phone, 0)
-        + COALESCE(oee.logements_maj_owners, 0)
-        + COALESCE(oee.logements_maj_owners_address, 0)
-        + COALESCE(ns.logements_maj_notes, 0)
-        + COALESCE(ds.logements_maj_documents, 0)
-    ) AS logements_maj_enrichissement,
+    -- Logements distincts touchés par au moins une famille d'enrichissement.
+    COALESCE(enc.logements_maj_enrichissement, 0) AS logements_maj_enrichissement,
+    -- Volumétrie d'actes: somme des interventions, un logement pouvant en
+    -- porter plusieurs. Toujours >= logements_maj_enrichissement.
+    COALESCE(enc.actes_enrichissement, 0) AS actes_enrichissement,
 
     COALESCE(oee.logements_maj_mails, 0) AS logements_maj_mails,
     COALESCE(oee.logements_maj_phone, 0) AS logements_maj_phone,
-    COALESCE(oee.logements_maj_owners, 0) + COALESCE(rce.logements_maj_owners_rank, 0) AS logements_maj_owners,
+    COALESCE(oee.logements_maj_owners, 0) AS logements_maj_owners,
+    COALESCE(rce.logements_maj_owners_rank, 0) AS logements_maj_owners_rank,
     COALESCE(oee.logements_maj_owners_address, 0) AS logements_maj_owners_address,
     COALESCE(dpes.logements_maj_dpe, 0) AS logements_maj_dpe,
+    dpes.date_derniere_maj_dpe,
     COALESCE(ns.logements_maj_notes, 0) AS logements_maj_notes,
     COALESCE(ds.logements_maj_documents, 0) AS logements_maj_documents,
 
-    LEAST(oee.date_premiere_enrichissement_owner, ds.date_dernier_document_importe) AS date_premiere_maj_enrichissement,
-    GREATEST(oee.date_derniere_enrichissement_owner, ds.date_dernier_document_importe) AS date_derniere_maj_enrichissement,
+    enc.date_premiere_maj_enrichissement,
+    enc.date_derniere_maj_enrichissement,
 
     -- =====================================================
     -- DOCUMENTS
@@ -494,6 +575,7 @@ SELECT
     -- =====================================================
     eb.has_groups AS a_1_groupe_cree,
     COALESCE(ghs.logements_exportes_via_groupes, 0) AS logements_exportes_via_groupes,
+    COALESCE(ghs.exports_groupes, 0) AS exports_groupes,
     eb.groupes_exportes,
     eb.groupes_crees,
     eb.date_dernier_groupe_cree,
@@ -502,6 +584,7 @@ SELECT
     -- CAMPAGNES
     -- =====================================================
     COALESCE(chs.logements_contactes_via_campagnes, 0) AS logements_contactes_via_campagnes,
+    COALESCE(chs.contacts_campagnes, 0) AS contacts_campagnes,
     (eb.campagnes_envoyees > 0 AND COALESCE(hsc.logements_maj_situation, 0) > 0) AS a_1_campagne_envoyee_et_1_maj_situation,
     eb.has_campaigns AS a_1_campagne_creee,
     eb.is_creation_lt_30_days > 0 AS a_1_campagne_creee_30_jours,
@@ -572,20 +655,38 @@ SELECT
     -- =====================================================
     -- ECHELONS INSCRITS
     -- =====================================================
+    -- NULL (et non 0) lorsque l'échelon ne s'applique pas à cet établissement:
+    -- voir int_production_establishments_echelons.
+    ei.total_communes_in_territory,
     ei.communes_inscrites,
     ei.communes_inscrites_pct,
-    CAST(NULL AS INTEGER) AS intercommunalites_inscrites,
-    CAST(NULL AS FLOAT) AS intercommunalites_inscrites_pct,
-    CAST(NULL AS INTEGER) AS departements_inscrits,
-    CAST(NULL AS FLOAT) AS departements_inscrits_pct,
-    CAST(NULL AS INTEGER) AS sded_inscrits,
-    CAST(NULL AS FLOAT) AS sded_inscrits_pct
+    ei.intercommunalites_inscrites,
+    ei.intercommunalites_couvrant_le_perimetre,
+    ei.intercommunalites_inscrites_pct,
+    ei.departements_inscrits,
+    ei.departements_couvrant_le_perimetre,
+    ei.departements_inscrits_pct,
+    ei.sded_inscrits,
+    ei.sded_couvrant_le_perimetre,
+    ei.sded_inscrits_pct,
+
+    -- =====================================================
+    -- MILLESIMES (colonnes larges)
+    -- =====================================================
+    -- Distinct À L'INTÉRIEUR de chaque année: ne pas sommer les années.
+    {% for year in years %}
+    COALESCE(ap.logements_contactes_via_campagnes_{{ year }}, 0)
+        AS logements_contactes_via_campagnes_{{ year }},
+    COALESCE(ap.logements_exportes_via_groupes_{{ year }}, 0)
+        AS logements_exportes_via_groupes_{{ year }}{{ "," if not loop.last }}
+    {% endfor %}
 
 FROM establishment_base eb
 LEFT JOIN establishment_connexions ec ON eb.establishment_id = CAST(ec.establishment_id AS VARCHAR)
 LEFT JOIN housing_status_counts hsc ON eb.establishment_id = CAST(hsc.establishment_id AS VARCHAR)
 LEFT JOIN owner_enrichment_events oee ON eb.establishment_id = CAST(oee.establishment_id AS VARCHAR)
 LEFT JOIN rank_change_events rce ON eb.establishment_id = CAST(rce.establishment_id AS VARCHAR)
+LEFT JOIN enrichment_counts enc ON eb.establishment_id = CAST(enc.establishment_id AS VARCHAR)
 LEFT JOIN notes_stats ns ON eb.establishment_id = CAST(ns.establishment_id AS VARCHAR)
 LEFT JOIN document_stats ds ON eb.establishment_id = CAST(ds.establishment_id AS VARCHAR)
 LEFT JOIN campaign_housing_stats chs ON eb.establishment_id = CAST(chs.establishment_id AS VARCHAR)
@@ -593,4 +694,6 @@ LEFT JOIN group_housing_stats ghs ON eb.establishment_id = CAST(ghs.establishmen
 LEFT JOIN dpe_stats dpes ON eb.establishment_id = CAST(dpes.establishment_id AS VARCHAR)
 LEFT JOIN housing_park_counts hpc ON eb.establishment_id = CAST(hpc.establishment_id AS VARCHAR)
 LEFT JOIN geo_reference gr ON eb.establishment_id = CAST(gr.establishment_id AS VARCHAR)
-LEFT JOIN echelons_inscrits ei ON eb.establishment_id = ei.establishment_id
+LEFT JOIN {{ ref('int_production_establishments_echelons') }} ei
+    ON eb.establishment_id = ei.establishment_id
+LEFT JOIN annual_pivot ap ON eb.establishment_id = ap.establishment_id

--- a/analytics/dbt/models/intermediate/analysis/int_analysis_establishments_zlv_usage_annuel.sql
+++ b/analytics/dbt/models/intermediate/analysis/int_analysis_establishments_zlv_usage_annuel.sql
@@ -1,0 +1,89 @@
+-- Usage ZLV par établissement ET par année.
+--
+-- Grain: une ligne par (establishment_id, annee). Source unique de vérité pour
+-- les colonnes annuelles pivotées dans `marts_zlv_usage` et pour les séries
+-- temporelles de `marts_zlv_usage_annuel`.
+--
+-- Millésime retenu: `campaigns.sent_at` pour les campagnes, `groups.exported_at`
+-- pour les groupes, `events.created_at` pour les mises à jour de situation.
+--
+-- ATTENTION: les compteurs de logements sont distincts À L'INTÉRIEUR d'une
+-- année. Un logement recontacté en 2023 puis en 2025 compte dans les deux, donc
+-- SUM(années) >= total distinct toutes années. C'est voulu: chaque année doit
+-- répondre à "combien de logements distincts cette année-là".
+
+WITH campaign_years AS (
+    SELECT
+        CAST(pc.establishment_id AS VARCHAR) AS establishment_id,
+        EXTRACT(YEAR FROM pc.sent_at) AS annee,
+        COUNT(DISTINCT pc.campaign_id) AS campagnes_envoyees,
+        COUNT(DISTINCT pch.housing_id) AS logements_contactes_via_campagnes,
+        COUNT(pch.housing_id) AS contacts_campagnes
+    FROM {{ ref ('int_production_campaigns') }} pc
+    JOIN {{ ref ('int_production_campaigns_housing') }} pch
+        ON pc.campaign_id = pch.campaign_id
+    WHERE pc.sent_at IS NOT NULL
+    GROUP BY 1, 2
+),
+
+group_years AS (
+    SELECT
+        CAST(pg.establishment_id AS VARCHAR) AS establishment_id,
+        EXTRACT(YEAR FROM pg.exported_at) AS annee,
+        COUNT(DISTINCT pg.id) AS groupes_exportes,
+        COUNT(DISTINCT phg.housing_id) AS logements_exportes_via_groupes,
+        COUNT(phg.housing_id) AS exports_groupes
+    FROM {{ ref ('stg_production_groups') }} pg
+    JOIN {{ ref ('stg_production_groups_housing') }} phg
+        ON pg.id = phg.group_id
+    WHERE pg.exported_at IS NOT NULL
+    GROUP BY 1, 2
+),
+
+situation_years AS (
+    SELECT
+        establishment_id,
+        EXTRACT(YEAR FROM created_at) AS annee,
+        COUNT(DISTINCT housing_id) AS logements_maj_situation,
+        COUNT(DISTINCT CASE WHEN status_changed THEN housing_id END) AS logements_maj_suivi,
+        COUNT(DISTINCT CASE WHEN occupancy_changed THEN housing_id END) AS logements_maj_occupation
+    FROM {{ ref ('int_production_events') }}
+    WHERE user_source = 'user'
+      AND (status_changed OR occupancy_changed)
+      AND type IN ('housing:status-updated', 'housing:occupancy-updated')
+      AND establishment_id IS NOT NULL
+      AND housing_id IS NOT NULL
+    GROUP BY 1, 2
+),
+
+all_keys AS (
+    SELECT establishment_id, annee FROM campaign_years
+    UNION
+    SELECT establishment_id, annee FROM group_years
+    UNION
+    SELECT establishment_id, annee FROM situation_years
+)
+
+SELECT
+    k.establishment_id,
+    CAST(k.annee AS INTEGER) AS annee,
+
+    COALESCE(cy.campagnes_envoyees, 0) AS campagnes_envoyees,
+    COALESCE(cy.logements_contactes_via_campagnes, 0) AS logements_contactes_via_campagnes,
+    COALESCE(cy.contacts_campagnes, 0) AS contacts_campagnes,
+
+    COALESCE(gy.groupes_exportes, 0) AS groupes_exportes,
+    COALESCE(gy.logements_exportes_via_groupes, 0) AS logements_exportes_via_groupes,
+    COALESCE(gy.exports_groupes, 0) AS exports_groupes,
+
+    COALESCE(sy.logements_maj_situation, 0) AS logements_maj_situation,
+    COALESCE(sy.logements_maj_suivi, 0) AS logements_maj_suivi,
+    COALESCE(sy.logements_maj_occupation, 0) AS logements_maj_occupation
+
+FROM all_keys k
+LEFT JOIN campaign_years cy
+    ON k.establishment_id = cy.establishment_id AND k.annee = cy.annee
+LEFT JOIN group_years gy
+    ON k.establishment_id = gy.establishment_id AND k.annee = gy.annee
+LEFT JOIN situation_years sy
+    ON k.establishment_id = sy.establishment_id AND k.annee = sy.annee

--- a/analytics/dbt/models/intermediate/analysis/schema.yml
+++ b/analytics/dbt/models/intermediate/analysis/schema.yml
@@ -343,3 +343,40 @@ models:
         description: "Score d'engagement ZLV composite (0-10)"
       - name: zlv_engagement_category
         description: "Catégorie d'engagement ZLV (Aucun, Faible, Moyen, Fort)"
+
+  - name: int_analysis_establishments_zlv_usage_annuel
+    description: |
+      Usage ZLV par établissement et par année. Grain: (establishment_id, annee).
+      Source unique des colonnes annuelles pivotées dans marts_zlv_usage et de
+      marts_zlv_usage_annuel.
+
+      Les compteurs de logements sont distincts à l'intérieur d'une année: la
+      somme des années est donc supérieure ou égale au total toutes années.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - establishment_id
+            - annee
+    columns:
+      - name: establishment_id
+        description: "Identifiant de l'établissement"
+        tests:
+          - not_null
+      - name: annee
+        description: "Année du millésime"
+        tests:
+          - not_null
+      - name: campagnes_envoyees
+        description: "Campagnes envoyées cette année-là"
+      - name: logements_contactes_via_campagnes
+        description: "Logements distincts contactés par une campagne envoyée cette année-là"
+      - name: contacts_campagnes
+        description: "Volumétrie brute des contacts de l'année"
+      - name: groupes_exportes
+        description: "Groupes exportés cette année-là"
+      - name: logements_exportes_via_groupes
+        description: "Logements distincts présents dans un groupe exporté cette année-là"
+      - name: exports_groupes
+        description: "Volumétrie brute des exports de l'année"
+      - name: logements_maj_situation
+        description: "Logements distincts dont la situation a été mise à jour cette année-là"

--- a/analytics/dbt/models/intermediate/production/int_production_establishments_echelons.sql
+++ b/analytics/dbt/models/intermediate/production/int_production_establishments_echelons.sql
@@ -1,0 +1,146 @@
+-- Échelons inscrits: pour un établissement donné, combien d'établissements des
+-- échelons inférieurs couvrant son périmètre sont inscrits sur ZLV.
+--
+-- "Inscrit" = l'établissement compte au moins un utilisateur (`user_number > 0`).
+-- À ne pas confondre avec "ouvert" (`available` ET au moins un utilisateur):
+-- une collectivité peut avoir des comptes sans que l'accès soit ouvert.
+--
+-- Un compteur n'est renseigné que pour les établissements d'un échelon
+-- STRICTEMENT supérieur à celui mesuré (rangs ci-dessous). Sinon il vaut NULL,
+-- et non 0: une commune n'a pas de sous-échelon, et un pourcentage sur un
+-- dénominateur vide n'a pas de sens.
+--
+-- Rangs: 1 commune, 2 intercommunalité (EPCI, PETR, SIVOM), 3 département
+-- (DEP, SDED), 4 région (REG, SDER, CTU). Exception assumée: `sded_inscrits`
+-- est aussi calculé pour les départements, un département ayant un intérêt
+-- direct à savoir si "son" service déconcentré est inscrit.
+--
+-- Dénominateurs: pour les communes, le nombre de `geo_code` du périmètre (une
+-- commune = un code géographique), plus robuste que le nombre d'établissements
+-- de type Commune. Pour les autres échelons, le nombre d'établissements de
+-- l'échelon dont le périmètre intersecte celui de l'établissement mesuré.
+
+WITH establishments AS (
+    SELECT
+        CAST(establishment_id AS VARCHAR) AS establishment_id,
+        kind,
+        COALESCE(user_number, 0) > 0 AS inscrit,
+        CASE
+            WHEN kind = 'Commune' THEN 1
+            WHEN kind IN ('CA', 'CC', 'CU', 'ME', 'PETR', 'SIVOM') THEN 2
+            -- Le libellé long est un kind réel en base, à l'échelon départemental.
+            WHEN kind IN (
+                'DEP',
+                'SDED',
+                'Service déconcentré de l''État à compétence (inter) départementale'
+            ) THEN 3
+            WHEN kind IN ('REG', 'SDER', 'CTU') THEN 4
+            ELSE NULL
+        END AS echelon_rank
+    FROM {{ ref ('marts_production_establishments') }}
+),
+
+localities AS (
+    SELECT
+        CAST(establishment_id AS VARCHAR) AS establishment_id,
+        geo_code
+    FROM {{ ref ('int_production_establishments_localities') }}
+),
+
+perimeter_size AS (
+    SELECT
+        establishment_id,
+        COUNT(DISTINCT geo_code) AS total_communes_in_territory
+    FROM localities
+    GROUP BY establishment_id
+),
+
+-- Communes du périmètre couvertes par une commune inscrite.
+communes_inscrites AS (
+    SELECT
+        l.establishment_id,
+        COUNT(DISTINCT l.geo_code) AS n_inscrits
+    FROM localities l
+    JOIN localities cl ON l.geo_code = cl.geo_code
+    JOIN establishments ce ON cl.establishment_id = ce.establishment_id
+    WHERE ce.kind = 'Commune'
+      AND ce.inscrit
+    GROUP BY l.establishment_id
+),
+
+-- Établissements des autres échelons intersectant le périmètre, inscrits ou non.
+{% set echelons = [
+    ('intercommunalites', ['CA', 'CC', 'CU', 'ME'], 2, 'intercommunalites_inscrites'),
+    ('departements', ['DEP'], 3, 'departements_inscrits'),
+    ('sded', ['SDED'], 3, 'sded_inscrits'),
+] %}
+
+{% for name, kinds, rank, col in echelons %}
+{{ name }}_couvrants AS (
+    SELECT
+        l.establishment_id,
+        COUNT(DISTINCT xe.establishment_id) AS n_total,
+        COUNT(DISTINCT CASE WHEN xe.inscrit THEN xe.establishment_id END) AS n_inscrits
+    FROM localities l
+    JOIN localities xl ON l.geo_code = xl.geo_code
+    JOIN establishments xe ON xl.establishment_id = xe.establishment_id
+    WHERE xe.kind IN ({{ "'" ~ kinds | join("', '") ~ "'" }})
+      AND xe.establishment_id <> l.establishment_id
+    GROUP BY l.establishment_id
+),
+{% endfor %}
+
+final AS (
+    SELECT
+        e.establishment_id,
+        e.kind,
+        e.echelon_rank,
+        ps.total_communes_in_territory,
+
+        CASE WHEN e.echelon_rank > 1 AND COALESCE(ps.total_communes_in_territory, 0) > 0
+            THEN COALESCE(ci.n_inscrits, 0)
+        END AS communes_inscrites,
+
+        {% for name, kinds, rank, col in echelons %}
+        {% set applicable = "e.echelon_rank > 3 OR (e.echelon_rank = 3 AND e.kind <> 'SDED')" if name == 'sded' else "e.echelon_rank > " ~ rank %}
+        CASE WHEN ({{ applicable }}) AND COALESCE({{ name }}.n_total, 0) > 0
+            THEN {{ name }}.n_inscrits
+        END AS {{ col }},
+        CASE WHEN ({{ applicable }})
+            THEN {{ name }}.n_total
+        END AS {{ name }}_couvrant_le_perimetre,
+        {% endfor %}
+
+        CASE WHEN e.echelon_rank > 1 AND COALESCE(ps.total_communes_in_territory, 0) > 0
+            THEN ROUND(
+                COALESCE(ci.n_inscrits, 0)::FLOAT
+                / ps.total_communes_in_territory * 100, 0
+            )
+        END AS communes_inscrites_pct
+
+    FROM establishments e
+    LEFT JOIN perimeter_size ps ON e.establishment_id = ps.establishment_id
+    LEFT JOIN communes_inscrites ci ON e.establishment_id = ci.establishment_id
+    {% for name, kinds, rank, col in echelons %}
+    LEFT JOIN {{ name }}_couvrants AS {{ name }} ON e.establishment_id = {{ name }}.establishment_id
+    {% endfor %}
+)
+
+SELECT
+    establishment_id,
+    kind,
+    echelon_rank,
+    total_communes_in_territory,
+    communes_inscrites,
+    communes_inscrites_pct,
+    {% for name, kinds, rank, col in echelons %}
+    {{ col }},
+    {{ name }}_couvrant_le_perimetre,
+    CASE WHEN COALESCE({{ name }}_couvrant_le_perimetre, 0) > 0
+        THEN ROUND(
+            {{ col }}::FLOAT
+            / {{ name }}_couvrant_le_perimetre * 100, 0
+        )
+    END AS {{ col }}_pct{{ "," if not loop.last }}
+    {% endfor %}
+FROM final

--- a/analytics/dbt/models/intermediate/production/int_production_event_authors.sql
+++ b/analytics/dbt/models/intermediate/production/int_production_event_authors.sql
@@ -1,0 +1,21 @@
+-- Auteurs d'événements: tous les utilisateurs, supprimés inclus.
+--
+-- À utiliser partout où l'on rattache un événement à un établissement.
+-- `int_production_users` filtre `deleted_at IS NULL` et convient donc aux
+-- effectifs (user_number, connexions), mais pas à l'attribution d'événements:
+-- un événement créé par un utilisateur depuis supprimé y perd son
+-- établissement et disparaît de tous les compteurs.
+--
+-- `user_type` est recalculé ici plutôt que repris de `int_production_users`,
+-- pour rester renseigné sur un compte supprimé (sans quoi un administrateur ZLV
+-- supprimé retombe en 'user').
+
+SELECT
+    id,
+    establishment_id,
+    deleted_at,
+    CASE
+        WHEN email LIKE '%beta.gouv.fr' THEN 'zlv'
+        ELSE 'user'
+    END AS user_type
+FROM {{ ref ('stg_production_users') }}

--- a/analytics/dbt/models/intermediate/production/int_production_events.sql
+++ b/analytics/dbt/models/intermediate/production/int_production_events.sql
@@ -1,28 +1,10 @@
--- Résolution de l'auteur d'un événement.
---
--- On lit `stg_production_users` (tous les utilisateurs) et NON
--- `int_production_users` (qui filtre `deleted_at IS NULL`). Sinon tout
--- événement créé par un utilisateur depuis supprimé perd son
--- `establishment_id` (NULL) et n'est plus attribuable à aucun établissement:
--- ~25 000 logements orphelins, dont 19 000 récupérables ici.
---
--- Même raison pour `user_type`: il était calculé dans `int_production_users`,
--- donc NULL pour un utilisateur supprimé, puis ramené à 'user' par le
--- COALESCE ci-dessous. Un administrateur ZLV supprimé était ainsi compté
--- comme un utilisateur de collectivité.
-WITH event_authors AS (
-    SELECT
-        id,
-        establishment_id,
-        deleted_at,
-        CASE
-            WHEN email LIKE '%beta.gouv.fr' THEN 'zlv'
-            ELSE 'user'
-        END AS user_type
-    FROM {{ ref ('stg_production_users') }}
-),
+-- L'auteur est résolu via `int_production_event_authors` (tous les utilisateurs,
+-- supprimés inclus) et NON via `int_production_users` (qui filtre
+-- `deleted_at IS NULL`). Sinon tout événement créé par un utilisateur depuis
+-- supprimé perd son `establishment_id` et n'est plus attribuable à aucun
+-- établissement: ~25 000 logements orphelins, dont 19 000 récupérables ici.
 
-all_events AS (
+WITH all_events AS (
     SELECT
         id,
         created_at,
@@ -79,5 +61,5 @@ SELECT
     u.deleted_at IS NOT NULL AS created_by_deleted_user
 FROM
     all_events ae
-LEFT JOIN event_authors u ON ae.created_by = u.id
+LEFT JOIN {{ ref ('int_production_event_authors') }} u ON ae.created_by = u.id
 LEFT JOIN {{ ref ('status') }} s ON s.status = ae.new_status

--- a/analytics/dbt/models/intermediate/production/int_production_notes.sql
+++ b/analytics/dbt/models/intermediate/production/int_production_notes.sql
@@ -7,5 +7,8 @@ SELECT
 FROM {{ ref ('stg_production_notes') }} n
 LEFT JOIN {{ ref ('int_production_housing_notes') }} hn ON hn.note_id = n.id
 LEFT JOIN {{ ref ('int_production_owner_notes') }} pon ON pon.note_id = n.id
-LEFT JOIN {{ ref ('int_production_users') }} u ON n.created_by = u.id
+-- Auteur résolu via int_production_event_authors (utilisateurs supprimés
+-- inclus): une note écrite par un agent dont le compte a été fermé doit rester
+-- attribuée à son établissement.
+LEFT JOIN {{ ref ('int_production_event_authors') }} u ON n.created_by = u.id
 WHERE n.deleted_at IS NULL

--- a/analytics/dbt/models/intermediate/production/schema.yml
+++ b/analytics/dbt/models/intermediate/production/schema.yml
@@ -132,3 +132,51 @@ models:
 
   - name: int_production_notes_as_events
     description: "Notes transformées en pseudo-événements pour traitement unifié"
+
+  - name: int_production_event_authors
+    description: |
+      Auteurs d'événements: tous les utilisateurs, supprimés inclus. À utiliser
+      pour rattacher un événement à un établissement. `int_production_users`
+      filtre les comptes supprimés et convient aux effectifs, pas à
+      l'attribution.
+    columns:
+      - name: id
+        description: "Identifiant de l'utilisateur"
+        tests:
+          - unique
+          - not_null
+      - name: establishment_id
+        description: "Établissement de rattachement de l'utilisateur"
+      - name: user_type
+        description: "zlv pour un compte @beta.gouv.fr, user sinon"
+        tests:
+          - accepted_values:
+              values: ['zlv', 'user']
+      - name: deleted_at
+        description: "Date de suppression du compte, NULL si actif"
+
+  - name: int_production_establishments_echelons
+    description: |
+      Échelons inscrits par établissement: combien d'établissements des échelons
+      inférieurs couvrant son périmètre comptent au moins un utilisateur.
+      "Inscrit" = `user_number > 0`, à distinguer de "ouvert" (`available` ET au
+      moins un utilisateur). Les compteurs valent NULL — et non 0 — lorsque
+      l'échelon n'est pas un sous-échelon de l'établissement mesuré.
+    columns:
+      - name: establishment_id
+        description: "Identifiant de l'établissement"
+        tests:
+          - unique
+          - not_null
+      - name: echelon_rank
+        description: "1 commune, 2 intercommunalité, 3 département, 4 région. NULL si le kind n'est pas un échelon administratif."
+      - name: total_communes_in_territory
+        description: "Nombre de communes du périmètre"
+      - name: communes_inscrites
+        description: "Communes du périmètre ayant au moins un utilisateur inscrit"
+      - name: intercommunalites_inscrites
+        description: "Intercommunalités du périmètre ayant au moins un utilisateur inscrit"
+      - name: departements_inscrits
+        description: "Départements du périmètre ayant au moins un utilisateur inscrit"
+      - name: sded_inscrits
+        description: "Services déconcentrés départementaux du périmètre ayant au moins un utilisateur inscrit"

--- a/analytics/dbt/models/marts/analysis/marts_zlv_usage.sql
+++ b/analytics/dbt/models/marts/analysis/marts_zlv_usage.sql
@@ -8,6 +8,20 @@ config (
 -- Marts: Establishment-level ZLV usage metrics
 -- Contains only fields referenced in fields_usage_establishments.csv
 -- Excludes activation/pro-activity derived typologies
+--
+-- Règle d'attribution: tout compteur d'activité provient d'un ÉVÉNEMENT créé par
+-- un utilisateur de l'établissement. Le territoire (geo_code) ne sert qu'aux
+-- référentiels (parc, région, département, échelons) et, pour les événements
+-- portant sur un propriétaire, de filtre d'assiette. Voir
+-- docs/decisions/20260805163000-attribution-des-metriques-d-usage-par-evenement-utilisateur.md
+--
+-- NE PAS SOMMER entre établissements les colonnes `logements_*`: un même
+-- logement peut être compté par plusieurs établissements (deux collectivités
+-- peuvent l'avoir mis à jour toutes les deux).
+
+{% set first_year = 2020 %}
+{% set last_year = modules.datetime.date.today().year %}
+{% set years = range(first_year, last_year + 1) | list %}
 
 SELECT
     -- =====================================================
@@ -56,10 +70,13 @@ SELECT
     eu.logements_maj_mails,
     eu.logements_maj_phone,
     eu.logements_maj_owners,
+    eu.logements_maj_owners_rank,
     eu.logements_maj_owners_address,
     eu.logements_maj_dpe,
+    eu.date_derniere_maj_dpe,
     eu.logements_maj_notes,
     eu.logements_maj_documents,
+    eu.actes_enrichissement,
 
     -- =====================================================
     -- DOCUMENTS
@@ -72,6 +89,7 @@ SELECT
     -- =====================================================
     eu.a_1_groupe_cree,
     eu.logements_exportes_via_groupes,
+    eu.exports_groupes,
     eu.groupes_exportes,
     eu.groupes_crees,
     eu.date_dernier_groupe_cree,
@@ -80,6 +98,7 @@ SELECT
     -- CAMPAGNES
     -- =====================================================
     eu.logements_contactes_via_campagnes,
+    eu.contacts_campagnes,
     eu.a_1_campagne_envoyee_et_1_maj_situation,
     eu.a_1_campagne_creee,
     eu.a_1_campagne_creee_30_jours,
@@ -113,13 +132,29 @@ SELECT
     -- =====================================================
     -- ECHELONS INSCRITS
     -- =====================================================
+    -- NULL quand l'échelon ne s'applique pas à l'établissement mesuré.
+    eu.total_communes_in_territory,
     eu.communes_inscrites,
     eu.communes_inscrites_pct,
     eu.intercommunalites_inscrites,
+    eu.intercommunalites_couvrant_le_perimetre,
     eu.intercommunalites_inscrites_pct,
     eu.departements_inscrits,
+    eu.departements_couvrant_le_perimetre,
     eu.departements_inscrits_pct,
     eu.sded_inscrits,
-    eu.sded_inscrits_pct
+    eu.sded_couvrant_le_perimetre,
+    eu.sded_inscrits_pct,
+
+    -- =====================================================
+    -- MILLESIMES
+    -- =====================================================
+    -- Compteurs distincts À L'INTÉRIEUR de chaque année: un logement recontacté
+    -- en 2023 puis en 2025 compte dans les deux. La somme des années est donc
+    -- supérieure ou égale au total toutes années — ne pas l'utiliser comme total.
+    {% for year in years %}
+    eu.logements_contactes_via_campagnes_{{ year }},
+    eu.logements_exportes_via_groupes_{{ year }}{{ "," if not loop.last }}
+    {% endfor %}
 
 FROM {{ ref('int_analysis_establishments_zlv_usage') }} eu

--- a/analytics/dbt/models/marts/analysis/marts_zlv_usage_annuel.sql
+++ b/analytics/dbt/models/marts/analysis/marts_zlv_usage_annuel.sql
@@ -1,0 +1,41 @@
+{{
+config (
+    materialized = 'table',
+)
+}}
+
+-- Marts: usage ZLV par établissement et par année.
+--
+-- Version longue de `marts_zlv_usage`, destinée aux séries temporelles. Les
+-- mêmes chiffres sont disponibles en colonnes larges dans `marts_zlv_usage`
+-- pour les campagnes et les groupes.
+--
+-- ATTENTION: les compteurs de logements sont distincts à l'intérieur d'une
+-- année. Ne pas sommer les années pour obtenir un total: un logement recontacté
+-- deux années différentes compte dans chacune.
+
+SELECT
+    a.establishment_id,
+    a.annee,
+
+    e.name AS nom,
+    ea.type_regroupe AS type_simple,
+    ea.type_explicite AS type_detaille,
+
+    a.campagnes_envoyees,
+    a.logements_contactes_via_campagnes,
+    a.contacts_campagnes,
+
+    a.groupes_exportes,
+    a.logements_exportes_via_groupes,
+    a.exports_groupes,
+
+    a.logements_maj_situation,
+    a.logements_maj_suivi,
+    a.logements_maj_occupation
+
+FROM {{ ref ('int_analysis_establishments_zlv_usage_annuel') }} a
+LEFT JOIN {{ ref ('marts_production_establishments') }} e
+    ON a.establishment_id = e.establishment_id
+LEFT JOIN {{ ref ('marts_production_establishments_activation') }} ea
+    ON a.establishment_id = ea.establishment_id

--- a/analytics/dbt/models/marts/analysis/schema.yml
+++ b/analytics/dbt/models/marts/analysis/schema.yml
@@ -105,16 +105,57 @@ models:
       Champs strictement issus du spec fields_usage_establishments.csv.
       Inclut les echelons inscrits (communes inscrites dans les EPCI, etc).
 
-      Attribution des "logements mis a jour": les compteurs logements_maj_* sont
-      calcules a partir des EVENEMENTS crees par les utilisateurs de l etablissement
-      (int_production_events.establishment_id), et NON par le territoire geographique
-      du logement. Un logement n est donc compte que pour l etablissement dont un
-      utilisateur a reellement effectue la mise a jour.
+      Attribution: tout compteur d activite provient d un EVENEMENT cree par un
+      utilisateur de l etablissement, et NON du territoire geographique du
+      logement. Le territoire ne sert qu aux referentiels (parc, region,
+      departement, echelons) et, pour les evenements portant sur un proprietaire,
+      de filtre d assiette.
+
+      NE PAS SOMMER entre etablissements les colonnes logements_*: un meme
+      logement peut etre compte par plusieurs etablissements si plusieurs
+      collectivites l ont mis a jour. Pour un total national, compter les
+      logements distincts sur marts_production_housing.
     tests:
       - dbt_utils.expression_is_true:
           expression: logements_maj_suivi <= logements_maj_situation
       - dbt_utils.expression_is_true:
           expression: logements_maj_occupation <= logements_maj_situation
+      - dbt_utils.expression_is_true:
+          expression: logements_contactes_via_campagnes <= contacts_campagnes
+      - dbt_utils.expression_is_true:
+          expression: logements_exportes_via_groupes <= exports_groupes
+      - dbt_utils.expression_is_true:
+          expression: logements_maj_enrichissement <= actes_enrichissement
+      - dbt_utils.expression_is_true:
+          expression: >
+            logements_maj_enrichissement >= GREATEST(
+              logements_maj_mails, logements_maj_phone, logements_maj_owners,
+              logements_maj_owners_rank, logements_maj_owners_address,
+              logements_maj_notes, logements_maj_documents, logements_maj_dpe
+            )
+      - dbt_utils.expression_is_true:
+          expression: >
+            logements_maj_enrichissement <= (
+              logements_maj_mails + logements_maj_phone + logements_maj_owners
+              + logements_maj_owners_rank + logements_maj_owners_address
+              + logements_maj_notes + logements_maj_documents + logements_maj_dpe
+            )
+      - dbt_utils.expression_is_true:
+          expression: communes_inscrites <= total_communes_in_territory
+          config:
+            where: communes_inscrites IS NOT NULL
+      - dbt_utils.expression_is_true:
+          expression: intercommunalites_inscrites <= intercommunalites_couvrant_le_perimetre
+          config:
+            where: intercommunalites_inscrites IS NOT NULL
+      - dbt_utils.expression_is_true:
+          expression: departements_inscrits <= departements_couvrant_le_perimetre
+          config:
+            where: departements_inscrits IS NOT NULL
+      - dbt_utils.expression_is_true:
+          expression: sded_inscrits <= sded_couvrant_le_perimetre
+          config:
+            where: sded_inscrits IS NOT NULL
     columns:
       - name: establishment_id
         description: Identifiant unique de l etablissement
@@ -125,30 +166,134 @@ models:
         description: Nom de l etablissement
       - name: ouvert
         description: TRUE si l etablissement est disponible et a au moins 1 utilisateur
+      - name: type_simple
+        description: |
+          Echelon de l etablissement - Commune, Intercommunalite, Departement,
+          Region, DDT/M, DREAL/SDER, Autre. Departement, Region et DREAL/SDER
+          etaient auparavant agreges dans Autre.
+        tests:
+          - accepted_values:
+              values:
+                - Commune
+                - Intercommunalité
+                - Département
+                - Région
+                - DDT/M
+                - DREAL/SDER
+                - Autre
       - name: logements_maj_situation
         description: |
           Nombre de logements distincts mis a jour (suivi OU occupation) par les
-          utilisateurs de cet etablissement.
+          utilisateurs de cet etablissement. NE PAS SOMMER entre etablissements.
       - name: logements_maj_suivi
-        description: Nombre de logements distincts dont le dernier statut de suivi a ete pose par un utilisateur de l etablissement
+        description: Nombre de logements distincts dont le dernier statut de suivi a ete pose par un utilisateur de l etablissement. NE PAS SOMMER entre etablissements.
       - name: logements_maj_occupation
-        description: Nombre de logements distincts dont le dernier statut d occupation a ete pose par un utilisateur de l etablissement
+        description: Nombre de logements distincts dont le dernier statut d occupation a ete pose par un utilisateur de l etablissement. NE PAS SOMMER entre etablissements.
+      - name: logements_maj_enrichissement
+        description: |
+          Logements DISTINCTS touches par au moins une famille d enrichissement
+          (mail, telephone, nom ou adresse du proprietaire, rang, note, document,
+          DPE). A ne pas confondre avec actes_enrichissement.
+          NE PAS SOMMER entre etablissements.
+      - name: actes_enrichissement
+        description: |
+          Volumetrie d actes d enrichissement - un logement dont le mail ET le
+          telephone ont ete corriges compte deux fois. Mesure d effort de saisie,
+          toujours superieure ou egale a logements_maj_enrichissement.
+      - name: logements_maj_owners
+        description: Logements distincts du territoire dont le NOM du proprietaire a ete modifie par un utilisateur de l etablissement
+      - name: logements_maj_owners_rank
+        description: |
+          Logements distincts dont le rang d un proprietaire a ete modifie.
+          Auparavant additionne a logements_maj_owners, ce qui comptait deux fois
+          les logements concernes par les deux operations.
+      - name: logements_maj_dpe
+        description: |
+          Logements distincts dont le DPE constate (housing.actual_dpe) a ete
+          renseigne par un utilisateur, mesure via l evenement housing:updated.
+          Volumetrie faible et attendue - la fonctionnalite date de janvier 2026.
+          A ne pas confondre avec le DPE source LOVAC/ADEME.
+      - name: date_derniere_maj_dpe
+        description: Date du dernier renseignement de DPE constate par un utilisateur de l etablissement
+      - name: logements_contactes_via_campagnes
+        description: |
+          Logements DISTINCTS contactes par au moins une campagne envoyee. Un
+          logement present dans plusieurs campagnes ne compte qu une fois.
+          NE PAS SOMMER entre etablissements.
+      - name: contacts_campagnes
+        description: |
+          Volumetrie brute des contacts - un logement contacte par trois
+          campagnes compte trois fois. Mesure d effort, toujours superieure ou
+          egale a logements_contactes_via_campagnes.
+      - name: logements_exportes_via_groupes
+        description: |
+          Logements DISTINCTS presents dans au moins un groupe exporte.
+          NE PAS SOMMER entre etablissements.
+      - name: exports_groupes
+        description: Volumetrie brute des exports de groupes - un logement present dans plusieurs groupes compte plusieurs fois
+      - name: total_communes_in_territory
+        description: Nombre de communes du perimetre de l etablissement, denominateur de communes_inscrites_pct
       - name: communes_inscrites
-        description: Nombre de communes inscrites dans le territoire de l EPCI
+        description: |
+          Nombre de communes du perimetre ayant au moins un utilisateur inscrit
+          (user_number > 0). NULL si l echelon communal n est pas un sous-echelon
+          de cet etablissement (cas d une Commune).
       - name: communes_inscrites_pct
-        description: Pourcentage de communes inscrites dans le territoire de l EPCI
+        description: Part des communes du perimetre inscrites, en pourcentage
       - name: intercommunalites_inscrites
-        description: Nombre d intercommunalites inscrites dans le departement
+        description: Nombre d intercommunalites du perimetre inscrites. NULL si l echelon ne s applique pas (EPCI et Commune).
+      - name: intercommunalites_couvrant_le_perimetre
+        description: Nombre d intercommunalites intersectant le perimetre, denominateur du pourcentage
       - name: intercommunalites_inscrites_pct
-        description: Pourcentage d intercommunalites inscrites dans le departement
+        description: Part des intercommunalites du perimetre inscrites, en pourcentage
       - name: departements_inscrits
-        description: Nombre de departements inscrits dans la region
+        description: Nombre de departements du perimetre inscrits. NULL sauf pour les echelons regionaux.
+      - name: departements_couvrant_le_perimetre
+        description: Nombre de departements intersectant le perimetre
       - name: departements_inscrits_pct
-        description: Pourcentage de departements inscrits dans la region
+        description: Part des departements du perimetre inscrits, en pourcentage
       - name: sded_inscrits
-        description: Nombre de SDED inscrits dans la region
+        description: Nombre de services deconcentres departementaux inscrits couvrant le perimetre. NULL sauf pour les echelons departemental (hors DDT/M elle-meme) et regional.
+      - name: sded_couvrant_le_perimetre
+        description: Nombre de services deconcentres departementaux intersectant le perimetre
       - name: sded_inscrits_pct
-        description: Pourcentage de SDED inscrits dans la region
+        description: Part des services deconcentres departementaux du perimetre inscrits, en pourcentage
+
+  - name: marts_zlv_usage_annuel
+    description: |
+      Table Marts - Usage ZLV par etablissement ET par annee. Version longue de
+      marts_zlv_usage, pour les series temporelles. Millesime pris sur
+      campaigns.sent_at, groups.exported_at et events.created_at.
+
+      NE PAS SOMMER les annees pour obtenir un total: les compteurs de logements
+      sont distincts a l interieur de chaque annee, donc un logement recontacte
+      deux annees differentes compte dans chacune.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - establishment_id
+            - annee
+      - dbt_utils.expression_is_true:
+          expression: logements_contactes_via_campagnes <= contacts_campagnes
+      - dbt_utils.expression_is_true:
+          expression: logements_exportes_via_groupes <= exports_groupes
+      - dbt_utils.expression_is_true:
+          expression: annee >= 2019
+    columns:
+      - name: establishment_id
+        description: Identifiant de l etablissement
+        tests:
+          - not_null
+      - name: annee
+        description: Annee du millesime
+        tests:
+          - not_null
+      - name: logements_contactes_via_campagnes
+        description: Logements distincts contactes par une campagne envoyee cette annee-la
+      - name: logements_exportes_via_groupes
+        description: Logements distincts presents dans un groupe exporte cette annee-la
+      - name: logements_maj_situation
+        description: Logements distincts dont la situation a ete mise a jour cette annee-la par un utilisateur de l etablissement
 
   - name: marts_bi_housing_zlv_usage
     description: |

--- a/analytics/dbt/models/marts/production/marts_production_establishments_activation.sql
+++ b/analytics/dbt/models/marts/production/marts_production_establishments_activation.sql
@@ -103,13 +103,29 @@ SELECT
     WHEN e.kind = 'SDED' THEN 'Service Déconcentré Départemental'
     WHEN e.kind = 'SDER' THEN 'Service Déconcentré Régional'
     WHEN e.kind = 'ASSO' THEN 'Association'
+    WHEN e.kind = 'SIVOM' THEN 'SIVOM'
+    WHEN e.kind = 'CTU' THEN 'Collectivité Territoriale Unique'
+    WHEN e.kind IS NULL OR e.kind = '' THEN 'Inconnu'
     ELSE e.kind
   END AS type_explicite,
-CASE 
+
+  -- Échelon de l'établissement.
+  --
+  -- Département, Région et les services déconcentrés régionaux étaient
+  -- auparavant agrégés dans 'Autre', avec les SIVOM, CTU, PETR et les
+  -- établissements sans type: un filtre sur l'échelon ne permettait donc pas de
+  -- les isoler. 'Autre' ne contient plus que ce qui n'est pas un échelon
+  -- administratif.
+CASE
     WHEN e.kind IN ('CA', 'CC', 'CU', 'ME') THEN 'Intercommunalité'
     WHEN e.kind = 'Commune' THEN 'Commune'
-    WHEN e.kind = 'SDED' THEN 'DDT/M'
-    WHEN e.kind IN ('DEP', 'PETR', 'REG', 'SDER', 'ASSO') THEN 'Autre'
+    WHEN e.kind = 'DEP' THEN 'Département'
+    WHEN e.kind = 'REG' THEN 'Région'
+    WHEN e.kind IN (
+        'SDED',
+        'Service déconcentré de l''État à compétence (inter) départementale'
+    ) THEN 'DDT/M'
+    WHEN e.kind = 'SDER' THEN 'DREAL/SDER'
     ELSE 'Autre'
   END AS type_regroupe
   

--- a/analytics/dbt/tests/production/establishment/test_zlv_usage_annual_sum_ge_total.sql
+++ b/analytics/dbt/tests/production/establishment/test_zlv_usage_annual_sum_ge_total.sql
@@ -1,0 +1,44 @@
+-- Test: la somme des colonnes annuelles ne peut pas être INFÉRIEURE au total
+-- toutes années.
+--
+-- Les compteurs annuels sont distincts à l'intérieur d'une année: un logement
+-- recontacté en 2023 puis en 2025 compte dans chacune. La somme des années est
+-- donc >= au total distinct, jamais <. Une somme inférieure signalerait une
+-- année manquante dans le pivot (millésime hors de la plage compilée) ou une
+-- divergence de règle entre le modèle annuel et le modèle global.
+--
+-- Ce test documente aussi le piège qui a produit le ticket d'origine: additionner
+-- des comptages distincts ne donne pas un total.
+
+{{ config(severity='error') }}
+
+{% set first_year = 2020 %}
+{% set last_year = modules.datetime.date.today().year %}
+{% set years = range(first_year, last_year + 1) | list %}
+
+SELECT
+    establishment_id,
+    logements_contactes_via_campagnes,
+    (
+        {% for year in years %}
+        logements_contactes_via_campagnes_{{ year }}{{ " +" if not loop.last }}
+        {% endfor %}
+    ) AS somme_annees_campagnes,
+    logements_exportes_via_groupes,
+    (
+        {% for year in years %}
+        logements_exportes_via_groupes_{{ year }}{{ " +" if not loop.last }}
+        {% endfor %}
+    ) AS somme_annees_groupes,
+    'Somme des annees inferieure au total toutes annees' AS issue
+FROM {{ ref('marts_zlv_usage') }}
+WHERE logements_contactes_via_campagnes > (
+        {% for year in years %}
+        logements_contactes_via_campagnes_{{ year }}{{ " +" if not loop.last }}
+        {% endfor %}
+    )
+   OR logements_exportes_via_groupes > (
+        {% for year in years %}
+        logements_exportes_via_groupes_{{ year }}{{ " +" if not loop.last }}
+        {% endfor %}
+    )

--- a/analytics/dbt/tests/production/establishment/test_zlv_usage_reconciles_with_housing.sql
+++ b/analytics/dbt/tests/production/establishment/test_zlv_usage_reconciles_with_housing.sql
@@ -1,0 +1,41 @@
+-- Test de réconciliation: la somme de logements_maj_situation sur tous les
+-- établissements doit rester proche du nombre de logements distincts mis à jour
+-- par des utilisateurs dans marts_production_housing.
+--
+-- C'est le test qui garde la question d'origine du ticket ("58 000 côté Housing
+-- contre 121 000 côté Usage") sous contrôle. Les deux chiffres ne peuvent pas
+-- être égaux par construction:
+--   - un logement mis à jour par DEUX établissements compte deux fois dans la
+--     somme (écart positif attendu, faible);
+--   - un logement dont l'auteur de l'événement est introuvable dans la table
+--     users n'est attribué à aucun établissement (écart négatif, ~6 300).
+--
+-- On borne donc l'écart relatif à 15%. Au-delà, c'est un retour de
+-- l'attribution géographique (facteur ~28) ou une perte d'attribution massive.
+
+{{ config(severity='error') }}
+
+WITH usage_total AS (
+    SELECT SUM(logements_maj_situation) AS somme_usage
+    FROM {{ ref('marts_zlv_usage') }}
+),
+
+housing_total AS (
+    SELECT COUNT(*) AS logements_distincts
+    FROM {{ ref('marts_production_housing') }}
+    WHERE last_event_status_label_user_followup IS NOT NULL
+       OR last_event_status_label_user_occupancy IS NOT NULL
+)
+
+SELECT
+    u.somme_usage,
+    h.logements_distincts,
+    ROUND(
+        ABS(u.somme_usage - h.logements_distincts)::FLOAT
+        / NULLIF(h.logements_distincts, 0) * 100, 2
+    ) AS ecart_pct,
+    'Ecart trop important entre marts_zlv_usage et marts_production_housing' AS issue
+FROM usage_total u
+CROSS JOIN housing_total h
+WHERE h.logements_distincts > 0
+  AND ABS(u.somme_usage - h.logements_distincts)::FLOAT / h.logements_distincts > 0.15

--- a/analytics/dbt/tests/production/stats/test_kpi_zlv_usage_thresholds.sql
+++ b/analytics/dbt/tests/production/stats/test_kpi_zlv_usage_thresholds.sql
@@ -1,0 +1,41 @@
+-- Test de régression KPI sur marts_zlv_usage.
+--
+-- Chaque seuil est un plancher volontairement bas par rapport à la mesure du
+-- 2026-08-05, pour détecter un passage à zéro (source renommée, jointure cassée,
+-- filtre trop restrictif) sans se déclencher sur une variation normale. Les
+-- valeurs mesurées à la mise en place sont indiquées en commentaire.
+--
+-- Sévérité 'warn': un franchissement mérite un regard, pas un blocage du DAG.
+
+{{ config(severity='warn') }}
+
+WITH mesures AS (
+    SELECT
+        COUNT(*) FILTER (WHERE logements_maj_situation > 0) AS etabs_avec_maj,
+        SUM(logements_contactes_via_campagnes) AS logements_contactes,
+        SUM(logements_exportes_via_groupes) AS logements_exportes,
+        SUM(logements_maj_enrichissement) AS logements_enrichis,
+        COUNT(*) FILTER (WHERE logements_maj_dpe > 0) AS etabs_avec_dpe,
+        COUNT(*) FILTER (WHERE communes_inscrites IS NOT NULL) AS etabs_avec_echelon_communal,
+        COUNT(*) FILTER (WHERE intercommunalites_inscrites IS NOT NULL) AS etabs_avec_echelon_epci
+    FROM {{ ref('marts_zlv_usage') }}
+),
+
+seuils AS (
+    -- (libellé, valeur mesurée, plancher)
+    SELECT 'etabs_avec_maj' AS kpi, etabs_avec_maj AS valeur, 500 AS plancher FROM mesures            -- mesuré 636+
+    UNION ALL SELECT 'logements_contactes', logements_contactes, 120000 FROM mesures                  -- mesuré 149 069
+    UNION ALL SELECT 'logements_exportes', logements_exportes, 1500000 FROM mesures                   -- mesuré 2 014 977
+    UNION ALL SELECT 'logements_enrichis', logements_enrichis, 50000 FROM mesures                     -- mesuré 68 006
+    UNION ALL SELECT 'etabs_avec_dpe', etabs_avec_dpe, 1 FROM mesures                                 -- mesuré 20
+    UNION ALL SELECT 'etabs_avec_echelon_communal', etabs_avec_echelon_communal, 1500 FROM mesures    -- mesuré 1 693
+    UNION ALL SELECT 'etabs_avec_echelon_epci', etabs_avec_echelon_epci, 300 FROM mesures             -- mesuré 425
+)
+
+SELECT
+    kpi,
+    valeur,
+    plancher,
+    'KPI sous son plancher de regression' AS issue
+FROM seuils
+WHERE valeur IS NULL OR valeur < plancher

--- a/docs/decisions/20260805163000-attribution-des-metriques-d-usage-par-evenement-utilisateur.md
+++ b/docs/decisions/20260805163000-attribution-des-metriques-d-usage-par-evenement-utilisateur.md
@@ -1,0 +1,199 @@
+---
+statut: accepté
+date: 2026-08-05
+décideurs: Raphaël Courivaud
+---
+
+# Les métriques d'usage sont attribuées par événement utilisateur, pas par territoire
+
+## Contexte et problématique
+
+Un signalement rapporte plusieurs incohérences dans la table `marts_zlv_usage`,
+dont la plus visible est un écart de comptage : « 58 000 logements mis à jour côté
+Marts Housing contre 121 000 issus de la somme effectuée dans Marts Usage ».
+
+L'investigation montre que ce n'est pas un écart mais **deux mesures différentes
+présentées comme la même**, et que la table mélangeait deux règles d'attribution
+incompatibles :
+
+- les compteurs de situation (suivi, occupation), les notes et les documents
+  partaient déjà de l'**auteur de l'événement** ;
+- les compteurs d'enrichissement du propriétaire et le DPE partaient du
+  **territoire du logement**, c'est-à-dire de `int_production_establishments_housing`.
+
+Un logement étant couvert par une commune, un EPCI, un département, une région et
+un service déconcentré, l'attribution territoriale le créditait à environ 25
+établissements — y compris ceux dont aucun utilisateur n'était intervenu.
+
+Mesures du 2026-08-05 sur l'entrepôt `dwh`, sommes sur les 36 791 établissements :
+
+| Compteur | Attribution territoriale | Attribution événementielle |
+| --- | --- | --- |
+| `logements_maj_owners` | 686 752 | 9 882 |
+| `logements_maj_phone` | 144 826 | 5 042 |
+| `logements_maj_mails` | 104 776 | 3 582 |
+| `logements_maj_owners_address` | 61 966 | 2 331 |
+| `logements_maj_dpe` | 1 222 | 49 |
+| `logements_maj_enrichissement` | 1 057 574 | 68 006 |
+
+Trois autres défauts, indépendants de la règle d'attribution, aggravaient la
+lecture de la table :
+
+1. **Comptages non dédoublonnés.** `logements_contactes_via_campagnes` et
+   `logements_exportes_via_groupes` utilisaient `COUNT()` au lieu de
+   `COUNT(DISTINCT)` : 178 223 au lieu de 149 069 pour les campagnes (77
+   établissements concernés), et 3 029 177 au lieu de 2 014 977 pour les groupes
+   (353 établissements, +50 %).
+2. **Agrégat construit par addition.** `logements_maj_enrichissement` était la
+   somme de six compteurs : un logement dont le mail et le téléphone avaient été
+   corrigés y comptait deux fois. Même défaut sur `logements_maj_owners`, qui
+   additionnait les modifications de nom et de rang.
+3. **Perte d'attribution sur les comptes supprimés.** `int_production_events`
+   résolvait l'auteur via `int_production_users`, qui filtre `deleted_at IS NULL` :
+   16,71 % des événements utilisateurs n'étaient rattachés à aucun établissement.
+
+### Ce que l'écart 58 000 / 121 000 mesurait réellement
+
+Les deux nombres du signalement sont périmés — ils précèdent une correction
+partielle déjà déployée. Au 2026-08-05, la somme de `logements_maj_situation`
+valait 156 224 pour 155 699 logements distincts réellement mis à jour par des
+utilisateurs. L'écart résiduel n'est pas une erreur : **un logement mis à jour par
+deux établissements compte dans les deux**, et c'est le comportement attendu d'un
+compteur par établissement. Additionner des comptages distincts ne produit pas un
+total ; c'est la confusion que l'ADR ferme.
+
+## Critères de décision
+
+- Une seule règle d'attribution dans une table, faute de quoi ses colonnes ne sont
+  ni comparables ni sommables entre elles
+- Ne pas créditer un établissement d'une action qu'aucun de ses utilisateurs n'a
+  effectuée
+- Un compteur nommé « logements » doit compter des logements distincts
+- Ne pas perdre l'information de volumétrie, qui mesure un effort réel
+- Rendre les pièges de lecture explicites dans la donnée plutôt que dans une
+  conversation
+
+## Options envisagées
+
+- **A. Attribution événementielle unique** — tout compteur d'activité vient d'un
+  événement créé par un utilisateur de l'établissement ; le territoire ne sert
+  qu'aux référentiels
+- **B. Hybride assumé** — attribution événementielle, plus une famille de colonnes
+  `*_territoire` exposant séparément « les logements de mon territoire enrichis,
+  par qui que ce soit »
+- **C. Statu quo territorial pour l'enrichissement**
+
+## Décision
+
+Option retenue : **A. Attribution événementielle unique**.
+
+Un compteur d'activité mesure ce que les utilisateurs d'un établissement ont fait.
+Le territoire reste utilisé pour deux usages qui ne sont pas de l'attribution :
+les **référentiels** (parc vacant, région, département, échelons inscrits) et, pour
+les événements portant sur un propriétaire, un **filtre d'assiette**.
+
+Ce filtre d'assiette mérite sa justification. Un événement `owner:updated` porte
+sur un propriétaire, pas sur un logement : il se déplie sur tous les logements de
+ce propriétaire. Sur les 34 036 paires (établissement, logement) ainsi produites,
+**19 530 concernaient des logements hors du périmètre de l'établissement** — un
+agent corrigeant le mail d'un propriétaire possédant huit logements dont six dans
+une autre région se voyait créditer les huit. L'intersection avec le périmètre
+ramène le compteur au sens voulu : « logements de mon territoire dont j'ai enrichi
+le propriétaire ».
+
+L'option B a été écartée : elle double le nombre de colonnes pour une question —
+la couverture du territoire — à laquelle `total_communes_in_territory` et les
+échelons inscrits répondent déjà. L'option C a été écartée parce qu'elle laissait
+deux règles dans la même table, donc l'impossibilité de comparer deux colonnes
+voisines.
+
+En conséquence :
+
+1. **L'auteur d'un événement est résolu sur tous les utilisateurs, supprimés
+   inclus** (`int_production_event_authors`). Le taux d'événements non rattachés
+   passe de 16,71 % à 2,08 %, soit 176 839 logements attribués au lieu de 155 699.
+   Le résidu correspond aux événements dont le `created_by` est absent de la table
+   des utilisateurs, non récupérable depuis l'entrepôt.
+2. **Tout compteur nommé `logements_*` est un `COUNT(DISTINCT housing_id)`**, et
+   la volumétrie brute est conservée dans des colonnes distinctes et nommées comme
+   telles : `contacts_campagnes`, `exports_groupes`, `actes_enrichissement`.
+3. **Les agrégats ne sont plus des sommes de compteurs.**
+   `logements_maj_enrichissement` devient le décompte distinct de l'union des
+   familles d'enrichissement, et `logements_maj_owners_rank` est exposé séparément
+   au lieu d'être additionné à `logements_maj_owners`.
+4. **Le DPE constaté est mesuré par l'événement `housing:updated`** plutôt que par
+   la présence d'une valeur dans `housing.actual_dpe`, la colonne ne portant ni
+   date ni auteur.
+5. **Les échelons inscrits sont calculés par une règle unique** pour tous les
+   échelons (`int_production_establishments_echelons`), là où seules les communes
+   des EPCI l'étaient et où intercommunalités, départements et SDED étaient des
+   `NULL` en dur. « Inscrit » signifie `user_number > 0` ; un compteur vaut `NULL`,
+   et non `0`, quand l'échelon n'est pas un sous-échelon de l'établissement mesuré.
+6. **Les millésimes sont portés par un modèle long**
+   (`int_analysis_establishments_zlv_usage_annuel`, exposé en
+   `marts_zlv_usage_annuel`) puis pivotés en colonnes larges de 2020 à l'année
+   courante. La plage est calculée à la compilation, donc aucune intervention au
+   changement d'année.
+7. **`type_simple` distingue les échelons** : `Département`, `Région` et
+   `DREAL/SDER` sortent de `Autre`, qui ne contient plus que ce qui n'est pas un
+   échelon administratif.
+
+### Conséquences
+
+- Bon, parce qu'une seule règle gouverne la table : deux colonnes voisines
+  redeviennent comparables
+- Bon, parce qu'un établissement n'est plus crédité du travail d'un autre
+- Bon, parce que la distinction acte / logement distinct est portée par les noms de
+  colonnes et par des tests, non par une convention orale
+- Bon, parce que les quatre colonnes d'échelons cessent d'être vides
+- Mauvais, parce que **tous les compteurs d'enrichissement s'effondrent** — d'un
+  facteur 15 à 70 selon la colonne. Les chiffres déjà communiqués aux
+  collectivités et les questions Metabase construites dessus deviennent faux, et
+  ce n'est pas une baisse d'activité mais la fin d'un sur-comptage
+- Mauvais, parce que `logements_maj_dpe` restera proche de zéro : `actual_dpe` date
+  de janvier 2026 et n'est renseignée que sur 49 logements. Un lecteur attendant
+  des milliers de lignes pense au DPE source LOVAC/ADEME, qui est une autre
+  métrique
+- Mauvais, parce que le changement de valeurs de `type_simple` modifie
+  silencieusement le résultat de tout filtre Metabase portant sur `'Autre'`
+- Mauvais, parce que la correction de l'attribution des comptes supprimés fait
+  **monter** des chiffres hors du périmètre de ce ticket :
+  `marts_production_housing`, `marts_production_establishments_activation`,
+  `marts_production_establishments_category_pro_activity` et les tables
+  `marts_bi_housing_*`
+- Neutre, parce que la somme des colonnes annuelles restera supérieure au total
+  toutes années : un logement recontacté deux années différentes compte dans
+  chacune. C'est documenté et testé plutôt que corrigé, un total annuel n'ayant
+  pas de sens autrement
+
+## Validation
+
+- Invariants dbt sur `marts_zlv_usage` : `suivi <= situation`,
+  `occupation <= situation`, `distinct <= brut` pour les campagnes, les groupes et
+  l'enrichissement, `MAX(familles) <= enrichissement <= SUM(familles)`,
+  `inscrits <= couvrant le périmètre`
+- Unicité de `establishment_id`, et de `(establishment_id, annee)` sur les modèles
+  annuels
+- Test de réconciliation entre la somme de `logements_maj_situation` et le nombre
+  de logements distincts de `marts_production_housing`, écart borné à 15 %
+- Test de non-régression sur `int_production_events` : moins de 6 % d'événements
+  utilisateurs sans établissement
+- Test de régression KPI en sévérité `warn` sur sept planchers, pour détecter un
+  passage à zéro sans bloquer le DAG
+- Descriptions `schema.yml` portant l'avertissement « ne pas sommer entre
+  établissements » sur chaque colonne distincte, visible dans Metabase
+
+## Plus d'information
+
+Deux points restent à trancher avec le porteur du produit, hors périmètre de cette
+décision :
+
+- la métrique attendue derrière « Logements MAJ DPE » — DPE constaté saisi par un
+  utilisateur, ou DPE source LOVAC/ADEME ;
+- la reprise des questions Metabase filtrant `type_simple = 'Autre'`.
+
+Méthode et réserve : tous les chiffres de cet ADR ont été mesurés le 2026-08-05 sur
+l'entrepôt MotherDuck `dwh`, en exécutant le SQL compilé des modèles en lecture
+seule avant déploiement. Les chiffres « après » de la table `marts_zlv_usage`
+n'intègrent pas encore la correction des comptes supprimés, qui les fera légèrement
+monter.


### PR DESCRIPTION
> Stacked on #1948 — review that one first. Base is `fix/events-establishment-attribution-deleted-users`, so this diff only shows the mart rework.

Closes the "Marts Usages" ticket.

## The actual problem

The table mixed **two incompatible attribution rules**. Situation, notes and documents already came from the event author; owner enrichment and DPE came from the housing's *territory*. A housing is covered by ~25 establishments (commune, EPCI, department, region, state service), so the territorial half credited establishments whose users never touched anything.

The reported "58 000 vs 121 000" figures are stale — they predate a partial fix already in production. Today the sum is 156 224 against 155 699 distinct housing actually updated by users. The residual gap is **not a bug**: a housing updated by two establishments counts for both. Summing distinct counts does not produce a total, and that confusion is what this PR closes for good.

## Measured impact

Sums over the 36 791 establishments (`dwh`, 2026-08-05):

| Counter | Before | After |
|---|---|---|
| `logements_maj_owners` | 686 752 | **9 882** |
| `logements_maj_phone` | 144 826 | **5 042** |
| `logements_maj_mails` | 104 776 | **3 582** |
| `logements_maj_owners_address` | 61 966 | **2 331** |
| `logements_maj_dpe` | 1 222 | **49** |
| `logements_maj_enrichissement` | 1 057 574 | **68 006** |
| `logements_contactes_via_campagnes` | 178 223 | **149 069** |
| `logements_exportes_via_groupes` | 3 029 177 | **2 014 977** |

These are not activity drops — they are the end of a 15× to 70× over-count.

## What changed

**One attribution rule.** Every activity counter comes from an event created by a user of the establishment. The territory is only used for reference data (vacant park, region, department, échelons) and, for owner-level events, as a perimeter filter: an `owner:updated` event unfolds onto every housing of that owner, and **19 530 of the 34 036 credited pairs were housing outside the establishment's own perimeter**. An agent fixing the email of an owner holding eight housing units, six of them in another region, was credited with all eight.

**Distinct counting.** All `logements_*` counters are `COUNT(DISTINCT housing_id)`. Raw volume is preserved in separate, explicitly named columns: `contacts_campagnes`, `exports_groupes`, `actes_enrichissement`. The groups counter was inflated by 50%, which the ticket did not even flag.

**No more aggregates built by addition.** `logements_maj_enrichissement` was the sum of six counters, so a housing whose email *and* phone were fixed counted twice. It is now the distinct union. Likewise `logements_maj_owners_rank` is exposed on its own instead of being added to `logements_maj_owners`.

**DPE.** Measured from the `housing:updated` event instead of the presence of a value in `housing.actual_dpe`, which carries neither date nor author. ⚠️ **This column will stay near zero**: `actual_dpe` shipped in January 2026 and is set on 49 housing units out of 10.8M. If thousands were expected, the metric wanted is the LOVAC/ADEME *source* DPE — a different thing, worth its own ticket.

**Échelons.** `int_production_establishments_echelons` computes every level with one rule (perimeter intersection). `intercommunalites_inscrites`, `departements_inscrits` and `sded_inscrits` were hardcoded `NULL`; `communes_inscrites` was only computed for EPCIs. "Inscrit" means `user_number > 0` (the ticket's wording), deliberately distinct from "ouvert" (`available` AND users). A counter is `NULL`, not `0`, when the level is not a sub-level of the establishment measured.

**Yearly breakdown.** `int_analysis_establishments_zlv_usage_annuel` (grain: establishment × year) is the single source, exposed as `marts_zlv_usage_annuel` for time series and pivoted into wide columns in `marts_zlv_usage`. Range is 2020 → current year, computed at compile time — 2020 exists (9 campaigns) and no ticket will be needed in January. Note that `SUM(years) >= total`: a housing recontacted in 2023 and 2025 counts in both. That is tested and documented rather than "fixed".

**`type_simple`.** `Département`, `Région` and `DREAL/SDER` leave the `Autre` bucket, which previously mixed them with SIVOM, CTU, PETR and 174 untyped establishments — so filtering by level could not isolate them. ⚠️ **Breaking for Metabase questions filtering `type_simple = 'Autre'`.**

## Tests

- `distinct <= raw` for campaigns, groups and enrichment
- `MAX(families) <= logements_maj_enrichissement <= SUM(families)`
- `inscrits <= covering the perimeter`, percentages within range
- unique `(establishment_id, annee)`; unique `establishment_id`
- reconciliation between the `logements_maj_situation` sum and distinct housing in `marts_production_housing`, bounded at 15%
- yearly sum never below the all-years total — this test *documents* the trap that produced the ticket
- seven KPI floors at `warn` severity, to catch a future drop to zero (like the DPE one) without blocking the DAG
- every distinct column carries a **"ne pas sommer entre établissements"** note in `schema.yml`, which Metabase displays

## Docs

`CONTEXT.md` gains the usage vocabulary (attribution événementielle, logement mis à jour, inscrit vs ouvert, échelon, acte vs logement distinct), and `docs/decisions/20260805163000-attribution-des-metriques-d-usage-par-evenement-utilisateur.md` records the rule and what it costs.

## Verification

`dbt compile` passes on the whole project. Every figure above was produced by running the compiled SQL read-only against `dwh` before deployment. `dbt run`/`dbt test` against prod were deliberately not executed from this branch, so the tests have not been run against materialized tables yet — they need a `dbt build` on staging after merge.

## For the PO

- the 58k/121k gap is stale and the residual difference is expected, not a bug
- enrichment figures already communicated are wrong and will drop sharply
- `logements_maj_dpe` stays near zero — likely a misunderstanding about which DPE
- Metabase questions filtering `type_simple = 'Autre'` need revisiting
- 6 328 housing stay unattributable: their event author is absent from the users table