### PR TITLE
fix(analytics): make enrichment counters cover every owner:updated field

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -18,10 +18,17 @@ publication (2019 à 2026). Chaque millésime est un instantané complet et
 autonome, pas un delta par rapport au précédent.
 _Avoid_: année LOVAC, version LOVAC, cru
 
+**Ligne LOVAC** :
+Un enregistrement d'un millésime LOVAC. Un même local peut apparaître sur
+plusieurs lignes d'un même millésime, parfois avec des années de début de
+vacance divergentes. Compter des lignes n'est donc jamais compter des
+logements.
+_Avoid_: enregistrement, occurrence, ligne (seul)
+
 **Local** :
 Une unité immobilière telle que le fichier LOVAC la décrit, quelle que soit sa
 nature (habitation, commerce, dépendance).
-_Avoid_: bien, unité, ligne LOVAC
+_Avoid_: bien, unité
 
 **Logement** :
 Un local à usage d'habitation, c'est-à-dire un appartement ou une maison
@@ -123,6 +130,8 @@ _Avoid_: contact, envoi, logement ciblé
 Toute amélioration de la connaissance d'un logement ou de son propriétaire par un
 utilisateur : coordonnées, identité, adresse, rang, note, document, DPE constaté.
 Distinct de la mise à jour de situation, qui porte sur le suivi et l'occupation.
+Un enregistrement qui ne change aucune valeur n'est pas un enrichissement, même
+s'il produit un événement.
 _Avoid_: complétion, qualification, fiabilisation
 
 **Acte** :

