### PR TITLE
Stop leaking secrets and shell-injecting PR titles in review-app.yml

### DIFF
--- a/.github/workflows/review-app.yml
+++ b/.github/workflows/review-app.yml
@@ -20,19 +20,9 @@ on:
         type: boolean
         default: false
 
-env:
-  CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}
-  CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
-  CLEVER_ORG: ${{ secrets.CLEVER_ORG }}
-  MAILER_HOST: ${{ secrets.MAILER_HOST }}
-  MAILER_PORT: ${{ secrets.MAILER_PORT }}
-  MAILER_USER: ${{ secrets.MAILER_USER }}
-  MAILER_PASSWORD: ${{ secrets.MAILER_PASSWORD }}
-  TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
-  METABASE_DOMAIN: ${{ secrets.METABASE_DOMAIN }}
-  METABASE_API_TOKEN: ${{ secrets.METABASE_API_TOKEN }}
-  E2E_EMAIL: ${{ secrets.CYPRESS_EMAIL }}
-  E2E_PASSWORD: ${{ secrets.CYPRESS_PASSWORD }}
+permissions:
+  contents: read
+  pull-requests: read
 
 jobs:
   resolve-pr:
@@ -46,11 +36,15 @@ jobs:
         id: get-pr
         env:
           GH_TOKEN: ${{ github.token }}
+          # Routed through env instead of interpolated into the script below:
+          # a PR title is attacker-controlled text and could otherwise inject
+          # arbitrary shell commands into this pull_request_target job.
+          PR_TITLE_INPUT: ${{ github.event.pull_request.title }}
         run: |
           if [ "${{ github.event_name }}" == "pull_request_target" ]; then
             # PR closed event - use the PR number from the event
             PR_NUMBER="${{ github.event.number }}"
-            PR_TITLE="${{ github.event.pull_request.title }}"
+            PR_TITLE="$PR_TITLE_INPUT"
           else
             # workflow_dispatch - find PR from branch
             BRANCH="${{ github.ref_name }}"
@@ -80,13 +74,16 @@ jobs:
           echo "pr_title=$PR_TITLE" >> $GITHUB_OUTPUT
 
       - name: Display summary
+        env:
+          # Same reasoning as above: pr_title carries the raw PR title.
+          PR_TITLE: ${{ steps.get-pr.outputs.pr_title }}
         run: |
           echo "### 🚀 Review App Configuration" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| Property | Value |" >> $GITHUB_STEP_SUMMARY
           echo "|----------|-------|" >> $GITHUB_STEP_SUMMARY
           echo "| **PR** | #${{ steps.get-pr.outputs.pr_number }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| **Title** | ${{ steps.get-pr.outputs.pr_title }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| **Title** | $PR_TITLE |" >> $GITHUB_STEP_SUMMARY
           echo "| **App prefix** | ${{ steps.get-pr.outputs.pr_name }} |" >> $GITHUB_STEP_SUMMARY
           echo "| **Iso prod** | ${{ github.event.inputs.iso_prod || 'false' }} |" >> $GITHUB_STEP_SUMMARY
   check-duplicates:
@@ -95,6 +92,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       PR_NAME: ${{ needs.resolve-pr.outputs.pr_name }}
+      CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}
+      CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
+      CLEVER_ORG: ${{ secrets.CLEVER_ORG }}
     steps:
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -181,6 +181,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       PR_NAME: ${{ needs.resolve-pr.outputs.pr_name }}
+      CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}
+      CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
+      CLEVER_ORG: ${{ secrets.CLEVER_ORG }}
     steps:
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -210,6 +213,9 @@ jobs:
     env:
       PR_NAME: ${{ needs.resolve-pr.outputs.pr_name }}
       APP_ALIAS: ${{ needs.resolve-pr.outputs.pr_name }}-api
+      CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}
+      CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
+      CLEVER_ORG: ${{ secrets.CLEVER_ORG }}
     steps:
       - name: Extract branch name
         shell: bash
@@ -364,6 +370,9 @@ jobs:
     env:
       PR_NAME: ${{ needs.resolve-pr.outputs.pr_name }}
       APP_ALIAS: ${{ needs.resolve-pr.outputs.pr_name }}-front
+      CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}
+      CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
+      CLEVER_ORG: ${{ secrets.CLEVER_ORG }}
     steps:
       - name: Extract branch name
         shell: bash
@@ -420,6 +429,9 @@ jobs:
     env:
       PR_NAME: ${{ needs.resolve-pr.outputs.pr_name }}
       APP_ALIAS: ${{ needs.resolve-pr.outputs.pr_name }}-api
+      CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}
+      CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
+      CLEVER_ORG: ${{ secrets.CLEVER_ORG }}
     steps:
       - name: Extract branch name
         shell: bash
@@ -462,6 +474,9 @@ jobs:
       url: https://${{ needs.resolve-pr.outputs.pr_name }}-front.cleverapps.io
     env:
       APP_ALIAS: ${{ needs.resolve-pr.outputs.pr_name }}-front
+      CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}
+      CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
+      CLEVER_ORG: ${{ secrets.CLEVER_ORG }}
     steps:
       - name: Extract branch name
         shell: bash
@@ -496,6 +511,9 @@ jobs:
     if: always() && (github.event.inputs.action_type == 'Supprimer' || (github.event_name == 'pull_request_target' && github.event.action == 'closed'))
     env:
       APP_ALIAS: ${{ needs.resolve-pr.outputs.pr_name }}-api
+      CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}
+      CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
+      CLEVER_ORG: ${{ secrets.CLEVER_ORG }}
     steps:
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -516,6 +534,9 @@ jobs:
     if: always() && (github.event.inputs.action_type == 'Supprimer' || (github.event_name == 'pull_request_target' && github.event.action == 'closed'))
     env:
       APP_ALIAS: ${{ needs.resolve-pr.outputs.pr_name }}-front
+      CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}
+      CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
+      CLEVER_ORG: ${{ secrets.CLEVER_ORG }}
     steps:
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -536,6 +557,9 @@ jobs:
     if: always() && (github.event.inputs.action_type == 'Supprimer' || (github.event_name == 'pull_request_target' && github.event.action == 'closed'))
     env:
       PR_NAME: ${{ needs.resolve-pr.outputs.pr_name }}
+      CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}
+      CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
+      CLEVER_ORG: ${{ secrets.CLEVER_ORG }}
     steps:
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/review-app.yml
+++ b/.github/workflows/review-app.yml
@@ -20,13 +20,18 @@ on:
         type: boolean
         default: false
 
-permissions:
-  contents: read
-  pull-requests: read
+# No default token permissions: each job below declares only the
+# GITHUB_TOKEN scopes it actually needs (explicit `{}` where a job needs
+# none) instead of inheriting a broader default. This limits blast radius
+# if a third-party action gets compromised or a job misbehaves, even
+# though this repo only takes PRs from trusted members.
+permissions: {}
 
 jobs:
   resolve-pr:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     outputs:
       pr_number: ${{ steps.get-pr.outputs.pr_number }}
       pr_name: ${{ steps.get-pr.outputs.pr_name }}
@@ -90,6 +95,7 @@ jobs:
     if: github.event.inputs.action_type == 'Créer'
     needs: [resolve-pr]
     runs-on: ubuntu-latest
+    permissions: {}
     env:
       PR_NAME: ${{ needs.resolve-pr.outputs.pr_name }}
       CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}
@@ -179,6 +185,7 @@ jobs:
     if: github.event.inputs.action_type == 'Créer'
     needs: [resolve-pr, check-duplicates]
     runs-on: ubuntu-latest
+    permissions: {}
     env:
       PR_NAME: ${{ needs.resolve-pr.outputs.pr_name }}
       CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}