--- a/analytics/dbt/models/intermediate/analysis/int_analysis_establishments_zlv_usage.sql
+++ b/analytics/dbt/models/intermediate/analysis/int_analysis_establishments_zlv_usage.sql
@@ -258,27 +258,52 @@ housing_status_counts AS (
 -- un filtre d'assiette. Sens retenu: "logements de mon territoire dont j'ai
 -- enrichi le propriétaire".
 
-owner_enrichment_pairs AS (
+-- Le payload d'un `owner:updated` ne porte que 6 champs: email, phone, name,
+-- birthdate, address, additionalAddress. Tous sont suivis, afin que la somme des
+-- compteurs de détail couvre bien l'agrégat `logements_maj_enrichissement`.
+--
+-- 2 247 événements ne modifient aucun de ces champs (payload vide des deux
+-- côtés, ou valeurs identiques): ils sont exclus, une mise à jour sans
+-- changement n'étant pas un enrichissement.
+owner_updated_changes AS (
     SELECT
-        CAST(ou.establishment_id AS VARCHAR) AS establishment_id,
-        ooh.housing_id,
+        oe.owner_id,
+        oev.created_by,
         oev.created_at,
         (oev.next_new ->> 'email') IS DISTINCT FROM (oev.next_old ->> 'email') AS mail_changed,
         (oev.next_new ->> 'phone') IS DISTINCT FROM (oev.next_old ->> 'phone') AS phone_changed,
         (oev.next_new ->> 'name') IS DISTINCT FROM (oev.next_old ->> 'name') AS name_changed,
+        (oev.next_new ->> 'birthdate') IS DISTINCT FROM (oev.next_old ->> 'birthdate') AS birthdate_changed,
         (
             (oev.next_new ->> 'address') IS DISTINCT FROM (oev.next_old ->> 'address')
             OR (oev.next_new ->> 'additionalAddress') IS DISTINCT FROM (oev.next_old ->> 'additionalAddress')
         ) AS address_changed
     FROM {{ ref('stg_production_owner_events') }} oe
     JOIN {{ ref('stg_production_events') }} oev ON oe.event_id = oev.id
-    JOIN {{ ref('stg_production_owners_housing') }} ooh ON oe.owner_id = ooh.owner_id
-    JOIN {{ ref('int_production_event_authors') }} ou ON oev.created_by = ou.id
+    WHERE oev.type = 'owner:updated'
+),
+
+owner_enrichment_pairs AS (
+    SELECT
+        CAST(ou.establishment_id AS VARCHAR) AS establishment_id,
+        ooh.housing_id,
+        ouc.created_at,
+        ouc.mail_changed,
+        ouc.phone_changed,
+        ouc.name_changed,
+        ouc.birthdate_changed,
+        ouc.address_changed
+    FROM owner_updated_changes ouc
+    JOIN {{ ref('stg_production_owners_housing') }} ooh ON ouc.owner_id = ooh.owner_id
+    JOIN {{ ref('int_production_event_authors') }} ou ON ouc.created_by = ou.id
     JOIN {{ ref('int_production_establishments_housing') }} oeh
         ON ooh.housing_id = oeh.housing_id
        AND CAST(oeh.establishment_id AS VARCHAR) = CAST(ou.establishment_id AS VARCHAR)
-    WHERE oev.type = 'owner:updated'
-      AND ou.user_type = 'user'
+    WHERE ou.user_type = 'user'
+      AND (
+          ouc.mail_changed OR ouc.phone_changed OR ouc.name_changed
+          OR ouc.birthdate_changed OR ouc.address_changed
+      )
 ),
 
 owner_enrichment_events AS (
@@ -287,6 +312,7 @@ owner_enrichment_events AS (
         COUNT(DISTINCT CASE WHEN mail_changed THEN housing_id END) AS logements_maj_mails,
         COUNT(DISTINCT CASE WHEN phone_changed THEN housing_id END) AS logements_maj_phone,
         COUNT(DISTINCT CASE WHEN name_changed THEN housing_id END) AS logements_maj_owners,
+        COUNT(DISTINCT CASE WHEN birthdate_changed THEN housing_id END) AS logements_maj_owners_birthdate,
         COUNT(DISTINCT CASE WHEN address_changed THEN housing_id END) AS logements_maj_owners_address
     FROM owner_enrichment_pairs
     GROUP BY establishment_id
@@ -554,6 +580,7 @@ SELECT
     COALESCE(oee.logements_maj_mails, 0) AS logements_maj_mails,
     COALESCE(oee.logements_maj_phone, 0) AS logements_maj_phone,
     COALESCE(oee.logements_maj_owners, 0) AS logements_maj_owners,
+    COALESCE(oee.logements_maj_owners_birthdate, 0) AS logements_maj_owners_birthdate,
     COALESCE(rce.logements_maj_owners_rank, 0) AS logements_maj_owners_rank,
     COALESCE(oee.logements_maj_owners_address, 0) AS logements_maj_owners_address,
     COALESCE(dpes.logements_maj_dpe, 0) AS logements_maj_dpe,

--- a/analytics/dbt/models/intermediate/analysis/schema.yml
+++ b/analytics/dbt/models/intermediate/analysis/schema.yml
@@ -226,17 +226,25 @@ models:
       - name: logements_maj_phone
         description: "Nombre de logements avec MAJ telephone proprietaire"
       - name: logements_maj_owners
-        description: "Nombre de logements avec MAJ nom ou rang proprietaire"
+        description: "Nombre de logements avec MAJ du nom du proprietaire"
+      - name: logements_maj_owners_birthdate
+        description: "Nombre de logements avec MAJ de la date de naissance du proprietaire"
+      - name: logements_maj_owners_rank
+        description: "Nombre de logements avec MAJ du rang d un proprietaire"
       - name: logements_maj_owners_address
         description: "Nombre de logements avec MAJ adresse proprietaire"
       - name: logements_maj_dpe
-        description: "Nombre de logements avec MAJ DPE (NULL - pas d evenements DPE dans ZLV)"
+        description: "Nombre de logements dont le DPE constate a ete renseigne par un utilisateur (evenement housing:updated sur actualEnergyConsumption)"
       - name: logements_maj_notes
         description: "Nombre de logements avec des notes utilisateur"
       - name: logements_maj_documents
         description: "Nombre de logements avec au moins 1 document attache"
       - name: logements_maj_enrichissement
-        description: "Nombre total de logements avec MAJ enrichissement (mails + phone + owners + address + notes + documents)"
+        description: |
+          Logements DISTINCTS touches par au moins une famille d enrichissement.
+          Inferieur ou egal a la somme des familles (mails, phone, owners,
+          owners_birthdate, owners_rank, owners_address, notes, documents, dpe),
+          un logement pouvant appartenir a plusieurs familles.
       - name: documents_importes
         description: "Nombre total de documents importes"
       - name: date_dernier_document_importe

--- a/analytics/dbt/models/marts/analysis/marts_zlv_usage.sql
+++ b/analytics/dbt/models/marts/analysis/marts_zlv_usage.sql
@@ -70,6 +70,7 @@ SELECT
     eu.logements_maj_mails,
     eu.logements_maj_phone,
     eu.logements_maj_owners,
+    eu.logements_maj_owners_birthdate,
     eu.logements_maj_owners_rank,
     eu.logements_maj_owners_address,
     eu.logements_maj_dpe,

--- a/analytics/dbt/models/marts/analysis/schema.yml
+++ b/analytics/dbt/models/marts/analysis/schema.yml
@@ -130,15 +130,22 @@ models:
           expression: >
             logements_maj_enrichissement >= GREATEST(
               logements_maj_mails, logements_maj_phone, logements_maj_owners,
-              logements_maj_owners_rank, logements_maj_owners_address,
-              logements_maj_notes, logements_maj_documents, logements_maj_dpe
+              logements_maj_owners_birthdate, logements_maj_owners_rank,
+              logements_maj_owners_address, logements_maj_notes,
+              logements_maj_documents, logements_maj_dpe
             )
+      # Sous-additivite: chaque famille d'enrichissement doit avoir son compteur
+      # de detail, sans quoi l'agregat compte des logements qu'aucune colonne
+      # n'explique. Ce test a detecte 767 logements dans ce cas (37
+      # etablissements), causes par des `owner:updated` sans changement et par
+      # `birthdate` non suivi.
       - dbt_utils.expression_is_true:
           expression: >
             logements_maj_enrichissement <= (
               logements_maj_mails + logements_maj_phone + logements_maj_owners
-              + logements_maj_owners_rank + logements_maj_owners_address
-              + logements_maj_notes + logements_maj_documents + logements_maj_dpe
+              + logements_maj_owners_birthdate + logements_maj_owners_rank
+              + logements_maj_owners_address + logements_maj_notes
+              + logements_maj_documents + logements_maj_dpe
             )
       - dbt_utils.expression_is_true:
           expression: communes_inscrites <= total_communes_in_territory
@@ -202,6 +209,13 @@ models:
           toujours superieure ou egale a logements_maj_enrichissement.
       - name: logements_maj_owners
         description: Logements distincts du territoire dont le NOM du proprietaire a ete modifie par un utilisateur de l etablissement
+      - name: logements_maj_owners_birthdate
+        description: |
+          Logements distincts du territoire dont la DATE DE NAISSANCE du
+          proprietaire a ete corrigee par un utilisateur de l etablissement.
+          Cinquieme et dernier champ du payload owner:updated - sans ce compteur
+          l agregat logements_maj_enrichissement comptait des logements
+          qu aucune colonne de detail n expliquait.
       - name: logements_maj_owners_rank
         description: |
           Logements distincts dont le rang d un proprietaire a ete modifie.


### PR DESCRIPTION
## What

Follow-up to #1948 / #1949. The sub-additivity invariant those PRs added
(`logements_maj_enrichissement <= sum of the detail counters`) failed on the first
prod build: **767 housing across 37 establishments** were counted as enriched with no
detail column explaining them, up to 306 for a single establishment.

The invariant did its job — it found a real defect rather than being too strict.

## Root cause

`owner_enrichment_pairs` accepted every `owner:updated` event, but the detail counters
covered only 4 of the 6 fields the payload carries.

Of 14 123 `owner:updated` events:

| case | n |
|---|---|
| `next_new` and `next_old` both empty → nothing changed | 1 699 |
| payload present, no field differs | 548 |
| `birthdate` only — no detail counter existed | 387 |

## Fix

- **Exclude the 2 247 no-op events.** Recording an edit that changes no value is not
  enrichment. `owner_enrichment_pairs` now requires at least one field to differ.
- **Track `birthdate`** via a new column `logements_maj_owners_birthdate` (839 housing).
  Chosen over folding it into `logements_maj_owners` so no existing column changes
  meaning for Metabase.

The payload has exactly six keys (`email, phone, name, birthdate, address,
additionalAddress`), all now covered, so the union feeding
`logements_maj_enrichissement` is a subset of the detail counters. The invariant holds
by construction.

## Prod verification

Rebuilt and tested against `--target prod`: **`PASS=36 WARN=0 ERROR=0 SKIP=0`**.

That clears everything that was red on the first build: 10 `Binder Error` tests (they
were hitting the stale table), the `FAIL 37`, and the 2 KPI threshold warnings —
`etabs_avec_echelon_communal` went 1 256 → 1 693 and `etabs_avec_echelon_epci` 0 → 425
once the échelons model actually materialised.

Final figures on `marts_zlv_usage` (36 791 establishments):

| metric | value |
|---|---|
| `logements_maj_situation` (summed) | 174 012 |
| `logements_maj_enrichissement` | 81 333 |
| `actes_enrichissement` | 122 505 |
| `logements_maj_owners_birthdate` | 839 |
| `logements_contactes_via_campagnes` | 149 069 distinct vs **178 223** raw contacts |
| `logements_exportes_via_groupes` | 2 014 977 distinct vs **3 029 177** raw exports |
| `logements_maj_dpe` | 49 |

The campaign double-counting reported in the ticket is confirmed and fixed: 29 154
re-contacts were previously inflating the count. Same for groups, with ~1 M redundant
exports.

Reconciliation: 176 885 housing genuinely touched by a user event vs 174 012 summed per
establishment — the sum is 1.6 % *lower*, accounted for by events whose housing falls
outside the establishment's perimeter. The ticket's 58 000-vs-121 000 discrepancy is
gone; it was two incompatible attribution rules in one table.

## Glossary

Second commit, kept separate:

- `Enrichissement` now states that an edit changing no value is not an enrichment —
  the distinction this bug turned on.
- `Ligne LOVAC` was sitting uncommitted in the working tree after #1951; committed here
  rather than dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)