@@ -207,6 +214,8 @@ jobs:
     if: github.event.inputs.action_type == 'Créer'
     needs: [resolve-pr, check-duplicates, deploy-addons]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     environment:
       name: ${{ needs.resolve-pr.outputs.pr_name }}-api
       url: https://${{ needs.resolve-pr.outputs.pr_name }}-api.cleverapps.io
@@ -364,6 +373,8 @@ jobs:
     if: github.event.inputs.action_type == 'Créer'
     needs: [resolve-pr, check-duplicates, deploy-addons]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     environment:
       name: ${{ needs.resolve-pr.outputs.pr_name }}-front
       url: https://${{ needs.resolve-pr.outputs.pr_name }}-front.cleverapps.io
@@ -423,6 +434,8 @@ jobs:
     if: github.event.inputs.action_type == 'Mettre à jour'
     needs: [resolve-pr]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     environment:
       name: ${{ needs.resolve-pr.outputs.pr_name }}-api
       url: https://${{ needs.resolve-pr.outputs.pr_name }}-api.cleverapps.io
@@ -469,6 +482,8 @@ jobs:
     if: github.event.inputs.action_type == 'Mettre à jour'
     needs: [resolve-pr]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     environment:
       name: ${{ needs.resolve-pr.outputs.pr_name }}-front
       url: https://${{ needs.resolve-pr.outputs.pr_name }}-front.cleverapps.io
@@ -509,6 +524,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [resolve-pr]
     if: always() && (github.event.inputs.action_type == 'Supprimer' || (github.event_name == 'pull_request_target' && github.event.action == 'closed'))
+    permissions: {}
     env:
       APP_ALIAS: ${{ needs.resolve-pr.outputs.pr_name }}-api
       CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}
@@ -532,6 +548,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [resolve-pr]
     if: always() && (github.event.inputs.action_type == 'Supprimer' || (github.event_name == 'pull_request_target' && github.event.action == 'closed'))
+    permissions: {}
     env:
       APP_ALIAS: ${{ needs.resolve-pr.outputs.pr_name }}-front
       CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}
@@ -555,6 +572,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [resolve-pr]
     if: always() && (github.event.inputs.action_type == 'Supprimer' || (github.event_name == 'pull_request_target' && github.event.action == 'closed'))
+    permissions: {}
     env:
       PR_NAME: ${{ needs.resolve-pr.outputs.pr_name }}
       CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}


### PR DESCRIPTION
## Summary
- `review-app.yml` runs on `pull_request_target: closed`, which fires for any PR against `main` (including forks) with no approval gate.
- Its workflow-level `env:` block loaded `CLEVER_*`, `MAILER_*`, `TEST_PASSWORD`, `METABASE_*`, and `CYPRESS_*` secrets into **every** job, including `resolve-pr`. The mailer/test/metabase/cypress secrets were unused anywhere in this file — removed. `CLEVER_*` is now scoped to only the jobs that actually call the `clever` CLI.
- `resolve-pr` interpolated `github.event.pull_request.title` (and its own `pr_title` output) directly into `run:` blocks. A PR title is attacker-controlled text — opening a fork PR with a crafted title and closing it would execute arbitrary shell in a job that, before this fix, had every secret above loaded as env vars. Both spots now go through `env:` indirection instead of inline `${{ }}` templating.
- Added an explicit `permissions: { contents: read, pull-requests: read }` block since none was set.

Found via a security review of `.github/workflows/*.yml` requested during work on #1955.

## Test plan
- [ ] YAML validated (`ruby -ryaml`)
- [ ] Trigger `workflow_dispatch` with `action_type: Créer` on a scratch PR to confirm `check-duplicates`/`deploy-*` still authenticate against Clever Cloud correctly with the job-scoped secrets
- [ ] Close a PR against `main` and confirm `delete-*` jobs still clean up the review app

🤖 Generated with [Claude Code](https://claude.com/claude-code)